### PR TITLE
feat: add the ability to attach to another canvas

### DIFF
--- a/devserver/base.html
+++ b/devserver/base.html
@@ -9,6 +9,7 @@
   <body>
     <div style="display: flex; justify-content: center; flex-direction: column; align-items: center; height: 100vh;">
       <canvas id="graph" width="300" height="300" style="border: 1px solid black; background-color: white;"></canvas>
+      <canvas id="graph2" width="600" height="500" style="border: 1px solid black; background-color: white;"></canvas>
       <div style="display: flex; justify-content: center; flex-direction: row;">
         <button id="download-img-btn">下載圖片</button>
         <!-- <button id="play-animation-btn">開始播放</button> -->
@@ -18,8 +19,7 @@
         <button id="experimental-zoom-handler-btn">對原點縮放</button>
         <button id="util-btn">util</button>
       </div>
-      <canvas id="graph2" width="300" height="300" style="border: 1px solid black; background-color: white;"></canvas>
     </div>
-    <script type="module" src="/main.ts"></script>
+    <script type="module" src="/base.ts"></script>
   </body>
 </html>

--- a/devserver/base.ts
+++ b/devserver/base.ts
@@ -1,0 +1,20 @@
+import { CanvasPositionDimensionPublisher } from "src/boardify/utils/canvas-position-dimension";
+
+const canvas = document.getElementById("graph") as HTMLCanvasElement;
+const canvas2 = document.getElementById("graph2") as HTMLCanvasElement;
+
+const canvasPositionDimensionPublisher = new CanvasPositionDimensionPublisher(canvas);
+canvasPositionDimensionPublisher.onPositionUpdate((rect) => {
+    console.log(rect);
+});
+
+canvasPositionDimensionPublisher.attach(canvas2);
+
+canvas2.width = 700;
+
+const utilBtn = document.getElementById("util-btn") as HTMLButtonElement;
+
+utilBtn.addEventListener("click", () => {
+    canvas2.width = 800;
+});
+

--- a/devserver/main.ts
+++ b/devserver/main.ts
@@ -31,6 +31,7 @@ export function comboDetect(inputKey: string, currentString: string, combo: stri
 const utilBtn = document.getElementById("util-btn") as HTMLButtonElement;
 
 const canvas = document.getElementById("graph") as HTMLCanvasElement;
+const canvas2 = document.getElementById("graph2") as HTMLCanvasElement;
 const canvasPositionDimensionPublisher = new CanvasPositionDimensionPublisher(canvas);
 const testAbortController = new AbortController();
 
@@ -48,8 +49,10 @@ const board = new Board(canvas);
 utilBtn.addEventListener("click", ()=>{
     // canvas.style.width = "300px";
     // canvasPositionDimensionPublisher.dispose();
-    testAbortController.abort();
-    board.getCameraRig().panToWorld({x: 100, y: 100});
+    // testAbortController.abort();
+    console.log('width', canvas.width);
+    canvas.height = 400;
+    board.attach(canvas2);
 });
 
 board.camera.setRotation(0 * Math.PI / 180);

--- a/src/boardify/utils/canvas-position-dimension.ts
+++ b/src/boardify/utils/canvas-position-dimension.ts
@@ -41,24 +41,24 @@ export class CanvasPositionDimensionPublisher {
         });
         
         // Add scroll handler to detect position changes during scrolling
-        this.scrollHandler = () => {
+        this.scrollHandler = (() => {
             const newRect = canvas.getBoundingClientRect();
             const trueRect = getTrueRect(newRect, window.getComputedStyle(canvas));
             if (rectChanged(this.lastRect, trueRect)) {
                 this.publishPositionUpdate(trueRect);
                 this.lastRect = trueRect;
             }
-        };
+        }).bind(this);
 
         // Add window resize handler to detect position changes when window size changes
-        this.resizeHandler = () => {
+        this.resizeHandler = (() => {
             const newRect = canvas.getBoundingClientRect();
             const trueRect = getTrueRect(newRect, window.getComputedStyle(canvas));
             if (rectChanged(this.lastRect, trueRect)) {
                 this.publishPositionUpdate(trueRect);
                 this.lastRect = trueRect;
             }
-        };
+        }).bind(this);
         
         this.resizeObserver.observe(canvas);
         this.intersectionObserver.observe(canvas);
@@ -72,6 +72,30 @@ export class CanvasPositionDimensionPublisher {
         this.intersectionObserver.disconnect();
         window.removeEventListener('scroll', this.scrollHandler);
         window.removeEventListener('resize', this.resizeHandler);
+    }
+
+    attach(canvas: HTMLCanvasElement) {
+        this.dispose();
+        this.resizeObserver.observe(canvas);
+        this.intersectionObserver.observe(canvas);
+        this.scrollHandler = (() => {
+            const newRect = canvas.getBoundingClientRect();
+            const trueRect = getTrueRect(newRect, window.getComputedStyle(canvas));
+            if (rectChanged(this.lastRect, trueRect)) {
+                this.publishPositionUpdate(trueRect);
+                this.lastRect = trueRect;
+            }
+        }).bind(this);
+        this.resizeHandler = (() => {
+            const newRect = canvas.getBoundingClientRect();
+            const trueRect = getTrueRect(newRect, window.getComputedStyle(canvas));
+            if (rectChanged(this.lastRect, trueRect)) {
+                this.publishPositionUpdate(trueRect);
+                this.lastRect = trueRect;
+            }
+        }).bind(this);
+        window.addEventListener("scroll", this.scrollHandler, { passive: true });
+        window.addEventListener("resize", this.resizeHandler, { passive: true });
     }
 
     private publishPositionUpdate(rect: DOMRect) {

--- a/src/input-interpretation/input-state-machine/kmt-input-context.ts
+++ b/src/input-interpretation/input-state-machine/kmt-input-context.ts
@@ -108,6 +108,16 @@ export class CanvasProxy implements CanvasOperator {
     setCursor(style: "grab" | "default" | "grabbing"): void {
         this._canvas.style.cursor = style;
     }
+
+    attach(canvas: HTMLCanvasElement){
+        this._canvasPositionDimensionPublisher.attach(canvas);
+        this._canvas = canvas;
+        const boundingRect = canvas.getBoundingClientRect();
+        const trueRect = getTrueRect(boundingRect, window.getComputedStyle(canvas));
+        this._width = trueRect.width;
+        this._height = trueRect.height;
+        this._position = {x: trueRect.left, y: trueRect.top};
+    }
 }
 
 /**

--- a/src/input-interpretation/kmt-event-parser/vanilla-kmt-event-parser.ts
+++ b/src/input-interpretation/kmt-event-parser/vanilla-kmt-event-parser.ts
@@ -9,6 +9,7 @@ export interface KMTEventParser {
     disabled: boolean;
     setUp(): void;
     tearDown(): void;
+    attach(canvas: HTMLCanvasElement): void;
 }
 
 /**
@@ -197,4 +198,9 @@ export class VanillaKMTEventParser implements KMTEventParser {
         }
     }
 
+    attach(canvas: HTMLCanvasElement){
+        this.tearDown();
+        this._canvas = canvas;
+        this.setUp();
+    }
 }

--- a/src/input-interpretation/touch-event-parser/vanilla-touch-event-parser.ts
+++ b/src/input-interpretation/touch-event-parser/vanilla-touch-event-parser.ts
@@ -16,6 +16,7 @@ export interface TouchEventParser {
     disableStrategy(): void;
     setUp(): void;
     tearDown(): void;
+    attach(canvas: HTMLCanvasElement): void;
 }
 
 /**
@@ -158,5 +159,11 @@ export class VanillaTouchEventParser implements TouchEventParser {
             pointsMoved.push({ident: e.targetTouches[i].identifier, x: e.targetTouches[i].clientX, y: e.targetTouches[i].clientY});
         }
         this.touchSM.happens("touchmove", {points: pointsMoved});
+    }
+
+    attach(canvas: HTMLCanvasElement){
+        this.tearDown();
+        this._canvas = canvas;
+        this.setUp();
     }
 }


### PR DESCRIPTION
This is mainly prepping for react. 

When a component unmount and remounts I would like to have the option to reattach to new canvas instead of instantiate a new board class. 

Some other components within the library like event parser, canvas proxy, canvas dimension publisher, also have the ability to attach a new canvas to it instead of instantiate a new one.