### PR TITLE
fix: canvas context

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -53,3 +53,7 @@ jobs:
         npx nx show projects
     - name: Run unit tests
       run: pnpm test
+    - name: Test build
+      run: | 
+        pnpm build
+        pnpm build:apps

--- a/apps/examples/vite.config.js
+++ b/apps/examples/vite.config.js
@@ -13,7 +13,7 @@ export default defineConfig({
                 main: resolve(__dirname, "src/index.html"),
                 base: resolve(__dirname, "src/base/index.html"),
                 ruler: resolve(__dirname, "src/ruler/index.html"),
-                navigation: resolve(__dirname, "src/navigation/keyboard.html"),
+                navigation: resolve(__dirname, "src/navigation/index.html"),
                 "pixi-integration": resolve(__dirname, "src/pixi-integration/index.html"),
                 "konva-integration": resolve(__dirname, "src/konva-integration/index.html"),
                 "fabric-integration": resolve(__dirname, "src/fabric-integration/index.html"),

--- a/packages/board/src/input-interpretation/input-state-machine/touch-input-context.ts
+++ b/packages/board/src/input-interpretation/input-state-machine/touch-input-context.ts
@@ -1,7 +1,7 @@
 import type { Point } from "@ue-too/math";
 import { RawUserInputPublisher } from "../raw-input-publisher";
 import { BaseContext } from "@ue-too/being";
-import { CanvasOperator } from "./kmt-input-context";
+import { Canvas } from "./kmt-input-context";
 
 /**
  * @description The touch points.
@@ -23,17 +23,17 @@ export interface TouchContext extends BaseContext{
     notifyOnPan: (delta: Point) => void;
     notifyOnZoom: (zoomAmount: number, anchorPoint: Point) => void; 
     alignCoordinateSystem: boolean;
-    canvas: CanvasOperator;
+    canvas: Canvas;
 }
 
 export class TouchInputTracker implements TouchContext {
 
     private _inputPublisher: RawUserInputPublisher;
     private _touchPointsMap: Map<number, TouchPoints> = new Map<number, TouchPoints>();
-    private _canvas: CanvasOperator;
+    private _canvas: Canvas;
     private _alignCoordinateSystem: boolean;
 
-    constructor(canvas: CanvasOperator, inputPublisher: RawUserInputPublisher) {
+    constructor(canvas: Canvas, inputPublisher: RawUserInputPublisher) {
         this._canvas = canvas;
         this._inputPublisher = inputPublisher;
         this._alignCoordinateSystem = true;
@@ -94,7 +94,7 @@ export class TouchInputTracker implements TouchContext {
         this._alignCoordinateSystem = value;
     }
 
-    get canvas(): CanvasOperator {
+    get canvas(): Canvas {
         return this._canvas;
     }
 


### PR DESCRIPTION
The canvas operator in touch input context has been renamed to just canvas. 

CI does not include build process so this was not discovered in PR ci; added test build step in ci.