### PR TITLE
feat(banana): formation children can be flipped

### DIFF
--- a/apps/banana/src/assets/icons/lucide.ts
+++ b/apps/banana/src/assets/icons/lucide.ts
@@ -24,6 +24,7 @@ export {
     Eraser,
     Eye,
     FilePlus,
+    FlipVertical2,
     Focus,
     FolderOpen,
     Gauge,

--- a/apps/banana/src/components/formation-editor.tsx
+++ b/apps/banana/src/components/formation-editor.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { ArrowDown, ArrowUp, ArrowLeftRight, ChevronDown, ChevronUp, Layers, Link2, Merge, Pencil, Plus, Scissors, Trash2, TrainFront } from '@/assets/icons';
+import { ArrowDown, ArrowUp, ArrowLeftRight, ChevronDown, ChevronUp, FlipVertical2, Layers, Link2, Merge, Pencil, Plus, Scissors, Trash2, TrainFront } from '@/assets/icons';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -163,6 +163,20 @@ export function FormationEditor({
         [formationManager]
     );
 
+    const handleReverseNestedChildren = useCallback(
+        (formationId: string, childIndex: number) => {
+            formationManager.reverseNestedChildren(formationId, childIndex);
+        },
+        [formationManager]
+    );
+
+    const handleFlipChildDirection = useCallback(
+        (formationId: string, childIndex: number) => {
+            formationManager.flipChildDirection(formationId, childIndex);
+        },
+        [formationManager]
+    );
+
     const handleRenameFormation = useCallback(
         (formationId: string, name: string) => {
             formationManager.renameFormation(formationId, name);
@@ -304,6 +318,12 @@ export function FormationEditor({
                                 onSwapChildren={index =>
                                     handleSwapChildren(id, index)
                                 }
+                                onReverseNestedChildren={childIndex =>
+                                    handleReverseNestedChildren(id, childIndex)
+                                }
+                                onFlipChildDirection={childIndex =>
+                                    handleFlipChildDirection(id, childIndex)
+                                }
                                 otherFormations={unplacedFormations
                                     .filter(f => f.id !== id)
                                     .map(f => ({ id: f.id, formation: f.formation }))}
@@ -350,6 +370,10 @@ type FormationCardProps = {
     onReverseChildren?: () => void;
     /** Swap child at index with child at index+1. */
     onSwapChildren?: (index: number) => void;
+    /** Reverse the children order of a nested formation at the given child index. */
+    onReverseNestedChildren?: (childIndex: number) => void;
+    /** Flip the direction of any child (car or nested formation) at the given index. */
+    onFlipChildDirection?: (childIndex: number) => void;
     /** Other depot formations available to nest into this one. */
     otherFormations?: readonly { id: string; formation: Formation }[];
     /** Append another formation as a nested child. */
@@ -378,6 +402,8 @@ function FormationCard({
     onConsolidate,
     onReverseChildren,
     onSwapChildren,
+    onReverseNestedChildren,
+    onFlipChildDirection,
     otherFormations,
     onAppendFormation,
     onPrependFormation,
@@ -580,6 +606,30 @@ function FormationCard({
                                         </div>
                                         {!readOnly && (
                                             <div className="flex items-center gap-0.5">
+                                                {isNested && onReverseNestedChildren && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="icon-xs"
+                                                        onClick={() =>
+                                                            onReverseNestedChildren(index)
+                                                        }
+                                                        title={t('reverseNestedTooltip')}
+                                                    >
+                                                        <ArrowLeftRight className="size-2.5" />
+                                                    </Button>
+                                                )}
+                                                {onFlipChildDirection && (
+                                                    <Button
+                                                        variant="ghost"
+                                                        size="icon-xs"
+                                                        onClick={() =>
+                                                            onFlipChildDirection(index)
+                                                        }
+                                                        title={t('flipChildDirectionTooltip')}
+                                                    >
+                                                        <FlipVertical2 className="size-2.5" />
+                                                    </Button>
+                                                )}
                                                 {onSwapChildren && (
                                                     <>
                                                         <Button

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -236,6 +236,8 @@ const en = {
         consolidate: 'Consolidate',
         consolidateTooltip: 'Flatten nested formations into individual cars',
         reverseTooltip: 'Reverse the order of children',
+        reverseNestedTooltip: 'Reverse the order of this formation\'s children',
+        flipChildDirectionTooltip: 'Flip the direction of this child',
         couplable: 'couplable',
         couple: 'Couple',
         coupleWith: 'Couple with Train {{number}}',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -239,6 +239,8 @@ const zhTW = {
         consolidate: '合併',
         consolidateTooltip: '將巢狀編組扁平展開為個別車輛',
         reverseTooltip: '反轉子車輛順序',
+        reverseNestedTooltip: '反轉此編組的子車輛順序',
+        flipChildDirectionTooltip: '翻轉此子車輛的方向',
         renameFormation: '點擊以重新命名',
         renameCar: '點擊以重新命名',
         addFromStock: '從車庫加入',

--- a/apps/banana/src/trains/formation-manager.ts
+++ b/apps/banana/src/trains/formation-manager.ts
@@ -3,6 +3,10 @@ import { TrainUnit, generateFormationId } from './cars';
 import { Formation } from './formation';
 import { CarStockManager } from './car-stock-manager';
 
+function isFormation(unit: TrainUnit): unit is Formation {
+    return unit.depth > 0;
+}
+
 export type FormationEntry = { id: string; formation: Formation };
 
 type FormationChangeType = 'add' | 'remove' | 'update';
@@ -212,6 +216,57 @@ export class FormationManager {
             throw new Error(`Formation ${formationId} not found`);
         }
         formation.reverseChildren();
+        this._observable.notify(formationId, { type: 'update' });
+        this._notify();
+    }
+
+    /**
+     * Reverse the children order of a nested formation at the given child index.
+     */
+    reverseNestedChildren(formationId: string, childIndex: number): void {
+        const formation = this._formations.get(formationId);
+        if (formation === undefined) {
+            throw new Error(`Formation ${formationId} not found`);
+        }
+        const child = formation.originalChildren[childIndex];
+        if (child === undefined) {
+            throw new Error(
+                `Child index ${childIndex} out of bounds for formation ${formationId}`
+            );
+        }
+        if (!isFormation(child)) {
+            throw new Error(
+                `Child at index ${childIndex} is not a nested formation`
+            );
+        }
+        child.reverseChildren();
+        formation.invalidateCache();
+        this._observable.notify(formationId, { type: 'update' });
+        this._notify();
+    }
+
+    /**
+     * Flip the direction of a child at the given index.
+     * For a Car: flips its head/tail orientation.
+     * For a nested Formation: flips each of its children's direction without reordering.
+     */
+    flipChildDirection(formationId: string, childIndex: number): void {
+        const formation = this._formations.get(formationId);
+        if (formation === undefined) {
+            throw new Error(`Formation ${formationId} not found`);
+        }
+        const child = formation.originalChildren[childIndex];
+        if (child === undefined) {
+            throw new Error(
+                `Child index ${childIndex} out of bounds for formation ${formationId}`
+            );
+        }
+        if (isFormation(child)) {
+            child.flipChildrenDirection();
+        } else {
+            child.switchDirection();
+        }
+        formation.invalidateCache();
         this._observable.notify(formationId, { type: 'update' });
         this._notify();
     }

--- a/apps/banana/src/trains/formation.ts
+++ b/apps/banana/src/trains/formation.ts
@@ -188,6 +188,14 @@ export class Formation implements TrainUnit {
         this._invalidateCache();
     }
 
+    /** Flip the direction of each direct child without changing their order. */
+    flipChildrenDirection(): void {
+        for (const child of this._children) {
+            child.switchDirection();
+        }
+        this._invalidateCache();
+    }
+
     /** Reverse the order of direct children in both operational and original lists. */
     reverseChildren(): void {
         this._children.reverse();
@@ -430,6 +438,11 @@ export class Formation implements TrainUnit {
             new Car(generateCarId(), [20], 2.5, 2.5),
             new Car(generateCarId(), [20], 2.5, 2.5),
         ]);
+    }
+
+    /** Invalidate cached values. Called when a child is mutated externally. */
+    invalidateCache(): void {
+        this._invalidateCache();
     }
 
     private _invalidateCache(): void {

--- a/apps/banana/test/nested-formation-flip.test.ts
+++ b/apps/banana/test/nested-formation-flip.test.ts
@@ -1,0 +1,238 @@
+import { Car, generateCarId, generateFormationId } from '../src/trains/cars';
+import { Formation } from '../src/trains/formation';
+import { FormationManager } from '../src/trains/formation-manager';
+import { CarStockManager } from '../src/trains/car-stock-manager';
+
+function makeCar(id: string): Car {
+    return new Car(id, [10], 2, 2);
+}
+
+describe('Nested formation flip operations', () => {
+    let carStock: CarStockManager;
+    let manager: FormationManager;
+
+    beforeEach(() => {
+        carStock = new CarStockManager();
+        manager = new FormationManager(carStock);
+    });
+
+    describe('reverseNestedChildren', () => {
+        it('reverses the order of children in a nested formation without flipping direction', () => {
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            const carC = makeCar('C');
+
+            const nested = new Formation(generateFormationId(), [carA, carB]);
+            carStock.addCar(carC);
+            const parent = manager.createFormation(['C']);
+            manager.addFormation(nested);
+            manager.appendFormation(parent.id, nested.id);
+
+            const nestedChild = parent.originalChildren.find(c => c.depth > 0)!;
+            expect(nestedChild.flatCars().map(c => c.id)).toEqual(['A', 'B']);
+
+            const nestedIndex = parent.originalChildren.indexOf(nestedChild);
+            manager.reverseNestedChildren(parent.id, nestedIndex);
+
+            // Order reversed, but cars NOT flipped
+            expect(nestedChild.flatCars().map(c => c.id)).toEqual(['B', 'A']);
+            expect(nestedChild.flipped).toBe(false);
+            expect(carA.flipped).toBe(false);
+            expect(carB.flipped).toBe(false);
+        });
+
+        it('throws when child at index is not a nested formation', () => {
+            const carA = makeCar('A');
+            carStock.addCar(carA);
+            const parent = manager.createFormation(['A']);
+
+            expect(() => manager.reverseNestedChildren(parent.id, 0)).toThrow(
+                /not a nested formation/
+            );
+        });
+
+        it('throws when formation id is not found', () => {
+            expect(() => manager.reverseNestedChildren('nonexistent', 0)).toThrow(
+                /not found/
+            );
+        });
+
+        it('throws when child index is out of bounds', () => {
+            const carA = makeCar('A');
+            carStock.addCar(carA);
+            const parent = manager.createFormation(['A']);
+
+            expect(() => manager.reverseNestedChildren(parent.id, 5)).toThrow(
+                /out of bounds/
+            );
+        });
+
+        it('notifies observers on change', () => {
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            const carC = makeCar('C');
+
+            const nested = new Formation(generateFormationId(), [carA, carB]);
+            carStock.addCar(carC);
+            const parent = manager.createFormation(['C']);
+            manager.addFormation(nested);
+            manager.appendFormation(parent.id, nested.id);
+
+            const nestedIndex = parent.originalChildren.findIndex(c => c.depth > 0);
+
+            let notified = false;
+            manager.subscribe(() => { notified = true; });
+
+            manager.reverseNestedChildren(parent.id, nestedIndex);
+            expect(notified).toBe(true);
+        });
+    });
+
+    describe('flipChildDirection', () => {
+        it('flips a single car direction without affecting others', () => {
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            carStock.addCar(carA);
+            carStock.addCar(carB);
+            const parent = manager.createFormation(['A', 'B']);
+
+            expect(carA.flipped).toBe(false);
+            expect(carB.flipped).toBe(false);
+
+            // Flip only car A (index 0)
+            manager.flipChildDirection(parent.id, 0);
+
+            expect(carA.flipped).toBe(true);
+            expect(carB.flipped).toBe(false);
+            // Order unchanged
+            expect(parent.flatCars().map(c => c.id)).toEqual(['A', 'B']);
+        });
+
+        it('flips direction of all cars in a nested formation without reordering', () => {
+            // Parent: [C, nested=[A, B]]
+            // Flip nested → [C, nested=[A(f), B(f)]] — order preserved, cars flipped
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            const carC = makeCar('C');
+
+            const nested = new Formation(generateFormationId(), [carA, carB]);
+            carStock.addCar(carC);
+            const parent = manager.createFormation(['C']);
+            manager.addFormation(nested);
+            manager.appendFormation(parent.id, nested.id);
+
+            const nestedIndex = parent.originalChildren.findIndex(c => c.depth > 0);
+            manager.flipChildDirection(parent.id, nestedIndex);
+
+            // Order preserved, but each car is flipped
+            expect(nested.flatCars().map(c => c.id)).toEqual(['A', 'B']);
+            expect(carA.flipped).toBe(true);
+            expect(carB.flipped).toBe(true);
+            // C is untouched
+            expect(carC.flipped).toBe(false);
+        });
+
+        it('flipping only one child leaves others untouched', () => {
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            const carC = makeCar('C');
+            carStock.addCar(carA);
+            carStock.addCar(carB);
+            carStock.addCar(carC);
+            const parent = manager.createFormation(['A', 'B', 'C']);
+
+            manager.flipChildDirection(parent.id, 1); // flip B only
+
+            expect(carA.flipped).toBe(false);
+            expect(carB.flipped).toBe(true);
+            expect(carC.flipped).toBe(false);
+        });
+
+        it('double flip restores original direction', () => {
+            const carA = makeCar('A');
+            carStock.addCar(carA);
+            const parent = manager.createFormation(['A']);
+
+            manager.flipChildDirection(parent.id, 0);
+            expect(carA.flipped).toBe(true);
+
+            manager.flipChildDirection(parent.id, 0);
+            expect(carA.flipped).toBe(false);
+        });
+
+        it('throws when formation id is not found', () => {
+            expect(() => manager.flipChildDirection('nonexistent', 0)).toThrow(
+                /not found/
+            );
+        });
+
+        it('throws when child index is out of bounds', () => {
+            const carA = makeCar('A');
+            carStock.addCar(carA);
+            const parent = manager.createFormation(['A']);
+
+            expect(() => manager.flipChildDirection(parent.id, 5)).toThrow(
+                /out of bounds/
+            );
+        });
+
+        it('invalidates parent formation cache', () => {
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            const carC = makeCar('C');
+
+            const nested = new Formation(generateFormationId(), [carA, carB]);
+            carStock.addCar(carC);
+            const parent = manager.createFormation(['C']);
+            manager.addFormation(nested);
+            manager.appendFormation(parent.id, nested.id);
+
+            // Populate cache
+            parent.flatCars();
+            parent.bogieOffsets();
+
+            const nestedIndex = parent.originalChildren.findIndex(c => c.depth > 0);
+            manager.flipChildDirection(parent.id, nestedIndex);
+
+            // Cache should be invalidated — flatCars still returns correct data
+            expect(parent.flatCars().map(c => c.id)).toEqual(['C', 'A', 'B']);
+        });
+
+        it('notifies observers on change', () => {
+            const carA = makeCar('A');
+            carStock.addCar(carA);
+            const parent = manager.createFormation(['A']);
+
+            let notified = false;
+            manager.subscribe(() => { notified = true; });
+
+            manager.flipChildDirection(parent.id, 0);
+            expect(notified).toBe(true);
+        });
+    });
+
+    describe('composing reverse + flip achieves switch direction', () => {
+        it('reverse then flip produces same result as switchDirection', () => {
+            // [A, B] → reverse → [B, A] → flip → [B(f), A(f)]
+            // This is equivalent to switchDirection: reverse order + flip each car
+            const carA = makeCar('A');
+            const carB = makeCar('B');
+            const carC = makeCar('C');
+
+            const nested = new Formation(generateFormationId(), [carA, carB]);
+            carStock.addCar(carC);
+            const parent = manager.createFormation(['C']);
+            manager.addFormation(nested);
+            manager.appendFormation(parent.id, nested.id);
+
+            const nestedIndex = parent.originalChildren.findIndex(c => c.depth > 0);
+
+            manager.reverseNestedChildren(parent.id, nestedIndex);
+            manager.flipChildDirection(parent.id, nestedIndex);
+
+            expect(nested.flatCars().map(c => c.id)).toEqual(['B', 'A']);
+            expect(carA.flipped).toBe(true);
+            expect(carB.flipped).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Add **flip direction** button for any child (car or nested formation) in depot formations — flips head/tail orientation without reordering
- Add **reverse order** button for nested formation children — reorders without flipping car direction
- The two operations compose: reverse + flip = full direction switch
- Only affects unplaced (depot) formations; placed trains are unaffected

## Test plan
- [x] 14 unit tests covering both operations, error cases, cache invalidation, and observer notification
- [ ] Manual test: create nested formation in depot, verify both buttons appear on nested children and flip button appears on individual cars
- [ ] Verify reverse order and flip direction produce distinct results
- [ ] Verify placed formations (on track) show no new buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)