### PR TITLE
fix(banana): skip tunnel entrance geometry for fully-underground ramps

### DIFF
--- a/apps/banana/src/trains/tracks/geometry-utils.ts
+++ b/apps/banana/src/trains/tracks/geometry-utils.ts
@@ -1,0 +1,11 @@
+import { TrackSegmentDrawData } from './types';
+
+/** Resolution of the procedural track segment texture (power-of-two for repeat wrap). */
+const TRACK_TEX_SIZE = 64;
+
+/** Compute the ballast/slab half-width for a draw data entry. Always derived from gauge. */
+export const ballastHalfWidth = (drawData: TrackSegmentDrawData): number => {
+    const tieOverhang = 4;
+    const tieHw = (drawData.gauge / 2) * ((TRACK_TEX_SIZE + tieOverhang * 2) / TRACK_TEX_SIZE);
+    return tieHw + 0.15;
+};

--- a/apps/banana/src/trains/tracks/render-system.ts
+++ b/apps/banana/src/trains/tracks/render-system.ts
@@ -9,6 +9,8 @@ import type { TerrainData } from '@/terrain/terrain-data';
 import { clearShadowCache } from '@/utils';
 import { WorldRenderSystem, findElevationInterval } from '@/world-render-system';
 import { CameraState, CameraZoomEventPayload, ObservableBoardCamera } from '@ue-too/board';
+import { ballastHalfWidth } from './geometry-utils';
+import { computeTunnelEntranceGeometry } from './tunnel-geometry';
 
 /** Zoom level above which detailed track draw data is shown; below this only the bezier curve is drawn. */
 const ZOOM_THRESHOLD_DETAILED_TRACK = 5;
@@ -39,13 +41,6 @@ const SHADOW_TEX_SIZE = 4;
 
 /** Size of the tiny solid-color textures used for tunnel meshes. */
 const TUNNEL_TEX_SIZE = 4;
-
-/** Compute the ballast/slab half-width for a draw data entry. Always derived from gauge. */
-const ballastHalfWidth = (drawData: TrackSegmentDrawData): number => {
-    const tieOverhang = 4;
-    const tieHw = (drawData.gauge / 2) * ((TRACK_TEX_SIZE + tieOverhang * 2) / TRACK_TEX_SIZE);
-    return tieHw + 0.15;
-};
 
 /** Compute the rail mesh half-width (always derived from gauge — not affected by ballast width). */
 const railHalfWidth = (drawData: TrackSegmentDrawData): number => {
@@ -654,104 +649,14 @@ export class TrackRenderSystem {
 
     /**
      * Shared geometry computation for tunnel entrance walls and cover.
-     *
-     * Only applies to sloped segments (elevation.from !== elevation.to) where
-     * at least one end is below terrain.
-     *
-     * @returns Edge point arrays and metadata, or null when not applicable.
+     * Delegates to the pure helper in `tunnel-geometry.ts`.
      */
-    private _computeTunnelEntranceGeometry(drawData: TrackSegmentDrawData): {
-        leftInner: { x: number; y: number }[];
-        leftOuter: { x: number; y: number }[];
-        rightInner: { x: number; y: number }[];
-        rightOuter: { x: number; y: number }[];
-        coverEnd: 'start' | 'end' | 'both';
-        coverSteps: number;
-        surfaceBandIndex: number;
-    } | null {
-        const { curve, elevation } = drawData;
-        // Only draw on ramped tracks (not flat underground tracks).
-        if (elevation.from === elevation.to) return null;
-
-        // Sample terrain height at both ends of the track segment.
-        const startPoint = curve.getPointbyPercentage(0);
-        const endPoint = curve.getPointbyPercentage(1);
-        const startTerrainH = this._terrainData?.getHeight(startPoint.x, startPoint.y) ?? 0;
-        const endTerrainH = this._terrainData?.getHeight(endPoint.x, endPoint.y) ?? 0;
-
-        // Compute relative elevation (track elevation minus terrain height).
-        const relFrom = elevation.from - startTerrainH;
-        const relTo = elevation.to - endTerrainH;
-
-        // At least one end must be below terrain.
-        if (relFrom >= 0 && relTo >= 0) return null;
-
-        const ballastHw = ballastHalfWidth(drawData);
-        const hw = drawData.bed ? Math.max(ballastHw, (drawData.bedWidth ?? 3) / 2) : ballastHw;
-        /** Width of each retaining wall strip in world units (meters). */
-        const wallThickness = 0.4;
-        /** How far the walls extend beyond the terrain crossing (meters). */
-        const overshootDistance = 5;
-        const overshootT = curve.fullLength > 0
-            ? Math.min(0.15, overshootDistance / curve.fullLength)
-            : 0;
-
-        let tStart = 0;
-        let tEnd = 1;
-        let coverEnd: 'start' | 'end' | 'both';
-
-        if (relFrom >= 0 && relTo < 0) {
-            // Track goes from above terrain into underground.
-            const crossingT = relFrom / (relFrom - relTo);
-            tStart = Math.max(0, crossingT - overshootT);
-            tEnd = 1;
-            coverEnd = 'end';
-        } else if (relFrom < 0 && relTo >= 0) {
-            // Track goes from underground up to above terrain.
-            const crossingT = relFrom / (relFrom - relTo);
-            tStart = 0;
-            tEnd = Math.min(1, crossingT + overshootT);
-            coverEnd = 'start';
-        } else {
-            // Both ends below terrain (still a ramp).
-            tStart = 0;
-            tEnd = 1;
-            coverEnd = 'both';
-        }
-
-        // Place at the terrain surface elevation band.
-        const surfaceElev = Math.max(startTerrainH, endTerrainH);
-        const surfaceBandIndex = this._worldRenderSystem.getElevationBandIndex(surfaceElev);
-
-        const steps = Math.max(4, Math.ceil(curve.fullLength / 2));
-        const innerOffset = hw + 0.1;
-        const outerOffset = innerOffset + wallThickness;
-
-        const leftInner: { x: number; y: number }[] = [];
-        const leftOuter: { x: number; y: number }[] = [];
-        const rightInner: { x: number; y: number }[] = [];
-        const rightOuter: { x: number; y: number }[] = [];
-
-        for (let i = 0; i <= steps; i++) {
-            const t = tStart + (tEnd - tStart) * (i / steps);
-            const point = curve.getPointbyPercentage(t);
-            const tangent = PointCal.unitVector(curve.derivativeByPercentage(t));
-            const nx = -tangent.y;
-            const ny = tangent.x;
-
-            leftInner.push({ x: point.x - nx * innerOffset, y: point.y - ny * innerOffset });
-            leftOuter.push({ x: point.x - nx * outerOffset, y: point.y - ny * outerOffset });
-            rightInner.push({ x: point.x + nx * innerOffset, y: point.y + ny * innerOffset });
-            rightOuter.push({ x: point.x + nx * outerOffset, y: point.y + ny * outerOffset });
-        }
-
-        /** How far the cover extends along the ramp from the underground end (meters). */
-        const coverLength = 10;
-        const coverSteps = Math.max(1, Math.round(
-            (coverLength / curve.fullLength) * steps / (tEnd - tStart)
-        ));
-
-        return { leftInner, leftOuter, rightInner, rightOuter, coverEnd, coverSteps, surfaceBandIndex };
+    private _computeTunnelEntranceGeometry(drawData: TrackSegmentDrawData) {
+        return computeTunnelEntranceGeometry(
+            drawData,
+            this._terrainData ?? null,
+            (rawElevation) => this._worldRenderSystem.getElevationBandIndex(rawElevation),
+        );
     }
 
     /**
@@ -803,10 +708,9 @@ export class TrackRenderSystem {
             if (mesh) container.addChild(mesh);
         };
 
-        if (coverEnd === 'start' || coverEnd === 'both') {
+        if (coverEnd === 'start') {
             buildCover(0, Math.min(coverSteps, lastIdx));
-        }
-        if (coverEnd === 'end' || coverEnd === 'both') {
+        } else {
             buildCover(Math.max(0, lastIdx - coverSteps), lastIdx);
         }
 

--- a/apps/banana/src/trains/tracks/tunnel-geometry.ts
+++ b/apps/banana/src/trains/tracks/tunnel-geometry.ts
@@ -1,0 +1,112 @@
+import { PointCal } from '@ue-too/math';
+import type { TerrainData } from '../../terrain/terrain-data';
+import { TrackSegmentDrawData } from './types';
+import { ballastHalfWidth } from './geometry-utils';
+
+export type TunnelEntranceEdgePoint = { x: number; y: number };
+
+export type TunnelEntranceGeometry = {
+    leftInner: TunnelEntranceEdgePoint[];
+    leftOuter: TunnelEntranceEdgePoint[];
+    rightInner: TunnelEntranceEdgePoint[];
+    rightOuter: TunnelEntranceEdgePoint[];
+    coverEnd: 'start' | 'end';
+    coverSteps: number;
+    surfaceBandIndex: number;
+};
+
+/**
+ * Compute the retaining-wall + cover-cap geometry for a ramped track segment
+ * that transitions between above-terrain and below-terrain.
+ *
+ * Returns null when there is no terrain transition to build an entrance for:
+ * - flat tracks (elevation.from === elevation.to)
+ * - tracks fully above terrain at both endpoints
+ * - tracks fully below terrain at both endpoints (handled instead by the
+ *   fully-underground tunnel enclosure path)
+ */
+export function computeTunnelEntranceGeometry(
+    drawData: TrackSegmentDrawData,
+    terrainData: Pick<TerrainData, 'getHeight'> | null,
+    getElevationBandIndex: (rawElevation: number) => number,
+): TunnelEntranceGeometry | null {
+    const { curve, elevation } = drawData;
+    // Only draw on ramped tracks (not flat underground tracks).
+    if (elevation.from === elevation.to) return null;
+
+    // Sample terrain height at both ends of the track segment.
+    const startPoint = curve.getPointbyPercentage(0);
+    const endPoint = curve.getPointbyPercentage(1);
+    const startTerrainH = terrainData?.getHeight(startPoint.x, startPoint.y) ?? 0;
+    const endTerrainH = terrainData?.getHeight(endPoint.x, endPoint.y) ?? 0;
+
+    // Compute relative elevation (track elevation minus terrain height).
+    const relFrom = elevation.from - startTerrainH;
+    const relTo = elevation.to - endTerrainH;
+
+    // Need an actual above→below or below→above transition.
+    if (relFrom >= 0 && relTo >= 0) return null;
+    if (relFrom < 0 && relTo < 0) return null;
+
+    const ballastHw = ballastHalfWidth(drawData);
+    const hw = drawData.bed ? Math.max(ballastHw, (drawData.bedWidth ?? 3) / 2) : ballastHw;
+    /** Width of each retaining wall strip in world units (meters). */
+    const wallThickness = 0.4;
+    /** How far the walls extend beyond the terrain crossing (meters). */
+    const overshootDistance = 5;
+    const overshootT = curve.fullLength > 0
+        ? Math.min(0.15, overshootDistance / curve.fullLength)
+        : 0;
+
+    let tStart: number;
+    let tEnd: number;
+    let coverEnd: 'start' | 'end';
+
+    if (relFrom >= 0 && relTo < 0) {
+        // Track goes from above terrain into underground.
+        const crossingT = relFrom / (relFrom - relTo);
+        tStart = Math.max(0, crossingT - overshootT);
+        tEnd = 1;
+        coverEnd = 'end';
+    } else {
+        // relFrom < 0 && relTo >= 0: track goes from underground up to above terrain.
+        const crossingT = relFrom / (relFrom - relTo);
+        tStart = 0;
+        tEnd = Math.min(1, crossingT + overshootT);
+        coverEnd = 'start';
+    }
+
+    // Place at the terrain surface elevation band.
+    const surfaceElev = Math.max(startTerrainH, endTerrainH);
+    const surfaceBandIndex = getElevationBandIndex(surfaceElev);
+
+    const steps = Math.max(4, Math.ceil(curve.fullLength / 2));
+    const innerOffset = hw + 0.1;
+    const outerOffset = innerOffset + wallThickness;
+
+    const leftInner: TunnelEntranceEdgePoint[] = [];
+    const leftOuter: TunnelEntranceEdgePoint[] = [];
+    const rightInner: TunnelEntranceEdgePoint[] = [];
+    const rightOuter: TunnelEntranceEdgePoint[] = [];
+
+    for (let i = 0; i <= steps; i++) {
+        const t = tStart + (tEnd - tStart) * (i / steps);
+        const point = curve.getPointbyPercentage(t);
+        const tangent = PointCal.unitVector(curve.derivativeByPercentage(t));
+        const nx = -tangent.y;
+        const ny = tangent.x;
+
+        leftInner.push({ x: point.x - nx * innerOffset, y: point.y - ny * innerOffset });
+        leftOuter.push({ x: point.x - nx * outerOffset, y: point.y - ny * outerOffset });
+        rightInner.push({ x: point.x + nx * innerOffset, y: point.y + ny * innerOffset });
+        rightOuter.push({ x: point.x + nx * outerOffset, y: point.y + ny * outerOffset });
+    }
+
+    /** How far the cover extends along the ramp from the underground end (meters). */
+    const coverLength = 10;
+    const coverSteps = Math.max(1, Math.round(
+        (coverLength / curve.fullLength) * steps / (tEnd - tStart)
+    ));
+
+    return { leftInner, leftOuter, rightInner, rightOuter, coverEnd, coverSteps, surfaceBandIndex };
+}

--- a/apps/banana/test/tunnel-geometry.test.ts
+++ b/apps/banana/test/tunnel-geometry.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from 'bun:test';
+import { BCurve } from '@ue-too/curve';
+import { computeTunnelEntranceGeometry } from '../src/trains/tracks/tunnel-geometry';
+import type { TrackSegmentDrawData } from '../src/trains/tracks/types';
+
+/** A 100m straight curve along +X. Terrain can be varied along x for crossing tests. */
+const makeStraightCurve = () => new BCurve([{ x: 0, y: 0 }, { x: 100, y: 0 }]);
+
+/** Minimal draw data; fields not read by the helper are filled with placeholders. */
+const makeDrawData = (elevationFrom: number, elevationTo: number): TrackSegmentDrawData => ({
+    curve: makeStraightCurve(),
+    originalTrackSegment: {
+        trackSegmentNumber: 0,
+        startJointPosition: { x: 0, y: 0 },
+        endJointPosition: { x: 100, y: 0 },
+        tValInterval: { start: 0, end: 1 },
+    },
+    gauge: 1.435,
+    elevation: { from: elevationFrom, to: elevationTo },
+    originalElevation: { from: 0, to: 0 },
+    excludeSegmentsForCollisionCheck: new Set<number>(),
+    bed: false,
+});
+
+const flatTerrain = (height: number) => ({ getHeight: () => height });
+const xStepTerrain = (threshold: number, loH: number, hiH: number) => ({
+    getHeight: (x: number) => (x < threshold ? loH : hiH),
+});
+const bandIdx = (rawElevation: number) => Math.floor(rawElevation / 10);
+
+describe('computeTunnelEntranceGeometry', () => {
+    it('returns null for a flat track (elevation.from === elevation.to)', () => {
+        // Even if the flat track is below terrain, the entrance path must bail out —
+        // flat underground tracks are handled by the fully-underground enclosure instead.
+        const drawData = makeDrawData(10, 10);
+        const result = computeTunnelEntranceGeometry(drawData, flatTerrain(30), bandIdx);
+        expect(result).toBeNull();
+    });
+
+    it('returns null when both ends are above terrain', () => {
+        const drawData = makeDrawData(20, 25);
+        const result = computeTunnelEntranceGeometry(drawData, flatTerrain(0), bandIdx);
+        expect(result).toBeNull();
+    });
+
+    it('returns geometry with coverEnd="end" for a ramp entering underground (above → below)', () => {
+        const drawData = makeDrawData(20, 0);
+        const result = computeTunnelEntranceGeometry(drawData, flatTerrain(10), bandIdx);
+        expect(result).not.toBeNull();
+        expect(result!.coverEnd).toBe('end');
+        expect(result!.leftInner.length).toBeGreaterThan(0);
+        expect(result!.leftOuter.length).toBeGreaterThan(0);
+        expect(result!.rightInner.length).toBeGreaterThan(0);
+        expect(result!.rightOuter.length).toBeGreaterThan(0);
+        expect(result!.coverSteps).toBeGreaterThan(0);
+        expect(result!.surfaceBandIndex).toBe(bandIdx(10));
+    });
+
+    it('returns geometry with coverEnd="start" for a ramp exiting underground (below → above)', () => {
+        const drawData = makeDrawData(0, 20);
+        const result = computeTunnelEntranceGeometry(drawData, flatTerrain(10), bandIdx);
+        expect(result).not.toBeNull();
+        expect(result!.coverEnd).toBe('start');
+        expect(result!.leftInner.length).toBeGreaterThan(0);
+        expect(result!.rightOuter.length).toBeGreaterThan(0);
+    });
+
+    it('returns null for a ramp that is fully underground at both ends (regression: bug fix)', () => {
+        // Ramp from elevation 0 to 5, terrain at 30 everywhere.
+        // Both ends are well below terrain — this should NOT generate an entrance.
+        // Before the fix this returned geometry with coverEnd='both'.
+        const drawData = makeDrawData(0, 5);
+        const result = computeTunnelEntranceGeometry(drawData, flatTerrain(30), bandIdx);
+        expect(result).toBeNull();
+    });
+
+    it('handles varying terrain: ramp crossing a step-change terrain from above to below', () => {
+        // Terrain: 0m for x<50, 30m for x>=50. Ramp elevation 10 → 15.
+        // At start (x=0), terrain=0, track=10 → above (relFrom = 10 >= 0).
+        // At end (x=100), terrain=30, track=15 → below (relTo = -15 < 0).
+        // This is a legitimate above→below transition and must produce coverEnd='end'.
+        const drawData = makeDrawData(10, 15);
+        const result = computeTunnelEntranceGeometry(
+            drawData,
+            xStepTerrain(50, 0, 30),
+            bandIdx,
+        );
+        expect(result).not.toBeNull();
+        expect(result!.coverEnd).toBe('end');
+    });
+
+    it('treats relFrom === 0 (track exactly on terrain) as above, producing an entrance when the other end dives under', () => {
+        // Track at 10 with terrain at 10 at the start → relFrom = 0 (above by >= check).
+        // Track at 0 with terrain at 30 at the end → relTo = -30 (below).
+        // Expect a legitimate above→below entrance with coverEnd='end'.
+        const drawData = makeDrawData(10, 0);
+        const result = computeTunnelEntranceGeometry(
+            drawData,
+            xStepTerrain(50, 10, 30),
+            bandIdx,
+        );
+        expect(result).not.toBeNull();
+        expect(result!.coverEnd).toBe('end');
+    });
+
+    it('plumbs getElevationBandIndex through and picks the higher terrain surface', () => {
+        const drawData = makeDrawData(20, 0);
+        const result = computeTunnelEntranceGeometry(
+            drawData,
+            xStepTerrain(50, 5, 25),
+            bandIdx,
+        );
+        expect(result).not.toBeNull();
+        // surfaceBandIndex should come from max(startTerrainH, endTerrainH) = 25.
+        expect(result!.surfaceBandIndex).toBe(bandIdx(25));
+    });
+});


### PR DESCRIPTION
## Summary

- A ramped track whose both endpoints already sit beneath the terrain was incorrectly generating retaining walls + cover caps on top of the underlying tunnel enclosure. The shared entrance geometry helper only guarded the fully-above-ground case, so a below→below ramp fell through to a `coverEnd: 'both'` branch and produced spurious visuals.
- Added a missing early-out for fully-underground ramps — the existing tunnel walls + ceiling path already handles this case correctly.
- Extracted the geometry computation to a pure `tunnel-geometry.ts` module so it is unit-testable without instantiating the PixiJS-heavy `TrackRenderSystem`, and added tests that lock in the decision contract (including both the regression for the bug fix *and* the original legitimate above↔below entrance cases).

## Test plan

- [x] `bunx nx test banana` — 510 pass / 0 fail across 26 files (includes 8 new tunnel-geometry tests)
- [x] Manual repro in `bun run dev:banana`:
  - [x] Lay a flat fully-underground track through a hill → tunnel walls + ceiling still render (non-ramp regression)
  - [x] Lay a ramp entering underground from a hillside → retaining walls + cover cap still appear at the entrance (legitimate-entrance regression)
  - [x] Lay a ramp fully under a hill (e.g. elevation 0 → 10m beneath a 30m+ hill) → **expected**: only the tunnel enclosure; **no** spurious cover caps at the ramp's ends (this is the bug fix)
  - [x] Confirm the preview (ghost) track during placement behaves the same — the preview path shares the same helper

🤖 Generated with [Claude Code](https://claude.com/claude-code)