### PR TITLE
fix(banana): restore toolbar scroll-overflow arrow indicators

### DIFF
--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -246,7 +246,7 @@ export function BananaToolbar({
             ro.disconnect();
             mo.disconnect();
         };
-    }, [updateScrollIndicators]);
+    }, [updateScrollIndicators, app]);
 
     // Sync render settings to PIXI systems
     useRenderSync(app);


### PR DESCRIPTION
## Summary
- Fix the chevron scroll-overflow indicators on the simulator toolbar, which never appeared even when the toolbar overflowed the viewport.
- Root cause: `useBananaApp()` returns `null` on first render and the component early-returns `null` until the app is ready. The overflow-detection `useEffect` ran once at that initial mount when `scrollRef.current` was still `null`, took its early-return path, and never re-ran — its only dep was a stable `useCallback`. Observers and the scroll listener were therefore never attached after the scroll container actually mounted, leaving `canScrollDown` as `false` and both arrows `invisible`.
- Fix: add `app` to the effect's dependency array so the effect re-runs once the scroll container is in the DOM.

## Test plan
- [x] Reproduce in dev (`bunx nx dev banana`) — confirmed both chevron arrow containers had `visibility: hidden` despite `scrollHeight` (1088) > `clientHeight` (481).
- [x] Verify after fix: with `scrollTop=0`, only the down arrow is visible; scrolled to middle, both visible; scrolled to bottom, only the up arrow is visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)