### PR TITLE
feat(banana): add car editor link to landing page

### DIFF
--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -255,6 +255,7 @@ const en = {
         landingTagline2: 'tracks, stations, trains, and more.',
         openSimulator: 'Open Simulator',
         openTutorial: 'tutorial (WIP)',
+        openCarEditor: 'Open Car Editor',
         build: 'Build',
         simulate: 'Simulate',
         featureTrackDrawing: 'Bézier Track Drawing provides high flexibility',

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -190,6 +190,7 @@ const ja = {
         landingTagline2: '線路、駅、列車、そしてもっと。',
         openSimulator: 'シミュレーターを開く',
         openTutorial: 'チュートリアル（作成中）',
+        openCarEditor: '車両エディターを開く',
         build: '建設',
         simulate: 'シミュレート',
         featureTrackDrawing: 'ベジエ曲線による線路敷設',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -252,6 +252,7 @@ const zhTW = {
         landingTagline2: '軌道、車站、列車、自由組合',
         openSimulator: '開啟模擬器',
         openTutorial: '教學（製作中）',
+        openCarEditor: '開啟車輛編輯器',
         build: '建造',
         simulate: '模擬',
         featureTrackDrawing: '高度自由的佈軌系統',

--- a/apps/banana/src/pages/landing.tsx
+++ b/apps/banana/src/pages/landing.tsx
@@ -281,6 +281,24 @@ export function LandingPage(): React.ReactNode {
                                     usePixelFont
                                 />
                             </Link>
+                            <Link
+                                to="/train-editor"
+                                className="mt-7 transition-opacity hover:opacity-75"
+                                onMouseEnter={() => setCtaHover(true)}
+                                onMouseLeave={() => setCtaHover(false)}
+                                onClick={() =>
+                                    trackEvent('landing-open-car-editor')
+                                }
+                            >
+                                <LedMarquee
+                                    text={t('openCarEditor') + ' →'}
+                                    height={isCJK ? 36 : 24}
+                                    dotSize={isCJK ? 3 : undefined}
+                                    scroll={false}
+                                    pulse={!reduceMotion && !ctaHover}
+                                    usePixelFont
+                                />
+                            </Link>
                         </section>
 
                         <section className="flex flex-col items-center gap-8 px-4 py-6 sm:gap-10 sm:px-6">


### PR DESCRIPTION
## Summary
- Adds a third CTA link on the banana landing page pointing to `/train-editor`, matching the existing simulator/tutorial link style (LedMarquee, pulse, hover, analytics event `landing-open-car-editor`)
- Adds `openCarEditor` i18n entries for `en`, `ja`, and `zh-TW`
- Root page remains non-scrollable — the existing `fitScale` auto-scales the hero section to fit within the viewport

## Test plan
- [ ] Visit `/` in the banana app and confirm the three CTA links render (Open Simulator, tutorial, Open Car Editor)
- [ ] Click the Car Editor link and verify it navigates to `/train-editor`
- [ ] Resize the window — the page should stay non-scrollable at all viewport sizes
- [ ] Switch languages (en / ja / zh-TW) and verify the Car Editor label is translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)