### PR TITLE
feat(banana): toggle bogies rendering from debug panel

### DIFF
--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -155,6 +155,7 @@ export function BananaToolbar({
         showStationStops,
         showStationLocations,
         showProximityLines,
+        showBogies,
         showStats,
         terrainXray,
     } = useRenderSettingsStore(
@@ -176,6 +177,7 @@ export function BananaToolbar({
             showStationStops: s.showStationStops,
             showStationLocations: s.showStationLocations,
             showProximityLines: s.showProximityLines,
+            showBogies: s.showBogies,
             showStats: s.showStats,
             terrainXray: s.terrainXray,
         }))
@@ -1061,6 +1063,8 @@ export function BananaToolbar({
                     onShowStationLocationsChange={rs.getState().setShowStationLocations}
                     showProximityLines={showProximityLines}
                     onShowProximityLinesChange={rs.getState().setShowProximityLines}
+                    showBogies={showBogies}
+                    onShowBogiesChange={rs.getState().setShowBogies}
                     showStats={showStats}
                     onShowStatsChange={rs.getState().setShowStats}
                     terrainXray={terrainXray}

--- a/apps/banana/src/components/toolbar/DebugPanel.tsx
+++ b/apps/banana/src/components/toolbar/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import { Activity, ArrowLeftRight, Crosshair, Eye, Hash, Landmark, Link2, ListOrdered, OctagonXIcon, TrainFront, MapPin } from '@/assets/icons';
+import { Activity, ArrowLeftRight, CircleIcon, Crosshair, Eye, Hash, Landmark, Link2, ListOrdered, OctagonXIcon, TrainFront, MapPin } from '@/assets/icons';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -19,6 +19,8 @@ type DebugPanelProps = {
     onShowStationLocationsChange: (value: boolean) => void;
     showProximityLines: boolean;
     onShowProximityLinesChange: (value: boolean) => void;
+    showBogies: boolean;
+    onShowBogiesChange: (value: boolean) => void;
     showStats: boolean;
     onShowStatsChange: (value: boolean) => void;
     terrainXray: boolean;
@@ -50,6 +52,8 @@ export function DebugPanel({
     onShowStationLocationsChange,
     showProximityLines,
     onShowProximityLinesChange,
+    showBogies,
+    onShowBogiesChange,
     showStats,
     onShowStatsChange,
     terrainXray,
@@ -140,6 +144,17 @@ export function DebugPanel({
                         aria-label="Toggle coupling proximity lines"
                     >
                         <Link2 className="size-3.5" />
+                    </Toggle>
+                </div>
+                <div className="flex items-center justify-between gap-2 text-xs">
+                    <span className="text-foreground">{t('showBogies')}</span>
+                    <Toggle
+                        size="sm"
+                        pressed={showBogies}
+                        onPressedChange={onShowBogiesChange}
+                        aria-label="Toggle bogies rendering"
+                    >
+                        <CircleIcon className="size-3.5" />
                     </Toggle>
                 </div>
                 <div className="flex items-center justify-between gap-2 text-xs">

--- a/apps/banana/src/hooks/use-render-sync.ts
+++ b/apps/banana/src/hooks/use-render-sync.ts
@@ -93,6 +93,9 @@ export function useRenderSync(app: BananaAppComponents | null): void {
                     state.showProximityLines
                 );
             }
+            if (state.showBogies !== prev.showBogies) {
+                app.trainRenderSystem.showBogies = state.showBogies;
+            }
             if (state.showStats !== prev.showStats) {
                 app.statsDom.style.display = state.showStats
                     ? 'block'
@@ -137,5 +140,6 @@ function applyAll(
     app.debugOverlayRenderSystem.setShowProximityDebug(
         state.showProximityLines
     );
+    app.trainRenderSystem.showBogies = state.showBogies;
     app.statsDom.style.display = state.showStats ? 'block' : 'none';
 }

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -148,6 +148,7 @@ const en = {
         formationIds: 'Formation IDs',
         stationStops: 'Station stops',
         stationLocations: 'Station locations',
+        showBogies: 'Bogies',
         terrainXray: 'Terrain X-ray',
         fpsStats: 'FPS stats',
 

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -148,6 +148,7 @@ const ja = {
         formationIds: '編成 ID',
         stationStops: '停車駅',
         stationLocations: '駅の位置',
+        showBogies: '台車',
         terrainXray: '地形透視',
         fpsStats: 'FPS 統計',
 

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -148,6 +148,7 @@ const zhTW = {
         formationIds: '編組 ID',
         stationStops: '停靠站',
         stationLocations: '車站位置',
+        showBogies: '轉向架',
         terrainXray: '地形透視',
         fpsStats: 'FPS 統計',
 

--- a/apps/banana/src/stores/render-settings-store.ts
+++ b/apps/banana/src/stores/render-settings-store.ts
@@ -22,6 +22,7 @@ type RenderSettingsState = {
     showStationStops: boolean;
     showStationLocations: boolean;
     showProximityLines: boolean;
+    showBogies: boolean;
     showStats: boolean;
 };
 
@@ -44,6 +45,7 @@ type RenderSettingsActions = {
     setShowStationStops: (v: boolean) => void;
     setShowStationLocations: (v: boolean) => void;
     setShowProximityLines: (v: boolean) => void;
+    setShowBogies: (v: boolean) => void;
     setShowStats: (v: boolean) => void;
 };
 
@@ -71,6 +73,7 @@ export const useRenderSettingsStore = create<RenderSettingsStore>()(
             showStationStops: false,
             showStationLocations: false,
             showProximityLines: false,
+            showBogies: true,
             showStats: true,
 
             // Actions
@@ -92,6 +95,7 @@ export const useRenderSettingsStore = create<RenderSettingsStore>()(
             setShowStationStops: (v) => set({ showStationStops: v }),
             setShowStationLocations: (v) => set({ showStationLocations: v }),
             setShowProximityLines: (v) => set({ showProximityLines: v }),
+            setShowBogies: (v) => set({ showBogies: v }),
             setShowStats: (v) => set({ showStats: v }),
         }),
         { name: 'banana-render-settings' }

--- a/apps/banana/src/trains/train-render-system.ts
+++ b/apps/banana/src/trains/train-render-system.ts
@@ -290,6 +290,8 @@ export class TrainRenderSystem {
   /** Cache of loaded custom car textures by car ID. */
   private _customCarTextures: Map<string, { full: Texture; rear: Texture; front: Texture }> = new Map();
 
+  private _showBogies: boolean = true;
+
   constructor(
     worldRenderSystem: WorldRenderSystem,
     getPlacedTrains: () => readonly PlacedTrainEntry[],
@@ -342,6 +344,23 @@ export class TrainRenderSystem {
   /** The centralized occupancy registry, updated each frame. */
   get occupancyRegistry(): OccupancyRegistry {
     return this._occupancyRegistry;
+  }
+
+  get showBogies(): boolean {
+    return this._showBogies;
+  }
+
+  set showBogies(value: boolean) {
+    if (this._showBogies === value) return;
+    this._showBogies = value;
+    if (!value) {
+      for (const [trainId] of this._actualPools) {
+        this._hideActualBogiesForTrain(trainId);
+      }
+      for (const g of this._previewGraphicsPool) {
+        g.visible = false;
+      }
+    }
   }
 
   /** The proximity detector, updated each frame. */
@@ -427,6 +446,7 @@ export class TrainRenderSystem {
     for (let i = 0; i < positions.length; i++) {
       const g = this._previewGraphicsPool[i];
       g.position.set(positions[i].point.x, positions[i].point.y);
+      g.visible = this._showBogies;
     }
   }
 
@@ -457,7 +477,7 @@ export class TrainRenderSystem {
         const g = pool[i];
         const key = bogieKey(id, i);
         g.position.set(positions[i].point.x, positions[i].point.y);
-        g.visible = true;
+        g.visible = this._showBogies;
 
         const bandIndex = i === 0 ? headBand : (this._resolveBandIndex(positions[i]) ?? headBand);
         if (bandIndex !== null) {
@@ -823,7 +843,7 @@ export class TrainRenderSystem {
       this._previewContainer.addChild(g);
     }
     for (let i = 0; i < this._previewGraphicsPool.length; i++) {
-      this._previewGraphicsPool[i].visible = i < count;
+      this._previewGraphicsPool[i].visible = this._showBogies && i < count;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Add `showBogies` toggle to the debug panel (default on) that hides/shows train bogie circles in the viewport
- Wired through `render-settings-store` → `use-render-sync` → `TrainRenderSystem.showBogies`, which short-circuits visibility on actual and preview bogie pools
- Added `showBogies` i18n label to en/ja/zh-TW

## Test plan
- [ ] Open banana app, open the debug panel, toggle Bogies off — bogie circles disappear on all placed trains and during train placement preview
- [ ] Toggle back on — bogies reappear at the correct positions
- [ ] Verify car bodies, gangways, and other debug overlays are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)