### PR TITLE
feat(banana): save car definitions to IndexedDB library

### DIFF
--- a/apps/banana/src/components/car-definition-library/CarDefinitionLibraryDialog.tsx
+++ b/apps/banana/src/components/car-definition-library/CarDefinitionLibraryDialog.tsx
@@ -1,0 +1,180 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Trash2, X } from '@/assets/icons';
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+import { cn } from '@/lib/utils';
+import {
+    type CarDefinitionMetadata,
+    type StoredCarDefinition,
+    getCarDefinitionStorage,
+} from '@/storage';
+
+function formatRelativeTime(
+    timestamp: number,
+    t: (key: string, opts?: Record<string, unknown>) => string
+): string {
+    const diff = Date.now() - timestamp;
+    const seconds = Math.floor(diff / 1000);
+    if (seconds < 60) return t('justNow');
+    const minutes = Math.floor(seconds / 60);
+    if (minutes < 60) return t('minutesAgo', { count: minutes });
+    const hours = Math.floor(minutes / 60);
+    if (hours < 24) return t('hoursAgo', { count: hours });
+    const days = Math.floor(hours / 24);
+    return t('daysAgo', { count: days });
+}
+
+type CarDefinitionLibraryDialogProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    /** Called when the user picks a saved entry. Dialog closes afterwards. */
+    onPick: (stored: StoredCarDefinition) => void;
+    /** Highlight this entry if present (e.g. the currently loaded one in the train editor). */
+    highlightedId?: string | null;
+};
+
+export function CarDefinitionLibraryDialog({
+    open,
+    onOpenChange,
+    onPick,
+    highlightedId,
+}: CarDefinitionLibraryDialogProps) {
+    const { t } = useTranslation();
+    const [entries, setEntries] = useState<CarDefinitionMetadata[]>([]);
+    const [loading, setLoading] = useState(false);
+    const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+
+    const refresh = useCallback(async () => {
+        setLoading(true);
+        try {
+            const list = await getCarDefinitionStorage().listCarDefinitions();
+            setEntries(list);
+        } finally {
+            setLoading(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        if (open) {
+            setConfirmDeleteId(null);
+            refresh();
+        }
+    }, [open, refresh]);
+
+    const handleSelect = useCallback(
+        async (id: string) => {
+            const stored =
+                await getCarDefinitionStorage().loadCarDefinition(id);
+            if (!stored) {
+                await refresh();
+                return;
+            }
+            onPick(stored);
+            onOpenChange(false);
+        },
+        [onPick, onOpenChange, refresh]
+    );
+
+    const handleDelete = useCallback(
+        async (id: string) => {
+            await getCarDefinitionStorage().deleteCarDefinition(id);
+            setConfirmDeleteId(null);
+            await refresh();
+        },
+        [refresh]
+    );
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-md">
+                <DialogHeader>
+                    <DialogTitle>{t('carDefinitionLibraryTitle')}</DialogTitle>
+                    <DialogDescription>
+                        {t('carDefinitionLibraryDescription')}
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="mt-4 flex max-h-72 flex-col gap-2 overflow-y-auto">
+                    {entries.map(entry => {
+                        const confirming = confirmDeleteId === entry.id;
+                        const highlighted = entry.id === highlightedId;
+                        return (
+                            <div
+                                key={entry.id}
+                                className={cn(
+                                    'hover:bg-accent/50 flex items-center gap-3 rounded-md border p-3 transition-colors',
+                                    highlighted && 'border-primary bg-accent/30'
+                                )}
+                            >
+                                <button
+                                    type="button"
+                                    className="flex min-w-0 flex-1 cursor-pointer flex-col items-start gap-0.5 text-left"
+                                    onClick={() => handleSelect(entry.id)}
+                                >
+                                    <span className="truncate text-sm font-medium">
+                                        {entry.name}
+                                    </span>
+                                    <span className="text-muted-foreground text-xs">
+                                        {formatRelativeTime(entry.updatedAt, t)}
+                                    </span>
+                                </button>
+
+                                {confirming ? (
+                                    <div className="flex items-center gap-1">
+                                        <Button
+                                            variant="destructive"
+                                            size="sm"
+                                            onClick={e => {
+                                                e.stopPropagation();
+                                                handleDelete(entry.id);
+                                            }}
+                                        >
+                                            {t('confirmDelete')}
+                                        </Button>
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="size-7"
+                                            onClick={e => {
+                                                e.stopPropagation();
+                                                setConfirmDeleteId(null);
+                                            }}
+                                        >
+                                            <X className="size-3" />
+                                        </Button>
+                                    </div>
+                                ) : (
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        className="text-muted-foreground hover:text-destructive size-7 shrink-0"
+                                        onClick={e => {
+                                            e.stopPropagation();
+                                            setConfirmDeleteId(entry.id);
+                                        }}
+                                    >
+                                        <Trash2 className="size-3.5" />
+                                    </Button>
+                                )}
+                            </div>
+                        );
+                    })}
+
+                    {!loading && entries.length === 0 && (
+                        <p className="text-muted-foreground py-4 text-center text-sm">
+                            {t('noSavedCarDefinitions')}
+                        </p>
+                    )}
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/banana/src/components/car-definition-library/SaveCarDefinitionDialog.tsx
+++ b/apps/banana/src/components/car-definition-library/SaveCarDefinitionDialog.tsx
@@ -1,0 +1,88 @@
+import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { Button } from '@/components/ui/button';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from '@/components/ui/dialog';
+
+type SaveCarDefinitionDialogProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    initialName: string;
+    /** True when saving over an existing entry — changes the title/description copy. */
+    updatingExisting?: boolean;
+    onConfirm: (name: string) => void;
+};
+
+export function SaveCarDefinitionDialog({
+    open,
+    onOpenChange,
+    initialName,
+    updatingExisting = false,
+    onConfirm,
+}: SaveCarDefinitionDialogProps) {
+    const { t } = useTranslation();
+    const [name, setName] = useState(initialName);
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useEffect(() => {
+        if (open) {
+            setName(initialName);
+            setTimeout(() => inputRef.current?.select(), 0);
+        }
+    }, [open, initialName]);
+
+    const confirm = () => {
+        const trimmed = name.trim();
+        if (!trimmed) return;
+        onConfirm(trimmed);
+        onOpenChange(false);
+    };
+
+    return (
+        <Dialog open={open} onOpenChange={onOpenChange}>
+            <DialogContent className="max-w-sm">
+                <DialogHeader>
+                    <DialogTitle>
+                        {updatingExisting
+                            ? t('saveCarDefinitionUpdateTitle')
+                            : t('saveCarDefinitionTitle')}
+                    </DialogTitle>
+                    <DialogDescription>
+                        {updatingExisting
+                            ? t('saveCarDefinitionUpdateDescription')
+                            : t('saveCarDefinitionDescription')}
+                    </DialogDescription>
+                </DialogHeader>
+                <input
+                    ref={inputRef}
+                    className="bg-background w-full rounded border px-2 py-1.5 text-sm"
+                    value={name}
+                    placeholder={t('carDefinitionNamePlaceholder')}
+                    onChange={e => setName(e.target.value)}
+                    onKeyDown={e => {
+                        if (e.key === 'Enter') confirm();
+                        if (e.key === 'Escape') onOpenChange(false);
+                    }}
+                />
+                <DialogFooter>
+                    <Button
+                        variant="outline"
+                        onClick={() => onOpenChange(false)}
+                    >
+                        {t('cancel')}
+                    </Button>
+                    <Button onClick={confirm} disabled={!name.trim()}>
+                        {t('save')}
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+}

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -3,6 +3,10 @@ import {
     useCoordinateConversion,
     useToggleKmtInput,
 } from '@ue-too/board-pixi-react-integration';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useShallow } from 'zustand/react/shallow';
+
 import {
     Bug,
     Building2,
@@ -13,11 +17,11 @@ import {
     FilePlus,
     FolderOpen,
     Landmark,
-    Save,
     Layers,
     List,
     ListOrdered,
     Map,
+    Save,
     Signal,
     Spline,
     TrainFront,
@@ -25,11 +29,8 @@ import {
     Trash2,
     Warehouse,
 } from '@/assets/icons';
-import { useCallback, useEffect, useRef, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useShallow } from 'zustand/react/shallow';
-
 import type { BuildingPreset } from '@/buildings/types';
+import { CarDefinitionLibraryDialog } from '@/components/car-definition-library/CarDefinitionLibraryDialog';
 import { FormationEditor } from '@/components/formation-editor';
 import { Separator } from '@/components/ui/separator';
 import { TooltipProvider } from '@/components/ui/tooltip';
@@ -37,9 +38,6 @@ import { useBananaApp } from '@/contexts/pixi';
 import { useAutoSave } from '@/hooks/use-auto-save';
 import { useRenderSync } from '@/hooks/use-render-sync';
 import { cn } from '@/lib/utils';
-import { useRenderSettingsStore } from '@/stores/render-settings-store';
-import { useSceneStore } from '@/stores/scene-store';
-import { useToolbarUIStore } from '@/stores/toolbar-ui-store';
 import {
     type SerializedSceneData,
     deserializeSceneData,
@@ -48,6 +46,10 @@ import {
 } from '@/scene-serialization';
 import { StationManager } from '@/stations/station-manager';
 import type { SerializedStationData } from '@/stations/types';
+import type { StoredCarDefinition } from '@/storage';
+import { useRenderSettingsStore } from '@/stores/render-settings-store';
+import { useSceneStore } from '@/stores/scene-store';
+import { useToolbarUIStore } from '@/stores/toolbar-ui-store';
 import {
     TerrainData,
     validateSerializedTerrainData,
@@ -68,7 +70,6 @@ import {
     serializeTrainData,
     validateSerializedTrainData,
 } from '@/trains/train-serialization';
-
 import { trackEvent } from '@/utils/analytics';
 
 import { AutoSaveIntervalSelector } from './AutoSaveIntervalSelector';
@@ -80,14 +81,14 @@ import { FormationSelector } from './FormationSelector';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { LayoutDeletionToolbar } from './LayoutDeletionToolbar';
 import { ScaleRuler } from './ScaleRuler';
+import { SignalPanel } from './SignalPanel';
 import { StationListPanel } from './StationListPanel';
 import { SunAngleControl } from './SunAngleControl';
 import { TerrainControl } from './TerrainControl';
 import { TerrainLegend } from './TerrainLegend';
+import { TimetablePanel } from './TimetablePanel';
 import { ToolbarButton } from './ToolbarButton';
 import { TrackStyleSelector } from './TrackStyleSelector';
-import { SignalPanel } from './SignalPanel';
-import { TimetablePanel } from './TimetablePanel';
 import { TrainPanel } from './TrainPanel';
 import { TOOLBAR_LEFT } from './types';
 import { downloadJson, uploadJson } from './utils';
@@ -104,12 +105,12 @@ export function BananaToolbar({
     const convertCoords = useCoordinateConversion();
     const toggleKmtInput = useToggleKmtInput();
     const { saveNow } = useAutoSave();
-    const showScenePickerAction = useSceneStore((s) => s.showScenePicker);
-    const createNewScene = useSceneStore((s) => s.createNewScene);
+    const showScenePickerAction = useSceneStore(s => s.showScenePicker);
+    const createNewScene = useSceneStore(s => s.createNewScene);
 
     // Toolbar UI store — mode and panel visibility
-    const mode = useToolbarUIStore((s) => s.mode);
-    const setMode = useToolbarUIStore((s) => s.setMode);
+    const mode = useToolbarUIStore(s => s.mode);
+    const setMode = useToolbarUIStore(s => s.setMode);
     const {
         showDepot,
         showTrainPanel,
@@ -121,7 +122,7 @@ export function BananaToolbar({
         showExportSubmenu,
         showAutoSaveMenu,
     } = useToolbarUIStore(
-        useShallow((s) => ({
+        useShallow(s => ({
             showDepot: s.showDepot,
             showTrainPanel: s.showTrainPanel,
             showFormationEditor: s.showFormationEditor,
@@ -133,8 +134,8 @@ export function BananaToolbar({
             showAutoSaveMenu: s.showAutoSaveMenu,
         }))
     );
-    const setPanel = useToolbarUIStore((s) => s.setPanel);
-    const togglePanel = useToolbarUIStore((s) => s.togglePanel);
+    const setPanel = useToolbarUIStore(s => s.setPanel);
+    const togglePanel = useToolbarUIStore(s => s.togglePanel);
 
     // Render settings store
     const {
@@ -159,7 +160,7 @@ export function BananaToolbar({
         showStats,
         terrainXray,
     } = useRenderSettingsStore(
-        useShallow((s) => ({
+        useShallow(s => ({
             sunAngle: s.sunAngle,
             showElevationGradient: s.showElevationGradient,
             showPreviewCurveArcs: s.showPreviewCurveArcs,
@@ -197,6 +198,7 @@ export function BananaToolbar({
     const [stressStartX, setStressStartX] = useState(0);
     const [stressStartY, setStressStartY] = useState(0);
     const [carTemplates, setCarTemplates] = useState<CarTemplate[]>([]);
+    const [libraryDialogOpen, setLibraryDialogOpen] = useState(false);
 
     const selectedBuildingRef = useRef<number | null>(null);
 
@@ -440,7 +442,7 @@ export function BananaToolbar({
     const handleImportTracks = useCallback(() => {
         if (!app) return;
         trackEvent('import-tracks');
-        uploadJson(async (parsed) => {
+        uploadJson(async parsed => {
             const result = validateSerializedTrackData(parsed);
             if (!result.valid) {
                 alert(t('invalidTrackData', { error: result.error }));
@@ -454,10 +456,12 @@ export function BananaToolbar({
                 parsed as SerializedTrackData,
                 {
                     onProgress: (loaded, total) =>
-                        useSceneStore.getState().setSceneLoadProgress(
-                            total > 0 ? loaded / total : 1
-                        ),
-                },
+                        useSceneStore
+                            .getState()
+                            .setSceneLoadProgress(
+                                total > 0 ? loaded / total : 1
+                            ),
+                }
             );
 
             // Restore stations if present in the track data
@@ -521,7 +525,7 @@ export function BananaToolbar({
     const handleImportAll = useCallback(() => {
         if (!app) return;
         trackEvent('import-scene');
-        uploadJson(async (parsed) => {
+        uploadJson(async parsed => {
             const result = validateSerializedSceneData(parsed);
             if (!result.valid) {
                 alert(t('invalidSceneData', { error: result.error }));
@@ -533,9 +537,9 @@ export function BananaToolbar({
 
             await deserializeSceneData(app, parsed as SerializedSceneData, {
                 onProgress: (loaded, total) =>
-                    useSceneStore.getState().setSceneLoadProgress(
-                        total > 0 ? loaded / total : 1
-                    ),
+                    useSceneStore
+                        .getState()
+                        .setSceneLoadProgress(total > 0 ? loaded / total : 1),
             });
 
             useSceneStore.getState().setSceneLoading(false);
@@ -567,6 +571,30 @@ export function BananaToolbar({
         });
     }, [app, t]);
 
+    const addCarTemplateFromDefinition = useCallback(
+        (def: {
+            bogieOffsets: number[];
+            edgeToBogie?: number;
+            bogieToEdge?: number;
+            image?: {
+                src: string;
+                position: { x: number; y: number };
+                width: number;
+                height: number;
+            };
+        }) => {
+            const template: CarTemplate = {
+                id: generateTemplateId(),
+                bogieOffsets: def.bogieOffsets,
+                edgeToBogie: def.edgeToBogie ?? 2.5,
+                bogieToEdge: def.bogieToEdge ?? 2.5,
+                image: def.image,
+            };
+            setCarTemplates(prev => [...prev, template]);
+        },
+        []
+    );
+
     const handleImportCarDefinition = useCallback(() => {
         if (!app) return;
         trackEvent('import-car-definition');
@@ -576,32 +604,38 @@ export function BananaToolbar({
                 alert(t('invalidCarDefinition', { error: result.error }));
                 return;
             }
-            const def = parsed as {
-                bogieOffsets: number[];
-                edgeToBogie?: number;
-                bogieToEdge?: number;
-                image?: {
-                    src: string;
-                    position: { x: number; y: number };
-                    width: number;
-                    height: number;
-                };
-            };
-            const template: CarTemplate = {
-                id: generateTemplateId(),
-                bogieOffsets: def.bogieOffsets,
-                edgeToBogie: def.edgeToBogie ?? 2.5,
-                bogieToEdge: def.bogieToEdge ?? 2.5,
-                image: def.image,
-            };
-            setCarTemplates(prev => [...prev, template]);
+            addCarTemplateFromDefinition(
+                parsed as Parameters<typeof addCarTemplateFromDefinition>[0]
+            );
         });
+    }, [app, addCarTemplateFromDefinition, t]);
+
+    const handleImportCarDefinitionFromLibrary = useCallback(() => {
+        if (!app) return;
+        trackEvent('import-car-definition');
+        setLibraryDialogOpen(true);
     }, [app]);
+
+    const handleLibraryPick = useCallback(
+        (stored: StoredCarDefinition) => {
+            const result = validateCarDefinition(stored.data);
+            if (!result.valid) {
+                alert(t('invalidCarDefinition', { error: result.error }));
+                return;
+            }
+            addCarTemplateFromDefinition(stored.data);
+        },
+        [addCarTemplateFromDefinition, t]
+    );
 
     const handleSpawnStressTest = useCallback(
         (count: number, startX?: number, startY?: number) => {
             if (!app) return;
-            const placed = app.spawnParallelTracksWithTrains(count, startX, startY);
+            const placed = app.spawnParallelTracksWithTrains(
+                count,
+                startX,
+                startY
+            );
             console.log(
                 `Stress test: spawned ${placed} trains at (${startX ?? 0}, ${startY ?? 0})`
             );
@@ -685,73 +719,90 @@ export function BananaToolbar({
                 </div>
                 <div
                     ref={scrollRef}
-                    className="scrollbar-hide flex max-h-[calc(100dvh-6rem)] flex-col items-center gap-3 overflow-y-auto overflow-x-clip rounded-xl"
+                    className="scrollbar-hide flex max-h-[calc(100dvh-6rem)] flex-col items-center gap-3 overflow-x-clip overflow-y-auto rounded-xl"
                 >
-                {/* Main icon toolbar */}
-                <div className="bg-background/80 flex flex-col items-center gap-1 rounded-xl border p-1.5 shadow-lg backdrop-blur-sm">
-                    <ToolbarButton
-                        tooltip={
-                            isLayoutActive ? t('endLayout') : t('startLayout')
-                        }
-                        active={isLayoutActive}
-                        disabled={mode !== 'idle' && !isLayoutActive}
-                        onClick={handleLayoutToggle}
-                    >
-                        <TrainTrack />
-                    </ToolbarButton>
+                    {/* Main icon toolbar */}
+                    <div className="bg-background/80 flex flex-col items-center gap-1 rounded-xl border p-1.5 shadow-lg backdrop-blur-sm">
+                        <ToolbarButton
+                            tooltip={
+                                isLayoutActive
+                                    ? t('endLayout')
+                                    : t('startLayout')
+                            }
+                            active={isLayoutActive}
+                            disabled={mode !== 'idle' && !isLayoutActive}
+                            onClick={handleLayoutToggle}
+                        >
+                            <TrainTrack />
+                        </ToolbarButton>
 
-                    <Separator />
+                        <Separator />
 
-                    <ToolbarButton
-                        tooltip={
-                            mode === 'train-placement'
-                                ? t('endPlacement')
-                                : t('placeTrain')
-                        }
-                        active={mode === 'train-placement'}
-                        disabled={mode !== 'idle' && mode !== 'train-placement'}
-                        onClick={handleTrainPlacementToggle}
-                    >
-                        <TrainFront />
-                    </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={
+                                mode === 'train-placement'
+                                    ? t('endPlacement')
+                                    : t('placeTrain')
+                            }
+                            active={mode === 'train-placement'}
+                            disabled={
+                                mode !== 'idle' && mode !== 'train-placement'
+                            }
+                            onClick={handleTrainPlacementToggle}
+                        >
+                            <TrainFront />
+                        </ToolbarButton>
 
-                    <ToolbarButton
-                        tooltip={
-                            showTrainPanel
-                                ? t('closeTrainList')
-                                : t('trainList')
-                        }
-                        active={showTrainPanel}
-                        disabled={
-                            placedTrains.length === 0 &&
-                            mode !== 'train-placement'
-                        }
-                        onClick={() => { if (!showTrainPanel) trackEvent('open-train-panel'); togglePanel('trainPanel'); }}
-                    >
-                        <List />
-                    </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={
+                                showTrainPanel
+                                    ? t('closeTrainList')
+                                    : t('trainList')
+                            }
+                            active={showTrainPanel}
+                            disabled={
+                                placedTrains.length === 0 &&
+                                mode !== 'train-placement'
+                            }
+                            onClick={() => {
+                                if (!showTrainPanel)
+                                    trackEvent('open-train-panel');
+                                togglePanel('trainPanel');
+                            }}
+                        >
+                            <List />
+                        </ToolbarButton>
 
-                    <ToolbarButton
-                        tooltip={showDepot ? t('closeDepot') : t('openDepot')}
-                        active={showDepot}
-                        onClick={() => { if (!showDepot) trackEvent('open-depot'); togglePanel('depot'); }}
-                    >
-                        <Warehouse />
-                    </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={
+                                showDepot ? t('closeDepot') : t('openDepot')
+                            }
+                            active={showDepot}
+                            onClick={() => {
+                                if (!showDepot) trackEvent('open-depot');
+                                togglePanel('depot');
+                            }}
+                        >
+                            <Warehouse />
+                        </ToolbarButton>
 
-                    <ToolbarButton
-                        tooltip={
-                            showFormationEditor
-                                ? t('closeFormations')
-                                : t('editFormations')
-                        }
-                        active={showFormationEditor}
-                        onClick={() => { if (!showFormationEditor) trackEvent('open-formation-editor'); togglePanel('formationEditor'); }}
-                    >
-                        <ListOrdered />
-                    </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={
+                                showFormationEditor
+                                    ? t('closeFormations')
+                                    : t('editFormations')
+                            }
+                            active={showFormationEditor}
+                            onClick={() => {
+                                if (!showFormationEditor)
+                                    trackEvent('open-formation-editor');
+                                togglePanel('formationEditor');
+                            }}
+                        >
+                            <ListOrdered />
+                        </ToolbarButton>
 
-                    {/* <ToolbarButton
+                        {/* <ToolbarButton
                         tooltip={
                             mode === 'building-placement'
                                 ? t('endPlacement')
@@ -765,7 +816,7 @@ export function BananaToolbar({
                     >
                         <Building2 />
                     </ToolbarButton> */}
-                    {/* <ToolbarButton
+                        {/* <ToolbarButton
                         tooltip={
                             mode === 'building-deletion'
                                 ? t('endDeletion')
@@ -780,163 +831,200 @@ export function BananaToolbar({
                     >
                         <Trash2 />
                     </ToolbarButton> */}
-                    <ToolbarButton
-                        tooltip={
-                            mode === 'station-placement'
-                                ? t('endStationPlacement')
-                                : t('placeStation')
-                        }
-                        active={mode === 'station-placement'}
-                        disabled={
-                            mode !== 'idle' && mode !== 'station-placement'
-                        }
-                        onClick={handleStationPlacementToggle}
-                    >
-                        <Warehouse />
-                    </ToolbarButton>
-                    <ToolbarButton
-                        tooltip={
-                            mode === 'duplicate-to-side'
-                                ? 'Exit duplicate to side'
-                                : 'Duplicate track to side'
-                        }
-                        active={mode === 'duplicate-to-side'}
-                        disabled={
-                            mode !== 'idle' && mode !== 'duplicate-to-side'
-                        }
-                        onClick={handleDuplicateToSideToggle}
-                    >
-                        <Copy />
-                    </ToolbarButton>
-                    <ToolbarButton
-                        tooltip={
-                            showStationList
-                                ? t('closeStationList')
-                                : t('openStationList')
-                        }
-                        active={showStationList}
-                        onClick={() => { if (!showStationList) trackEvent('open-station-list'); togglePanel('stationList'); }}
-                    >
-                        <Landmark />
-                    </ToolbarButton>
-
-                    <ToolbarButton
-                        tooltip={
-                            showTimetable
-                                ? t('closeTimetable')
-                                : t('openTimetable')
-                        }
-                        active={showTimetable}
-                        onClick={() => togglePanel('timetable')}
-                    >
-                        <Clock />
-                    </ToolbarButton>
-
-                    <ToolbarButton
-                        tooltip={
-                            showSignalPanel
-                                ? t('closeSignals')
-                                : t('openSignals')
-                        }
-                        active={showSignalPanel}
-                        onClick={() => togglePanel('signalPanel')}
-                    >
-                        <Signal />
-                    </ToolbarButton>
-
-                    <Separator />
-
-                    <ToolbarButton
-                        tooltip={
-                            showElevationGradient
-                                ? t('hideElevationGradient')
-                                : t('showElevationGradient')
-                        }
-                        active={showElevationGradient}
-                        onClick={() => rs.getState().setShowElevationGradient(!showElevationGradient)}
-                    >
-                        <Layers />
-                    </ToolbarButton>
-
-                    <ToolbarButton
-                        tooltip={
-                            showPreviewCurveArcs
-                                ? t('hidePreviewCurveArcs')
-                                : t('showPreviewCurveArcs')
-                        }
-                        active={showPreviewCurveArcs}
-                        onClick={() => rs.getState().setShowPreviewCurveArcs(!showPreviewCurveArcs)}
-                    >
-                        <Spline />
-                    </ToolbarButton>
-
-                    <Separator />
-
-                    <ExportSubmenu
-                        show={showExportSubmenu}
-                        onShowChange={(open) => {
-                            setPanel('exportSubmenu', open);
-                            if (open) setPanel('autoSaveMenu', false);
-                        }}
-                        onExportTracks={handleExportTracks}
-                        onImportTracks={handleImportTracks}
-                        onExportTrains={handleExportTrains}
-                        onImportTrains={handleImportTrains}
-                        onExportAll={handleExportAll}
-                        onImportAll={handleImportAll}
-                        onImportTerrain={handleImportTerrain}
-                        onImportCarDefinition={handleImportCarDefinition}
-                    />
-
-                    <ToolbarButton tooltip={t('savedScenes')} onClick={() => showScenePickerAction()}>
-                        <FolderOpen />
-                    </ToolbarButton>
-                    <ToolbarButton tooltip={t('saveScene')} onClick={saveNow}>
-                        <Save />
-                    </ToolbarButton>
-                    <ToolbarButton tooltip={t('newScene')} onClick={() => createNewScene()}>
-                        <FilePlus />
-                    </ToolbarButton>
-                    <AutoSaveIntervalSelector
-                        show={showAutoSaveMenu}
-                        onShowChange={(open) => {
-                            setPanel('autoSaveMenu', open);
-                            if (open) setPanel('exportSubmenu', false);
-                        }}
-                    />
-
-                    <Separator />
-
-                    {onToggleMap && (
                         <ToolbarButton
-                            tooltip={showMap ? t('hideMap') : t('showMap')}
-                            active={showMap}
-                            onClick={onToggleMap}
+                            tooltip={
+                                mode === 'station-placement'
+                                    ? t('endStationPlacement')
+                                    : t('placeStation')
+                            }
+                            active={mode === 'station-placement'}
+                            disabled={
+                                mode !== 'idle' && mode !== 'station-placement'
+                            }
+                            onClick={handleStationPlacementToggle}
                         >
-                            <Map />
+                            <Warehouse />
                         </ToolbarButton>
-                    )}
+                        <ToolbarButton
+                            tooltip={
+                                mode === 'duplicate-to-side'
+                                    ? 'Exit duplicate to side'
+                                    : 'Duplicate track to side'
+                            }
+                            active={mode === 'duplicate-to-side'}
+                            disabled={
+                                mode !== 'idle' && mode !== 'duplicate-to-side'
+                            }
+                            onClick={handleDuplicateToSideToggle}
+                        >
+                            <Copy />
+                        </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={
+                                showStationList
+                                    ? t('closeStationList')
+                                    : t('openStationList')
+                            }
+                            active={showStationList}
+                            onClick={() => {
+                                if (!showStationList)
+                                    trackEvent('open-station-list');
+                                togglePanel('stationList');
+                            }}
+                        >
+                            <Landmark />
+                        </ToolbarButton>
 
-                    <ToolbarButton
-                        tooltip={
-                            showDebugPanel ? t('closeDebug') : t('openDebug')
-                        }
-                        active={showDebugPanel}
-                        onClick={() => { if (!showDebugPanel) trackEvent('open-debug-panel'); togglePanel('debugPanel'); }}
-                    >
-                        <Bug />
-                    </ToolbarButton>
-                </div>
+                        <ToolbarButton
+                            tooltip={
+                                showTimetable
+                                    ? t('closeTimetable')
+                                    : t('openTimetable')
+                            }
+                            active={showTimetable}
+                            onClick={() => togglePanel('timetable')}
+                        >
+                            <Clock />
+                        </ToolbarButton>
 
-                <SunAngleControl value={sunAngle} onChange={rs.getState().setSunAngle} />
-                <TerrainControl
-                    visible={terrainFillVisible}
-                    onVisibleChange={rs.getState().setTerrainFillVisible}
-                    opacity={terrainOpacity}
-                    onOpacityChange={rs.getState().setTerrainOpacity}
-                    whiteOcclusion={whiteOcclusion}
-                    onWhiteOcclusionChange={rs.getState().setWhiteOcclusion}
-                />
+                        <ToolbarButton
+                            tooltip={
+                                showSignalPanel
+                                    ? t('closeSignals')
+                                    : t('openSignals')
+                            }
+                            active={showSignalPanel}
+                            onClick={() => togglePanel('signalPanel')}
+                        >
+                            <Signal />
+                        </ToolbarButton>
+
+                        <Separator />
+
+                        <ToolbarButton
+                            tooltip={
+                                showElevationGradient
+                                    ? t('hideElevationGradient')
+                                    : t('showElevationGradient')
+                            }
+                            active={showElevationGradient}
+                            onClick={() =>
+                                rs
+                                    .getState()
+                                    .setShowElevationGradient(
+                                        !showElevationGradient
+                                    )
+                            }
+                        >
+                            <Layers />
+                        </ToolbarButton>
+
+                        <ToolbarButton
+                            tooltip={
+                                showPreviewCurveArcs
+                                    ? t('hidePreviewCurveArcs')
+                                    : t('showPreviewCurveArcs')
+                            }
+                            active={showPreviewCurveArcs}
+                            onClick={() =>
+                                rs
+                                    .getState()
+                                    .setShowPreviewCurveArcs(
+                                        !showPreviewCurveArcs
+                                    )
+                            }
+                        >
+                            <Spline />
+                        </ToolbarButton>
+
+                        <Separator />
+
+                        <ExportSubmenu
+                            show={showExportSubmenu}
+                            onShowChange={open => {
+                                setPanel('exportSubmenu', open);
+                                if (open) setPanel('autoSaveMenu', false);
+                            }}
+                            onExportTracks={handleExportTracks}
+                            onImportTracks={handleImportTracks}
+                            onExportTrains={handleExportTrains}
+                            onImportTrains={handleImportTrains}
+                            onExportAll={handleExportAll}
+                            onImportAll={handleImportAll}
+                            onImportTerrain={handleImportTerrain}
+                            onImportCarDefinition={handleImportCarDefinition}
+                            onImportCarDefinitionFromLibrary={
+                                handleImportCarDefinitionFromLibrary
+                            }
+                        />
+
+                        <ToolbarButton
+                            tooltip={t('savedScenes')}
+                            onClick={() => showScenePickerAction()}
+                        >
+                            <FolderOpen />
+                        </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={t('saveScene')}
+                            onClick={saveNow}
+                        >
+                            <Save />
+                        </ToolbarButton>
+                        <ToolbarButton
+                            tooltip={t('newScene')}
+                            onClick={() => createNewScene()}
+                        >
+                            <FilePlus />
+                        </ToolbarButton>
+                        <AutoSaveIntervalSelector
+                            show={showAutoSaveMenu}
+                            onShowChange={open => {
+                                setPanel('autoSaveMenu', open);
+                                if (open) setPanel('exportSubmenu', false);
+                            }}
+                        />
+
+                        <Separator />
+
+                        {onToggleMap && (
+                            <ToolbarButton
+                                tooltip={showMap ? t('hideMap') : t('showMap')}
+                                active={showMap}
+                                onClick={onToggleMap}
+                            >
+                                <Map />
+                            </ToolbarButton>
+                        )}
+
+                        <ToolbarButton
+                            tooltip={
+                                showDebugPanel
+                                    ? t('closeDebug')
+                                    : t('openDebug')
+                            }
+                            active={showDebugPanel}
+                            onClick={() => {
+                                if (!showDebugPanel)
+                                    trackEvent('open-debug-panel');
+                                togglePanel('debugPanel');
+                            }}
+                        >
+                            <Bug />
+                        </ToolbarButton>
+                    </div>
+
+                    <SunAngleControl
+                        value={sunAngle}
+                        onChange={rs.getState().setSunAngle}
+                    />
+                    <TerrainControl
+                        visible={terrainFillVisible}
+                        onVisibleChange={rs.getState().setTerrainFillVisible}
+                        opacity={terrainOpacity}
+                        onOpacityChange={rs.getState().setTerrainOpacity}
+                        whiteOcclusion={whiteOcclusion}
+                        onWhiteOcclusionChange={rs.getState().setWhiteOcclusion}
+                    />
                 </div>
                 {/* Bottom scroll arrow – always takes space, invisible when not needed */}
                 <div
@@ -968,7 +1056,9 @@ export function BananaToolbar({
                         electrified={electrified}
                         onElectrifiedChange={rs.getState().setElectrified}
                         projectionBuffer={projectionBuffer}
-                        onProjectionBufferChange={rs.getState().setProjectionBuffer}
+                        onProjectionBufferChange={
+                            rs.getState().setProjectionBuffer
+                        }
                         bed={bed}
                         onBedChange={rs.getState().setBed}
                         bedWidth={bedWidth}
@@ -1034,9 +1124,7 @@ export function BananaToolbar({
             )}
 
             {showTimetable && (
-                <TimetablePanel
-                    onClose={() => setPanel('timetable', false)}
-                />
+                <TimetablePanel onClose={() => setPanel('timetable', false)} />
             )}
 
             {showSignalPanel && (
@@ -1060,9 +1148,13 @@ export function BananaToolbar({
                     showStationStops={showStationStops}
                     onShowStationStopsChange={rs.getState().setShowStationStops}
                     showStationLocations={showStationLocations}
-                    onShowStationLocationsChange={rs.getState().setShowStationLocations}
+                    onShowStationLocationsChange={
+                        rs.getState().setShowStationLocations
+                    }
                     showProximityLines={showProximityLines}
-                    onShowProximityLinesChange={rs.getState().setShowProximityLines}
+                    onShowProximityLinesChange={
+                        rs.getState().setShowProximityLines
+                    }
                     showBogies={showBogies}
                     onShowBogiesChange={rs.getState().setShowBogies}
                     showStats={showStats}
@@ -1095,6 +1187,12 @@ export function BananaToolbar({
                 </span>
                 <ScaleRuler />
             </div>
+
+            <CarDefinitionLibraryDialog
+                open={libraryDialogOpen}
+                onOpenChange={setLibraryDialogOpen}
+                onPick={handleLibraryPick}
+            />
         </TooltipProvider>
     );
 }

--- a/apps/banana/src/components/toolbar/ExportSubmenu.tsx
+++ b/apps/banana/src/components/toolbar/ExportSubmenu.tsx
@@ -32,6 +32,7 @@ type ExportSubmenuProps = {
     onImportAll: () => void;
     onImportTerrain: () => void;
     onImportCarDefinition: () => void;
+    onImportCarDefinitionFromLibrary: () => void;
 };
 
 export function ExportSubmenu({
@@ -45,6 +46,7 @@ export function ExportSubmenu({
     onImportAll,
     onImportTerrain,
     onImportCarDefinition,
+    onImportCarDefinitionFromLibrary,
 }: ExportSubmenuProps) {
     const { t } = useTranslation();
 
@@ -102,6 +104,10 @@ export function ExportSubmenu({
                 <DropdownMenuItem onClick={onImportCarDefinition}>
                     <Gauge />
                     {t('importCarDefinitionFromEditor')}
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={onImportCarDefinitionFromLibrary}>
+                    <Gauge />
+                    {t('importCarDefinitionFromLibrary')}
                 </DropdownMenuItem>
             </DropdownMenuContent>
         </DropdownMenu>

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -52,11 +52,14 @@ const en = {
         importAll: 'Import All (tracks + trains + stations + timetable)',
         importTerrain: 'Import Terrain',
         invalidTerrainData: 'Invalid terrain data: {{error}}',
-        importCarDefinitionFromEditor: 'Import Car Definition (from Train Editor)',
+        importCarDefinitionFromEditor:
+            'Import Car Definition (from Train Editor)',
+        importCarDefinitionFromLibrary: 'Import Car Definition (from Library)',
 
         // Scene Management
         scenePickerTitle: 'Saved Scenes',
-        scenePickerDescription: 'Select a scene to continue, or create a new one.',
+        scenePickerDescription:
+            'Select a scene to continue, or create a new one.',
         newScene: 'New Scene',
         saveScene: 'Save Scene',
         savedScenes: 'Saved Scenes',
@@ -164,6 +167,20 @@ const en = {
         endImageEdit: 'End Image Edit',
         exportCarDefinition: 'Export Car Definition',
         importCarDefinition: 'Import Car Definition',
+        saveToLibrary: 'Save to Library',
+        loadFromLibrary: 'Load from Library',
+        save: 'Save',
+        carDefinitionLibraryTitle: 'Car Definition Library',
+        carDefinitionLibraryDescription: 'Pick a saved car definition to load.',
+        noSavedCarDefinitions: 'No saved car definitions yet.',
+        carDefinitionNamePlaceholder: 'Car name',
+        saveCarDefinitionTitle: 'Save car definition',
+        saveCarDefinitionDescription:
+            'Name this car to save it to the library.',
+        saveCarDefinitionUpdateTitle: 'Update car definition',
+        saveCarDefinitionUpdateDescription:
+            'Update the existing entry or rename it.',
+        untitledCar: 'Untitled car {{count}}',
         needAtLeast2Bogies: 'Need at least 2 bogies to export.',
         failedToParseJson: 'Failed to parse JSON: {{error}}',
         invalidFileMissingBogieOffsets: 'Invalid file: missing bogieOffsets.',
@@ -237,12 +254,13 @@ const en = {
         consolidate: 'Consolidate',
         consolidateTooltip: 'Flatten nested formations into individual cars',
         reverseTooltip: 'Reverse the order of children',
-        reverseNestedTooltip: 'Reverse the order of this formation\'s children',
+        reverseNestedTooltip: "Reverse the order of this formation's children",
         flipChildDirectionTooltip: 'Flip the direction of this child',
         couplable: 'couplable',
         couple: 'Couple',
         coupleWith: 'Couple with Train {{number}}',
-        couplingDepthExceeded: 'Cannot couple: formation nesting too deep. Consolidate one of the formations first.',
+        couplingDepthExceeded:
+            'Cannot couple: formation nesting too deep. Consolidate one of the formations first.',
         proximityLines: 'Coupling proximity',
         renameFormation: 'Click to rename',
         renameCar: 'Click to rename',
@@ -262,10 +280,12 @@ const en = {
         featureTrackDrawing: 'Bézier Track Drawing provides high flexibility',
         featureTerrain: '2D but not flat, subway? checked!',
         featureStations: 'Stations & Buildings (WIP)',
-        featureTrainSim: 'Train Simulation, want to drive the train yourself? Not a problem!',
+        featureTrainSim:
+            'Train Simulation, want to drive the train yourself? Not a problem!',
         featureFormations: 'Flexible Train Formations',
         featureNavigation: 'Smooth Navigation',
-        featureImportExport: 'Import & Export, cloud and browser-side auto-save in development',
+        featureImportExport:
+            'Import & Export, cloud and browser-side auto-save in development',
         featureDynamicFormations: 'Couple and decouple trains dynamically',
         featureGranularity: 'Granular timetable editing (WIP)',
         builtWithFooter:

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -52,11 +52,15 @@ const ja = {
         importAll: 'すべてインポート（線路 + 列車 + 駅）',
         importTerrain: '地形をインポート',
         invalidTerrainData: '無効な地形データ：{{error}}',
-        importCarDefinitionFromEditor: '車両定義をインポート（列車エディターから）',
+        importCarDefinitionFromEditor:
+            '車両定義をインポート（列車エディターから）',
+        importCarDefinitionFromLibrary:
+            '車両定義をインポート（ライブラリから）',
 
         // Scene Management
         scenePickerTitle: '保存済みシーン',
-        scenePickerDescription: 'シーンを選択して続行するか、新しいシーンを作成してください。',
+        scenePickerDescription:
+            'シーンを選択して続行するか、新しいシーンを作成してください。',
         newScene: '新しいシーン',
         saveScene: 'シーンを保存',
         savedScenes: '保存済みシーン',
@@ -162,9 +166,24 @@ const ja = {
         endImageEdit: '画像編集を終了',
         exportCarDefinition: '車両定義をエクスポート',
         importCarDefinition: '車両定義をインポート',
+        saveToLibrary: 'ライブラリに保存',
+        loadFromLibrary: 'ライブラリから読み込み',
+        save: '保存',
+        carDefinitionLibraryTitle: '車両定義ライブラリ',
+        carDefinitionLibraryDescription: '読み込む車両定義を選択してください。',
+        noSavedCarDefinitions: '保存済みの車両定義はありません。',
+        carDefinitionNamePlaceholder: '車両名',
+        saveCarDefinitionTitle: '車両定義を保存',
+        saveCarDefinitionDescription:
+            'ライブラリに保存するための名前を入力してください。',
+        saveCarDefinitionUpdateTitle: '車両定義を更新',
+        saveCarDefinitionUpdateDescription:
+            '既存のエントリを更新するか、名前を変更します。',
+        untitledCar: '名称未設定の車両 {{count}}',
         needAtLeast2Bogies: 'エクスポートには台車が2つ以上必要です。',
         failedToParseJson: 'JSON の解析に失敗：{{error}}',
-        invalidFileMissingBogieOffsets: '無効なファイル：bogieOffsets がありません。',
+        invalidFileMissingBogieOffsets:
+            '無効なファイル：bogieOffsets がありません。',
 
         // Formation Editor
         formations: '編成',
@@ -177,7 +196,8 @@ const ja = {
         couplable: '連結可能',
         couple: '連結',
         coupleWith: '列車{{number}}と連結',
-        couplingDepthExceeded: '連結不可：編成の入れ子が深すぎます。先にどちらかの編成を整理してください。',
+        couplingDepthExceeded:
+            '連結不可：編成の入れ子が深すぎます。先にどちらかの編成を整理してください。',
         proximityLines: '連結近接表示',
         nested: 'ネスト',
         containsNestedFormations: 'ネストされた編成を含む',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -53,6 +53,7 @@ const zhTW = {
         importTerrain: '匯入地形',
         invalidTerrainData: '無效的地形資料：{{error}}',
         importCarDefinitionFromEditor: '匯入車輛定義（從列車編輯器）',
+        importCarDefinitionFromLibrary: '匯入車輛定義（從程式庫）',
 
         // Scene Management
         scenePickerTitle: '已儲存的場景',
@@ -162,6 +163,18 @@ const zhTW = {
         endImageEdit: '結束圖片編輯',
         exportCarDefinition: '匯出車輛定義',
         importCarDefinition: '匯入車輛定義',
+        saveToLibrary: '儲存到程式庫',
+        loadFromLibrary: '從程式庫載入',
+        save: '儲存',
+        carDefinitionLibraryTitle: '車輛定義程式庫',
+        carDefinitionLibraryDescription: '選擇要載入的已儲存車輛定義。',
+        noSavedCarDefinitions: '尚未儲存任何車輛定義。',
+        carDefinitionNamePlaceholder: '車輛名稱',
+        saveCarDefinitionTitle: '儲存車輛定義',
+        saveCarDefinitionDescription: '為此車輛命名以儲存到程式庫。',
+        saveCarDefinitionUpdateTitle: '更新車輛定義',
+        saveCarDefinitionUpdateDescription: '更新現有項目或重新命名。',
+        untitledCar: '未命名車輛 {{count}}',
         needAtLeast2Bogies: '需要至少 2 個轉向架才能匯出。',
         failedToParseJson: '解析 JSON 失敗：{{error}}',
         invalidFileMissingBogieOffsets: '無效的檔案：缺少 bogieOffsets。',
@@ -263,7 +276,8 @@ const zhTW = {
         featureFormations: '靈活的列車編組',
         featureNavigation: '平滑導覽',
         featureImportExport: '匯入與匯出，雲端與瀏覽器端自動儲存開發中',
-        featureDynamicFormations: '直接模擬聯掛與解聯，PP 在苗栗臨時要掛補機？沒問題，不過你確定要嗎？（施工中）',
+        featureDynamicFormations:
+            '直接模擬聯掛與解聯，PP 在苗栗臨時要掛補機？沒問題，不過你確定要嗎？（施工中）',
         featureGranularity: '細粒度的時刻表編排（施工中）',
         builtWithFooter:
             '基於 <ueToo>ue-too</ueToo> 打造 · <issues>回饋</issues>',

--- a/apps/banana/src/storage/car-definition-storage.ts
+++ b/apps/banana/src/storage/car-definition-storage.ts
@@ -1,0 +1,52 @@
+import type { Point } from '@ue-too/math';
+
+/**
+ * Raw car-definition payload — the shape the train editor produces and consumes.
+ * Structurally identical to the JSON that the train editor file-export has always emitted,
+ * so files saved before the library existed remain importable by the main simulator.
+ */
+export type CarDefinitionData = {
+    bogieOffsets: number[];
+    edgeToBogie: number;
+    bogieToEdge: number;
+    bogies: Point[];
+    image?: {
+        src: string;
+        position: Point;
+        width: number;
+        height: number;
+    };
+};
+
+export type CarDefinitionMetadata = {
+    id: string;
+    name: string;
+    createdAt: number;
+    updatedAt: number;
+    version: number;
+};
+
+export type StoredCarDefinition = {
+    metadata: CarDefinitionMetadata;
+    data: CarDefinitionData;
+};
+
+/**
+ * Abstract storage interface for train-editor car definitions.
+ * Backed by IndexedDB locally; can be swapped to remote storage.
+ */
+export interface CarDefinitionStorage {
+    listCarDefinitions(): Promise<CarDefinitionMetadata[]>;
+    loadCarDefinition(id: string): Promise<StoredCarDefinition | null>;
+    saveCarDefinition(def: StoredCarDefinition): Promise<void>;
+    deleteCarDefinition(id: string): Promise<void>;
+}
+
+export const CAR_DEFINITION_DATA_VERSION = 1;
+
+export function generateCarDefinitionId(): string {
+    if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+        return crypto.randomUUID();
+    }
+    return `car-def-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+}

--- a/apps/banana/src/storage/idb-car-definition-storage.ts
+++ b/apps/banana/src/storage/idb-car-definition-storage.ts
@@ -1,0 +1,46 @@
+import type {
+    CarDefinitionMetadata,
+    CarDefinitionStorage,
+    StoredCarDefinition,
+} from './car-definition-storage';
+import { CAR_DEFINITIONS_STORE, openBananaDb, tx } from './idb';
+
+export class IdbCarDefinitionStorage implements CarDefinitionStorage {
+    private getDb(): Promise<IDBDatabase> {
+        return openBananaDb();
+    }
+
+    async listCarDefinitions(): Promise<CarDefinitionMetadata[]> {
+        const db = await this.getDb();
+        const all = await tx<StoredCarDefinition[]>(
+            db,
+            CAR_DEFINITIONS_STORE,
+            'readonly',
+            s => s.getAll()
+        );
+        return all
+            .map(entry => entry.metadata)
+            .sort((a, b) => b.updatedAt - a.updatedAt);
+    }
+
+    async loadCarDefinition(id: string): Promise<StoredCarDefinition | null> {
+        const db = await this.getDb();
+        const result = await tx<StoredCarDefinition | undefined>(
+            db,
+            CAR_DEFINITIONS_STORE,
+            'readonly',
+            s => s.get(id)
+        );
+        return result ?? null;
+    }
+
+    async saveCarDefinition(def: StoredCarDefinition): Promise<void> {
+        const db = await this.getDb();
+        await tx(db, CAR_DEFINITIONS_STORE, 'readwrite', s => s.put(def));
+    }
+
+    async deleteCarDefinition(id: string): Promise<void> {
+        const db = await this.getDb();
+        await tx(db, CAR_DEFINITIONS_STORE, 'readwrite', s => s.delete(id));
+    }
+}

--- a/apps/banana/src/storage/idb-scene-storage.ts
+++ b/apps/banana/src/storage/idb-scene-storage.ts
@@ -1,63 +1,18 @@
+import { META_STORE, SCENES_STORE, openBananaDb, tx } from './idb';
 import type { SceneMetadata, SceneStorage, StoredScene } from './scene-storage';
 
-const DB_NAME = 'banana-scenes';
-const DB_VERSION = 1;
-const SCENES_STORE = 'scenes';
-const META_STORE = 'meta';
-
-function openDb(): Promise<IDBDatabase> {
-    return new Promise((resolve, reject) => {
-        const request = indexedDB.open(DB_NAME, DB_VERSION);
-        request.onupgradeneeded = () => {
-            const db = request.result;
-            if (!db.objectStoreNames.contains(SCENES_STORE)) {
-                db.createObjectStore(SCENES_STORE, {
-                    keyPath: 'metadata.id',
-                });
-            }
-            if (!db.objectStoreNames.contains(META_STORE)) {
-                db.createObjectStore(META_STORE);
-            }
-        };
-        request.onsuccess = () => resolve(request.result);
-        request.onerror = () => reject(request.error);
-    });
-}
-
-function tx<T>(
-    db: IDBDatabase,
-    store: string,
-    mode: IDBTransactionMode,
-    fn: (s: IDBObjectStore) => IDBRequest<T>
-): Promise<T> {
-    return new Promise((resolve, reject) => {
-        const transaction = db.transaction(store, mode);
-        const req = fn(transaction.objectStore(store));
-        req.onsuccess = () => resolve(req.result);
-        req.onerror = () => reject(req.error);
-    });
-}
-
 export class IdbSceneStorage implements SceneStorage {
-    private dbPromise: Promise<IDBDatabase> | null = null;
-
     private getDb(): Promise<IDBDatabase> {
-        if (!this.dbPromise) {
-            this.dbPromise = openDb();
-        }
-        return this.dbPromise;
+        return openBananaDb();
     }
 
     async listScenes(): Promise<SceneMetadata[]> {
         const db = await this.getDb();
-        const all = await tx<StoredScene[]>(
-            db,
-            SCENES_STORE,
-            'readonly',
-            (s) => s.getAll()
+        const all = await tx<StoredScene[]>(db, SCENES_STORE, 'readonly', s =>
+            s.getAll()
         );
         return all
-            .map((scene) => scene.metadata)
+            .map(scene => scene.metadata)
             .sort((a, b) => b.updatedAt - a.updatedAt);
     }
 
@@ -67,19 +22,19 @@ export class IdbSceneStorage implements SceneStorage {
             db,
             SCENES_STORE,
             'readonly',
-            (s) => s.get(id)
+            s => s.get(id)
         );
         return result ?? null;
     }
 
     async saveScene(scene: StoredScene): Promise<void> {
         const db = await this.getDb();
-        await tx(db, SCENES_STORE, 'readwrite', (s) => s.put(scene));
+        await tx(db, SCENES_STORE, 'readwrite', s => s.put(scene));
     }
 
     async deleteScene(id: string): Promise<void> {
         const db = await this.getDb();
-        await tx(db, SCENES_STORE, 'readwrite', (s) => s.delete(id));
+        await tx(db, SCENES_STORE, 'readwrite', s => s.delete(id));
     }
 
     async getActiveSceneId(): Promise<string | null> {
@@ -88,7 +43,7 @@ export class IdbSceneStorage implements SceneStorage {
             db,
             META_STORE,
             'readonly',
-            (s) => s.get('active-scene-id')
+            s => s.get('active-scene-id')
         );
         return result ?? null;
     }
@@ -96,11 +51,11 @@ export class IdbSceneStorage implements SceneStorage {
     async setActiveSceneId(id: string | null): Promise<void> {
         const db = await this.getDb();
         if (id === null) {
-            await tx(db, META_STORE, 'readwrite', (s) =>
+            await tx(db, META_STORE, 'readwrite', s =>
                 s.delete('active-scene-id')
             );
         } else {
-            await tx(db, META_STORE, 'readwrite', (s) =>
+            await tx(db, META_STORE, 'readwrite', s =>
                 s.put(id, 'active-scene-id')
             );
         }
@@ -112,15 +67,13 @@ export class IdbSceneStorage implements SceneStorage {
             db,
             META_STORE,
             'readonly',
-            (s) => s.get(`pref:${key}`)
+            s => s.get(`pref:${key}`)
         );
         return result ?? null;
     }
 
     async setPreference(key: string, value: string): Promise<void> {
         const db = await this.getDb();
-        await tx(db, META_STORE, 'readwrite', (s) =>
-            s.put(value, `pref:${key}`)
-        );
+        await tx(db, META_STORE, 'readwrite', s => s.put(value, `pref:${key}`));
     }
 }

--- a/apps/banana/src/storage/idb.ts
+++ b/apps/banana/src/storage/idb.ts
@@ -1,0 +1,49 @@
+const DB_NAME = 'banana-scenes';
+const DB_VERSION = 2;
+
+export const SCENES_STORE = 'scenes';
+export const META_STORE = 'meta';
+export const CAR_DEFINITIONS_STORE = 'car-definitions';
+
+let dbPromise: Promise<IDBDatabase> | null = null;
+
+export function openBananaDb(): Promise<IDBDatabase> {
+    if (!dbPromise) {
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+            request.onupgradeneeded = () => {
+                const db = request.result;
+                if (!db.objectStoreNames.contains(SCENES_STORE)) {
+                    db.createObjectStore(SCENES_STORE, {
+                        keyPath: 'metadata.id',
+                    });
+                }
+                if (!db.objectStoreNames.contains(META_STORE)) {
+                    db.createObjectStore(META_STORE);
+                }
+                if (!db.objectStoreNames.contains(CAR_DEFINITIONS_STORE)) {
+                    db.createObjectStore(CAR_DEFINITIONS_STORE, {
+                        keyPath: 'metadata.id',
+                    });
+                }
+            };
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = () => reject(request.error);
+        });
+    }
+    return dbPromise;
+}
+
+export function tx<T>(
+    db: IDBDatabase,
+    store: string,
+    mode: IDBTransactionMode,
+    fn: (s: IDBObjectStore) => IDBRequest<T>
+): Promise<T> {
+    return new Promise((resolve, reject) => {
+        const transaction = db.transaction(store, mode);
+        const req = fn(transaction.objectStore(store));
+        req.onsuccess = () => resolve(req.result);
+        req.onerror = () => reject(req.error);
+    });
+}

--- a/apps/banana/src/storage/index.ts
+++ b/apps/banana/src/storage/index.ts
@@ -1,15 +1,37 @@
+import type { CarDefinitionStorage } from './car-definition-storage';
+import { IdbCarDefinitionStorage } from './idb-car-definition-storage';
 import { IdbSceneStorage } from './idb-scene-storage';
 import type { SceneStorage } from './scene-storage';
 
 export type { SceneMetadata, SceneStorage, StoredScene } from './scene-storage';
 export { SCENE_DATA_VERSION } from './scene-storage';
 
-let instance: SceneStorage | null = null;
+export type {
+    CarDefinitionData,
+    CarDefinitionMetadata,
+    CarDefinitionStorage,
+    StoredCarDefinition,
+} from './car-definition-storage';
+export {
+    CAR_DEFINITION_DATA_VERSION,
+    generateCarDefinitionId,
+} from './car-definition-storage';
+
+let sceneInstance: SceneStorage | null = null;
+let carDefinitionInstance: CarDefinitionStorage | null = null;
 
 /** Get the singleton scene storage instance. */
 export function getSceneStorage(): SceneStorage {
-    if (!instance) {
-        instance = new IdbSceneStorage();
+    if (!sceneInstance) {
+        sceneInstance = new IdbSceneStorage();
     }
-    return instance;
+    return sceneInstance;
+}
+
+/** Get the singleton car-definition storage instance. */
+export function getCarDefinitionStorage(): CarDefinitionStorage {
+    if (!carDefinitionInstance) {
+        carDefinitionInstance = new IdbCarDefinitionStorage();
+    }
+    return carDefinitionInstance;
 }

--- a/apps/banana/src/train-editor/train-editor-toolbar.tsx
+++ b/apps/banana/src/train-editor/train-editor-toolbar.tsx
@@ -1,16 +1,19 @@
+import type { ReactNode } from 'react';
+import { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+
 import {
     Download,
+    FolderOpen,
     GripHorizontal,
     Image,
     MousePointer2,
     Plus,
+    Save,
     Upload,
 } from '@/assets/icons';
-import type { ReactNode } from 'react';
-import { useCallback, useState } from 'react';
-import { useTranslation } from 'react-i18next';
-import type { Point } from '@ue-too/math';
-
+import { CarDefinitionLibraryDialog } from '@/components/car-definition-library/CarDefinitionLibraryDialog';
+import { SaveCarDefinitionDialog } from '@/components/car-definition-library/SaveCarDefinitionDialog';
 import { Button } from '@/components/ui/button';
 import { Separator } from '@/components/ui/separator';
 import {
@@ -20,6 +23,14 @@ import {
     TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
+import {
+    CAR_DEFINITION_DATA_VERSION,
+    type CarDefinitionData,
+    type StoredCarDefinition,
+    generateCarDefinitionId,
+    getCarDefinitionStorage,
+} from '@/storage';
+
 import { useTrainEditorApp } from './use-train-editor-app';
 
 type TrainEditorMode = 'idle' | 'edit-bogie' | 'add-bogie' | 'edit-image';
@@ -56,23 +67,10 @@ function ToolbarButton({
     );
 }
 
-/**
- * Exported train editor state: car bogie definition + optional reference image.
- */
-type TrainEditorExport = {
-    bogieOffsets: number[];
-    edgeToBogie: number;
-    bogieToEdge: number;
-    bogies: Point[];
-    image?: {
-        src: string;
-        position: Point;
-        width: number;
-        height: number;
-    };
-};
-
-function uploadJson(onJson: (parsed: unknown) => void, onError?: (error: string) => void): void {
+function uploadJson(
+    onJson: (parsed: unknown) => void,
+    onError?: (error: string) => void
+): void {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = '.json,application/json';
@@ -95,7 +93,9 @@ function uploadJson(onJson: (parsed: unknown) => void, onError?: (error: string)
     input.click();
 }
 
-function uploadImage(onLoad: (src: string, width: number, height: number) => void): void {
+function uploadImage(
+    onLoad: (src: string, width: number, height: number) => void
+): void {
     const input = document.createElement('input');
     input.type = 'file';
     input.accept = 'image/*';
@@ -123,6 +123,13 @@ export function TrainEditorToolbar() {
     const { t } = useTranslation();
     const app = useTrainEditorApp();
     const [mode, setMode] = useState<TrainEditorMode>('idle');
+    const [loadedLibraryEntry, setLoadedLibraryEntry] = useState<{
+        id: string;
+        name: string;
+    } | null>(null);
+    const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+    const [libraryDialogOpen, setLibraryDialogOpen] = useState(false);
+    const [pendingInitialName, setPendingInitialName] = useState('');
 
     const exitAllModes = useCallback(() => {
         if (!app) return;
@@ -180,19 +187,59 @@ export function TrainEditorToolbar() {
         });
     }, [app, exitAllModes]);
 
-    const handleExport = useCallback(() => {
-        if (!app) return;
+    const buildCarDefinitionData = useCallback((): CarDefinitionData | null => {
+        if (!app) return null;
         const def = app.bogieEditorEngine.exportCarDefinition();
-        if (!def) {
-            alert(t('needAtLeast2Bogies'));
-            return;
-        }
+        if (!def) return null;
         const image = app.imageEditorEngine.getImage();
-        const exportData: TrainEditorExport = {
+        return {
             ...def,
             bogies: [...app.bogieEditorEngine.getBogies()],
             image: image ? { ...image } : undefined,
         };
+    }, [app]);
+
+    const hydrateFromCarDefinition = useCallback(
+        (data: Partial<CarDefinitionData>): boolean => {
+            if (!app) return false;
+            if (!data.bogieOffsets || !Array.isArray(data.bogieOffsets)) {
+                alert(t('invalidFileMissingBogieOffsets'));
+                return false;
+            }
+            const currentBogies = app.bogieEditorEngine.getBogies();
+            for (let i = currentBogies.length - 1; i >= 0; i--) {
+                app.bogieEditorEngine.removeBogie(i);
+            }
+            if (data.bogies && Array.isArray(data.bogies)) {
+                for (const bogie of data.bogies) {
+                    app.bogieEditorEngine.addBogie(bogie);
+                }
+            }
+            if (data.image) {
+                app.imageEditorEngine.setImage(
+                    data.image.src,
+                    data.image.width,
+                    data.image.height
+                );
+                const img = app.imageEditorEngine.getImage();
+                if (img) {
+                    img.position = { ...data.image.position };
+                    img.width = data.image.width;
+                    img.height = data.image.height;
+                }
+                app.imageEditorEngine.notifyChange();
+            }
+            return true;
+        },
+        [app, t]
+    );
+
+    const handleExport = useCallback(() => {
+        const exportData = buildCarDefinitionData();
+        if (!exportData) {
+            alert(t('needAtLeast2Bogies'));
+            return;
+        }
         const json = JSON.stringify(exportData, null, 2);
         const blob = new Blob([json], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
@@ -203,42 +250,83 @@ export function TrainEditorToolbar() {
         link.click();
         document.body.removeChild(link);
         URL.revokeObjectURL(url);
-    }, [app]);
+    }, [buildCarDefinitionData, t]);
 
     const handleImport = useCallback(() => {
         if (!app) return;
-        uploadJson(parsed => {
-            const data = parsed as Partial<TrainEditorExport>;
-            if (!data.bogieOffsets || !Array.isArray(data.bogieOffsets)) {
-                alert(t('invalidFileMissingBogieOffsets'));
+        uploadJson(
+            parsed => {
+                const data = parsed as Partial<CarDefinitionData>;
+                if (hydrateFromCarDefinition(data)) {
+                    // File-imported entries are not tracked as a library slot.
+                    setLoadedLibraryEntry(null);
+                }
+            },
+            error => alert(t('failedToParseJson', { error }))
+        );
+    }, [app, hydrateFromCarDefinition, t]);
+
+    const handleOpenSaveDialog = useCallback(async () => {
+        if (!app) return;
+        const def = app.bogieEditorEngine.exportCarDefinition();
+        if (!def) {
+            alert(t('needAtLeast2Bogies'));
+            return;
+        }
+        if (loadedLibraryEntry) {
+            setPendingInitialName(loadedLibraryEntry.name);
+        } else {
+            const existing =
+                await getCarDefinitionStorage().listCarDefinitions();
+            setPendingInitialName(
+                t('untitledCar', { count: existing.length + 1 })
+            );
+        }
+        setSaveDialogOpen(true);
+    }, [app, loadedLibraryEntry, t]);
+
+    const handleConfirmSave = useCallback(
+        async (name: string) => {
+            const data = buildCarDefinitionData();
+            if (!data) {
+                alert(t('needAtLeast2Bogies'));
                 return;
             }
-            // Clear existing bogies
-            const currentBogies = app.bogieEditorEngine.getBogies();
-            for (let i = currentBogies.length - 1; i >= 0; i--) {
-                app.bogieEditorEngine.removeBogie(i);
+            const now = Date.now();
+            const id = loadedLibraryEntry?.id ?? generateCarDefinitionId();
+            const existing = loadedLibraryEntry
+                ? await getCarDefinitionStorage().loadCarDefinition(
+                      loadedLibraryEntry.id
+                  )
+                : null;
+            const createdAt = existing?.metadata.createdAt ?? now;
+            const stored: StoredCarDefinition = {
+                metadata: {
+                    id,
+                    name,
+                    createdAt,
+                    updatedAt: now,
+                    version: CAR_DEFINITION_DATA_VERSION,
+                },
+                data,
+            };
+            await getCarDefinitionStorage().saveCarDefinition(stored);
+            setLoadedLibraryEntry({ id, name });
+        },
+        [buildCarDefinitionData, loadedLibraryEntry, t]
+    );
+
+    const handleLoadFromLibrary = useCallback(
+        (stored: StoredCarDefinition) => {
+            if (hydrateFromCarDefinition(stored.data)) {
+                setLoadedLibraryEntry({
+                    id: stored.metadata.id,
+                    name: stored.metadata.name,
+                });
             }
-            // Restore bogies from saved positions
-            if (data.bogies && Array.isArray(data.bogies)) {
-                for (const bogie of data.bogies) {
-                    app.bogieEditorEngine.addBogie(bogie);
-                }
-            }
-            // Restore image
-            if (data.image) {
-                app.imageEditorEngine.setImage(data.image.src, data.image.width, data.image.height);
-                // Restore position (setImage resets to origin)
-                const img = app.imageEditorEngine.getImage();
-                if (img) {
-                    img.position = { ...data.image.position };
-                    img.width = data.image.width;
-                    img.height = data.image.height;
-                }
-                // Notify render system of the restored position
-                app.imageEditorEngine.notifyChange();
-            }
-        }, (error) => alert(t('failedToParseJson', { error })));
-    }, [app, t]);
+        },
+        [hydrateFromCarDefinition]
+    );
 
     if (!app) return null;
 
@@ -255,7 +343,11 @@ export function TrainEditorToolbar() {
                 <div className="bg-background/80 flex flex-col items-center gap-1 rounded-xl border p-1.5 shadow-lg backdrop-blur-sm">
                     {/* Edit bogies */}
                     <ToolbarButton
-                        tooltip={mode === 'edit-bogie' ? t('endEdit') : t('editBogies')}
+                        tooltip={
+                            mode === 'edit-bogie'
+                                ? t('endEdit')
+                                : t('editBogies')
+                        }
                         active={mode === 'edit-bogie'}
                         onClick={handleEditBogieToggle}
                     >
@@ -264,7 +356,9 @@ export function TrainEditorToolbar() {
 
                     {/* Add bogie */}
                     <ToolbarButton
-                        tooltip={mode === 'add-bogie' ? t('endAdd') : t('addBogie')}
+                        tooltip={
+                            mode === 'add-bogie' ? t('endAdd') : t('addBogie')
+                        }
                         active={mode === 'add-bogie'}
                         onClick={handleAddBogieToggle}
                     >
@@ -283,7 +377,11 @@ export function TrainEditorToolbar() {
 
                     {/* Edit image */}
                     <ToolbarButton
-                        tooltip={mode === 'edit-image' ? t('endImageEdit') : t('editImage')}
+                        tooltip={
+                            mode === 'edit-image'
+                                ? t('endImageEdit')
+                                : t('editImage')
+                        }
                         active={mode === 'edit-image'}
                         disabled={!hasImage && mode !== 'edit-image'}
                         onClick={handleEditImageToggle}
@@ -309,8 +407,41 @@ export function TrainEditorToolbar() {
                     >
                         <Upload />
                     </ToolbarButton>
+
+                    <Separator />
+
+                    {/* Save to library */}
+                    <ToolbarButton
+                        tooltip={t('saveToLibrary')}
+                        disabled={!hasBogies}
+                        onClick={handleOpenSaveDialog}
+                    >
+                        <Save />
+                    </ToolbarButton>
+
+                    {/* Load from library */}
+                    <ToolbarButton
+                        tooltip={t('loadFromLibrary')}
+                        onClick={() => setLibraryDialogOpen(true)}
+                    >
+                        <FolderOpen />
+                    </ToolbarButton>
                 </div>
             </div>
+
+            <SaveCarDefinitionDialog
+                open={saveDialogOpen}
+                onOpenChange={setSaveDialogOpen}
+                initialName={pendingInitialName}
+                updatingExisting={loadedLibraryEntry !== null}
+                onConfirm={handleConfirmSave}
+            />
+            <CarDefinitionLibraryDialog
+                open={libraryDialogOpen}
+                onOpenChange={setLibraryDialogOpen}
+                onPick={handleLoadFromLibrary}
+                highlightedId={loadedLibraryEntry?.id ?? null}
+            />
         </TooltipProvider>
     );
 }


### PR DESCRIPTION
## Summary
- Adds an in-browser car definition library alongside the existing file export/import: save by name, reload to keep editing (update-in-place), and import into the main simulator's depot without touching the filesystem.
- Mirrors the existing `SceneStorage` pattern — new `CarDefinitionStorage` interface + `IdbCarDefinitionStorage` impl sharing a single DB opener, so a future remote backend can drop in.
- Bumps the `banana-scenes` IndexedDB version to 2 to add a `car-definitions` object store; existing scenes survive the migration.

## Test plan
- [ ] Train editor: create bogies → Save to library with a name → refresh → Load from library → bogies/image restored
- [ ] Train editor: with an entry loaded, move a bogie → Save → library list still shows one entry with updated timestamp (update-in-place)
- [ ] Save a second entry → open Load dialog → delete the first → second survives
- [ ] Main simulator: Export submenu → Import Car Definition (from Library) → pick entry → template appears in depot → place a train with that formation
- [ ] Close the tab, reopen → both entries persist
- [ ] Pre-existing v1 `banana-scenes` DB upgrades to v2 without losing scenes

🤖 Generated with [Claude Code](https://claude.com/claude-code)