### PR TITLE
feat(banana): group toolbar into category rail + flyout panel

### DIFF
--- a/apps/banana/src/App.tsx
+++ b/apps/banana/src/App.tsx
@@ -1,8 +1,8 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
     ScrollBarDisplay,
     Wrapper,
 } from '@ue-too/board-pixi-react-integration';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import { SceneLoadingOverlay } from '@/components/SceneLoadingOverlay';
@@ -15,7 +15,7 @@ import {
     deserializeSceneData,
     validateSerializedSceneData,
 } from '@/scene-serialization';
-import { getSceneStorage, SCENE_DATA_VERSION } from '@/storage';
+import { SCENE_DATA_VERSION, getSceneStorage } from '@/storage';
 import { useSceneStore } from '@/stores/scene-store';
 import { initApp } from '@/utils/init-app';
 
@@ -26,9 +26,9 @@ import './App.css';
  */
 function InAppScenePicker() {
     const app = useBananaApp();
-    const setActiveScene = useSceneStore((s) => s.setActiveScene);
-    const hideScenePicker = useSceneStore((s) => s.hideScenePicker);
-    const createNewScene = useSceneStore((s) => s.createNewScene);
+    const setActiveScene = useSceneStore(s => s.setActiveScene);
+    const hideScenePicker = useSceneStore(s => s.hideScenePicker);
+    const createNewScene = useSceneStore(s => s.createNewScene);
 
     const handleSceneSelected = useCallback(
         async (sceneId: string | null) => {
@@ -62,12 +62,12 @@ function InAppScenePicker() {
 }
 
 function SceneGate() {
-    const initialized = useSceneStore((s) => s.initialized);
-    const scenePickerOpen = useSceneStore((s) => s.scenePickerOpen);
-    const setActiveScene = useSceneStore((s) => s.setActiveScene);
-    const setPendingSceneId = useSceneStore((s) => s.setPendingSceneId);
-    const pendingSceneId = useSceneStore((s) => s.pendingSceneId);
-    const initialize = useSceneStore((s) => s.initialize);
+    const initialized = useSceneStore(s => s.initialized);
+    const scenePickerOpen = useSceneStore(s => s.scenePickerOpen);
+    const setActiveScene = useSceneStore(s => s.setActiveScene);
+    const setPendingSceneId = useSceneStore(s => s.setPendingSceneId);
+    const pendingSceneId = useSceneStore(s => s.pendingSceneId);
+    const initialize = useSceneStore(s => s.initialize);
     const mountedRef = useRef(false);
     const [readyToMount, setReadyToMount] = useState(false);
 
@@ -163,9 +163,7 @@ function SceneGate() {
     // Show picker before PIXI mount
     if (scenePickerOpen && !readyToMount) {
         return (
-            <ScenePickerDialog
-                onSceneSelected={handleInitialSceneSelected}
-            />
+            <ScenePickerDialog onSceneSelected={handleInitialSceneSelected} />
         );
     }
 
@@ -174,10 +172,7 @@ function SceneGate() {
     }
 
     return (
-        <Wrapper
-            option={wrapperOption}
-            initFunction={initApp}
-        >
+        <Wrapper option={wrapperOption} initFunction={initApp}>
             {pendingSceneId && <SceneRestorer />}
             <SceneLoadingOverlay />
             <ScrollBarDisplay />

--- a/apps/banana/src/assets/icons/lucide.ts
+++ b/apps/banana/src/assets/icons/lucide.ts
@@ -44,6 +44,7 @@ export {
     Map,
     MapPin,
     Merge,
+    Moon,
     Mountain,
     MousePointer2,
     OctagonXIcon,

--- a/apps/banana/src/components/toolbar/AutoSaveIntervalSelector.tsx
+++ b/apps/banana/src/components/toolbar/AutoSaveIntervalSelector.tsx
@@ -1,6 +1,7 @@
+import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Check, Timer } from '@/assets/icons';
 
+import { Check, Timer } from '@/assets/icons';
 import { Button } from '@/components/ui/button';
 import {
     DropdownMenu,
@@ -8,8 +9,8 @@ import {
     DropdownMenuItem,
     DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useSceneStore } from '@/stores/scene-store';
 import { cn } from '@/lib/utils';
+import { useSceneStore } from '@/stores/scene-store';
 
 const INTERVAL_OPTIONS = [
     { labelKey: 'autoSave1Min', value: 60_000 },
@@ -21,31 +22,34 @@ const INTERVAL_OPTIONS = [
 type AutoSaveIntervalSelectorProps = {
     show: boolean;
     onShowChange: (show: boolean) => void;
+    /** Custom trigger element — overrides the default icon button. */
+    trigger?: ReactElement;
 };
 
 export function AutoSaveIntervalSelector({
     show,
     onShowChange,
+    trigger,
 }: AutoSaveIntervalSelectorProps) {
     const { t } = useTranslation();
-    const autoSaveIntervalMs = useSceneStore((s) => s.autoSaveIntervalMs);
-    const setAutoSaveIntervalMs = useSceneStore(
-        (s) => s.setAutoSaveIntervalMs
-    );
+    const autoSaveIntervalMs = useSceneStore(s => s.autoSaveIntervalMs);
+    const setAutoSaveIntervalMs = useSceneStore(s => s.setAutoSaveIntervalMs);
 
     return (
         <DropdownMenu open={show} onOpenChange={onShowChange}>
             <DropdownMenuTrigger asChild>
-                <Button
-                    variant="ghost"
-                    size="icon-lg"
-                    className={cn(
-                        "[&_svg:not([class*='size-'])]:size-5",
-                        show && 'bg-accent'
-                    )}
-                >
-                    <Timer />
-                </Button>
+                {trigger ?? (
+                    <Button
+                        variant="ghost"
+                        size="icon-lg"
+                        className={cn(
+                            "[&_svg:not([class*='size-'])]:size-5",
+                            show && 'bg-accent'
+                        )}
+                    >
+                        <Timer />
+                    </Button>
+                )}
             </DropdownMenuTrigger>
             <DropdownMenuContent
                 side="right"
@@ -53,7 +57,7 @@ export function AutoSaveIntervalSelector({
                 sideOffset={12}
                 className="bg-background/80 backdrop-blur-sm"
             >
-                {INTERVAL_OPTIONS.map((opt) => (
+                {INTERVAL_OPTIONS.map(opt => (
                     <DropdownMenuItem
                         key={opt.value}
                         onClick={() => setAutoSaveIntervalMs(opt.value)}
@@ -61,8 +65,7 @@ export function AutoSaveIntervalSelector({
                         <Check
                             className={cn(
                                 'size-4',
-                                autoSaveIntervalMs !== opt.value &&
-                                    'invisible'
+                                autoSaveIntervalMs !== opt.value && 'invisible'
                             )}
                         />
                         {t(opt.labelKey)}

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -9,11 +9,11 @@ import { useShallow } from 'zustand/react/shallow';
 
 import {
     Bug,
-    Building2,
     ChevronDown,
     ChevronUp,
     Clock,
     Copy,
+    Download,
     FilePlus,
     FolderOpen,
     Landmark,
@@ -24,15 +24,17 @@ import {
     Save,
     Signal,
     Spline,
+    Timer,
     TrainFront,
     TrainTrack,
-    Trash2,
     Warehouse,
+    X,
 } from '@/assets/icons';
 import type { BuildingPreset } from '@/buildings/types';
 import { CarDefinitionLibraryDialog } from '@/components/car-definition-library/CarDefinitionLibraryDialog';
 import { FormationEditor } from '@/components/formation-editor';
-import { Separator } from '@/components/ui/separator';
+import { Button } from '@/components/ui/button';
+import { ThemeToggle } from '@/components/ui/theme-toggle';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { useBananaApp } from '@/contexts/pixi';
 import { useAutoSave } from '@/hooks/use-auto-save';
@@ -49,7 +51,10 @@ import type { SerializedStationData } from '@/stations/types';
 import type { StoredCarDefinition } from '@/storage';
 import { useRenderSettingsStore } from '@/stores/render-settings-store';
 import { useSceneStore } from '@/stores/scene-store';
-import { useToolbarUIStore } from '@/stores/toolbar-ui-store';
+import {
+    type ToolbarCategory,
+    useToolbarUIStore,
+} from '@/stores/toolbar-ui-store';
 import {
     TerrainData,
     validateSerializedTerrainData,
@@ -74,6 +79,8 @@ import { trackEvent } from '@/utils/analytics';
 
 import { AutoSaveIntervalSelector } from './AutoSaveIntervalSelector';
 import { BuildingOptionsPanel } from './BuildingOptionsPanel';
+import { CategoryFlyout, type FlyoutCategory } from './CategoryFlyout';
+import { CategoryRail } from './CategoryRail';
 import { DebugPanel } from './DebugPanel';
 import { DepotPanel } from './DepotPanel';
 import { ExportSubmenu } from './ExportSubmenu';
@@ -87,7 +94,6 @@ import { SunAngleControl } from './SunAngleControl';
 import { TerrainControl } from './TerrainControl';
 import { TerrainLegend } from './TerrainLegend';
 import { TimetablePanel } from './TimetablePanel';
-import { ToolbarButton } from './ToolbarButton';
 import { TrackStyleSelector } from './TrackStyleSelector';
 import { TrainPanel } from './TrainPanel';
 import { TOOLBAR_LEFT } from './types';
@@ -136,6 +142,9 @@ export function BananaToolbar({
     );
     const setPanel = useToolbarUIStore(s => s.setPanel);
     const togglePanel = useToolbarUIStore(s => s.togglePanel);
+    const activeCategory = useToolbarUIStore(s => s.activeCategory);
+    const toggleCategory = useToolbarUIStore(s => s.toggleCategory);
+    const setActiveCategory = useToolbarUIStore(s => s.setActiveCategory);
 
     // Render settings store
     const {
@@ -208,6 +217,9 @@ export function BananaToolbar({
     buildingElevationRef.current = buildingElevation;
     const buildingHeightRef = useRef(buildingHeight);
     buildingHeightRef.current = buildingHeight;
+
+    // Shell ref used by CategoryFlyout to detect outside clicks
+    const shellRef = useRef<HTMLDivElement>(null);
 
     // Scroll overflow indicators
     const scrollRef = useRef<HTMLDivElement>(null);
@@ -700,245 +712,198 @@ export function BananaToolbar({
     const placedTrains = trainManager.getPlacedTrains();
     const isLayoutActive = mode === 'layout' || mode === 'layout-deletion';
 
-    return (
-        <TooltipProvider delayDuration={200}>
-            <div
-                className={cn(
-                    'pointer-events-auto absolute top-1/2 -translate-y-1/2 flex-col items-center gap-2',
-                    TOOLBAR_LEFT
-                )}
-            >
-                {/* Top scroll arrow – always takes space, invisible when not needed */}
-                <div
-                    className={cn(
-                        'bg-background/80 mb-2 flex justify-center rounded-full border px-2 py-0.5 shadow-sm backdrop-blur-sm',
-                        canScrollUp ? 'text-foreground' : 'invisible'
-                    )}
-                >
-                    <ChevronUp className="h-4 w-4" />
-                </div>
-                <div
-                    ref={scrollRef}
-                    className="scrollbar-hide flex max-h-[calc(100dvh-6rem)] flex-col items-center gap-3 overflow-x-clip overflow-y-auto rounded-xl"
-                >
-                    {/* Main icon toolbar */}
-                    <div className="bg-background/80 flex flex-col items-center gap-1 rounded-xl border p-1.5 shadow-lg backdrop-blur-sm">
-                        <ToolbarButton
-                            tooltip={
-                                isLayoutActive
-                                    ? t('endLayout')
-                                    : t('startLayout')
-                            }
-                            active={isLayoutActive}
-                            disabled={mode !== 'idle' && !isLayoutActive}
-                            onClick={handleLayoutToggle}
-                        >
-                            <TrainTrack />
-                        </ToolbarButton>
+    const modeHolderCategory: ToolbarCategory | null =
+        mode === 'layout' ||
+        mode === 'layout-deletion' ||
+        mode === 'station-placement' ||
+        mode === 'duplicate-to-side'
+            ? 'drawing'
+            : mode === 'train-placement'
+              ? 'trains'
+              : null;
 
-                        <Separator />
+    const modeLabelKey: string | null =
+        mode === 'layout'
+            ? 'modeDrawingLayout'
+            : mode === 'layout-deletion'
+              ? 'modeDeletingTrack'
+              : mode === 'train-placement'
+                ? 'modePlacingTrain'
+                : mode === 'station-placement'
+                  ? 'modePlacingStation'
+                  : mode === 'duplicate-to-side'
+                    ? 'modeDuplicatingTrack'
+                    : mode === 'building-placement'
+                      ? 'modePlacingBuilding'
+                      : mode === 'building-deletion'
+                        ? 'modeDeletingBuilding'
+                        : null;
 
-                        <ToolbarButton
-                            tooltip={
-                                mode === 'train-placement'
-                                    ? t('endPlacement')
-                                    : t('placeTrain')
-                            }
-                            active={mode === 'train-placement'}
-                            disabled={
-                                mode !== 'idle' && mode !== 'train-placement'
-                            }
-                            onClick={handleTrainPlacementToggle}
-                        >
-                            <TrainFront />
-                        </ToolbarButton>
-
-                        <ToolbarButton
-                            tooltip={
-                                showTrainPanel
-                                    ? t('closeTrainList')
-                                    : t('trainList')
-                            }
-                            active={showTrainPanel}
-                            disabled={
-                                placedTrains.length === 0 &&
-                                mode !== 'train-placement'
-                            }
-                            onClick={() => {
-                                if (!showTrainPanel)
-                                    trackEvent('open-train-panel');
-                                togglePanel('trainPanel');
-                            }}
-                        >
-                            <List />
-                        </ToolbarButton>
-
-                        <ToolbarButton
-                            tooltip={
-                                showDepot ? t('closeDepot') : t('openDepot')
-                            }
-                            active={showDepot}
-                            onClick={() => {
-                                if (!showDepot) trackEvent('open-depot');
-                                togglePanel('depot');
-                            }}
-                        >
-                            <Warehouse />
-                        </ToolbarButton>
-
-                        <ToolbarButton
-                            tooltip={
-                                showFormationEditor
-                                    ? t('closeFormations')
-                                    : t('editFormations')
-                            }
-                            active={showFormationEditor}
-                            onClick={() => {
-                                if (!showFormationEditor)
-                                    trackEvent('open-formation-editor');
-                                togglePanel('formationEditor');
-                            }}
-                        >
-                            <ListOrdered />
-                        </ToolbarButton>
-
-                        {/* <ToolbarButton
-                        tooltip={
-                            mode === 'building-placement'
-                                ? t('endPlacement')
-                                : t('placeBuilding')
-                        }
-                        active={mode === 'building-placement'}
-                        disabled={
-                            mode !== 'idle' && mode !== 'building-placement'
-                        }
-                        onClick={handleBuildingPlacementToggle}
-                    >
-                        <Building2 />
-                    </ToolbarButton> */}
-                        {/* <ToolbarButton
-                        tooltip={
-                            mode === 'building-deletion'
-                                ? t('endDeletion')
-                                : t('deleteBuilding')
-                        }
-                        active={mode === 'building-deletion'}
-                        destructive={mode === 'building-deletion'}
-                        disabled={
-                            mode !== 'idle' && mode !== 'building-deletion'
-                        }
-                        onClick={handleBuildingDeletionToggle}
-                    >
-                        <Trash2 />
-                    </ToolbarButton> */}
-                        <ToolbarButton
-                            tooltip={
-                                mode === 'station-placement'
-                                    ? t('endStationPlacement')
-                                    : t('placeStation')
-                            }
-                            active={mode === 'station-placement'}
-                            disabled={
-                                mode !== 'idle' && mode !== 'station-placement'
-                            }
-                            onClick={handleStationPlacementToggle}
-                        >
-                            <Warehouse />
-                        </ToolbarButton>
-                        <ToolbarButton
-                            tooltip={
-                                mode === 'duplicate-to-side'
-                                    ? 'Exit duplicate to side'
-                                    : 'Duplicate track to side'
-                            }
-                            active={mode === 'duplicate-to-side'}
-                            disabled={
-                                mode !== 'idle' && mode !== 'duplicate-to-side'
-                            }
-                            onClick={handleDuplicateToSideToggle}
-                        >
-                            <Copy />
-                        </ToolbarButton>
-                        <ToolbarButton
-                            tooltip={
-                                showStationList
-                                    ? t('closeStationList')
-                                    : t('openStationList')
-                            }
-                            active={showStationList}
-                            onClick={() => {
-                                if (!showStationList)
-                                    trackEvent('open-station-list');
-                                togglePanel('stationList');
-                            }}
-                        >
-                            <Landmark />
-                        </ToolbarButton>
-
-                        <ToolbarButton
-                            tooltip={
-                                showTimetable
-                                    ? t('closeTimetable')
-                                    : t('openTimetable')
-                            }
-                            active={showTimetable}
-                            onClick={() => togglePanel('timetable')}
-                        >
-                            <Clock />
-                        </ToolbarButton>
-
-                        <ToolbarButton
-                            tooltip={
-                                showSignalPanel
-                                    ? t('closeSignals')
-                                    : t('openSignals')
-                            }
-                            active={showSignalPanel}
-                            onClick={() => togglePanel('signalPanel')}
-                        >
-                            <Signal />
-                        </ToolbarButton>
-
-                        <Separator />
-
-                        <ToolbarButton
-                            tooltip={
-                                showElevationGradient
-                                    ? t('hideElevationGradient')
-                                    : t('showElevationGradient')
-                            }
-                            active={showElevationGradient}
-                            onClick={() =>
-                                rs
-                                    .getState()
-                                    .setShowElevationGradient(
-                                        !showElevationGradient
-                                    )
-                            }
-                        >
-                            <Layers />
-                        </ToolbarButton>
-
-                        <ToolbarButton
-                            tooltip={
-                                showPreviewCurveArcs
-                                    ? t('hidePreviewCurveArcs')
-                                    : t('showPreviewCurveArcs')
-                            }
-                            active={showPreviewCurveArcs}
-                            onClick={() =>
-                                rs
-                                    .getState()
-                                    .setShowPreviewCurveArcs(
-                                        !showPreviewCurveArcs
-                                    )
-                            }
-                        >
-                            <Spline />
-                        </ToolbarButton>
-
-                        <Separator />
-
+    const flyoutCategories: Record<ToolbarCategory, FlyoutCategory> = {
+        drawing: {
+            title: t('toolbarCategoryDrawing'),
+            rows: [
+                {
+                    kind: 'button',
+                    id: 'draw-layout',
+                    icon: <TrainTrack />,
+                    label: isLayoutActive ? t('endLayout') : t('startLayout'),
+                    active: isLayoutActive,
+                    disabled: mode !== 'idle' && !isLayoutActive,
+                    onClick: handleLayoutToggle,
+                },
+                {
+                    kind: 'button',
+                    id: 'place-station',
+                    icon: <Warehouse />,
+                    label: t('placeStation'),
+                    active: mode === 'station-placement',
+                    disabled: mode !== 'idle' && mode !== 'station-placement',
+                    onClick: handleStationPlacementToggle,
+                },
+                {
+                    kind: 'button',
+                    id: 'duplicate-track',
+                    icon: <Copy />,
+                    label: t('duplicateTrackToSide'),
+                    active: mode === 'duplicate-to-side',
+                    disabled: mode !== 'idle' && mode !== 'duplicate-to-side',
+                    onClick: handleDuplicateToSideToggle,
+                },
+            ],
+        },
+        trains: {
+            title: t('toolbarCategoryTrains'),
+            rows: [
+                {
+                    kind: 'button',
+                    id: 'place-train',
+                    icon: <TrainFront />,
+                    label: t('placeTrain'),
+                    active: mode === 'train-placement',
+                    disabled: mode !== 'idle' && mode !== 'train-placement',
+                    onClick: handleTrainPlacementToggle,
+                },
+                {
+                    kind: 'button',
+                    id: 'train-list',
+                    icon: <List />,
+                    label: t('trainList'),
+                    active: showTrainPanel,
+                    disabled:
+                        placedTrains.length === 0 && mode !== 'train-placement',
+                    onClick: () => {
+                        if (!showTrainPanel) trackEvent('open-train-panel');
+                        togglePanel('trainPanel');
+                    },
+                },
+                {
+                    kind: 'button',
+                    id: 'depot',
+                    icon: <Warehouse />,
+                    label: t('depot'),
+                    active: showDepot,
+                    onClick: () => {
+                        if (!showDepot) trackEvent('open-depot');
+                        togglePanel('depot');
+                    },
+                },
+                {
+                    kind: 'button',
+                    id: 'formations',
+                    icon: <ListOrdered />,
+                    label: t('formations'),
+                    active: showFormationEditor,
+                    onClick: () => {
+                        if (!showFormationEditor)
+                            trackEvent('open-formation-editor');
+                        togglePanel('formationEditor');
+                    },
+                },
+                {
+                    kind: 'button',
+                    id: 'timetable',
+                    icon: <Clock />,
+                    label: t('timetable'),
+                    active: showTimetable,
+                    onClick: () => togglePanel('timetable'),
+                },
+            ],
+        },
+        infra: {
+            title: t('toolbarCategoryInfra'),
+            rows: [
+                {
+                    kind: 'button',
+                    id: 'station-list',
+                    icon: <Landmark />,
+                    label: t('stations'),
+                    active: showStationList,
+                    onClick: () => {
+                        if (!showStationList) trackEvent('open-station-list');
+                        togglePanel('stationList');
+                    },
+                },
+                {
+                    kind: 'button',
+                    id: 'signals',
+                    icon: <Signal />,
+                    label: t('signals'),
+                    active: showSignalPanel,
+                    onClick: () => togglePanel('signalPanel'),
+                },
+                {
+                    kind: 'button',
+                    id: 'elevation-gradient',
+                    icon: <Layers />,
+                    label: t('elevationGradientLabel'),
+                    active: showElevationGradient,
+                    onClick: () =>
+                        rs
+                            .getState()
+                            .setShowElevationGradient(!showElevationGradient),
+                },
+                {
+                    kind: 'button',
+                    id: 'curve-arcs',
+                    icon: <Spline />,
+                    label: t('curveArcsLabel'),
+                    active: showPreviewCurveArcs,
+                    onClick: () =>
+                        rs
+                            .getState()
+                            .setShowPreviewCurveArcs(!showPreviewCurveArcs),
+                },
+            ],
+        },
+        scene: {
+            title: t('toolbarCategoryScene'),
+            rows: [
+                {
+                    kind: 'button',
+                    id: 'saved-scenes',
+                    icon: <FolderOpen />,
+                    label: t('savedScenes'),
+                    onClick: () => showScenePickerAction(),
+                },
+                {
+                    kind: 'button',
+                    id: 'save-scene',
+                    icon: <Save />,
+                    label: t('saveScene'),
+                    onClick: saveNow,
+                },
+                {
+                    kind: 'button',
+                    id: 'new-scene',
+                    icon: <FilePlus />,
+                    label: t('newScene'),
+                    onClick: () => createNewScene(),
+                },
+                {
+                    kind: 'custom',
+                    id: 'export-submenu',
+                    node: (
                         <ExportSubmenu
                             show={showExportSubmenu}
                             onShowChange={open => {
@@ -956,80 +921,164 @@ export function BananaToolbar({
                             onImportCarDefinitionFromLibrary={
                                 handleImportCarDefinitionFromLibrary
                             }
+                            trigger={
+                                <Button
+                                    variant={
+                                        showExportSubmenu ? 'default' : 'ghost'
+                                    }
+                                    size="sm"
+                                    className={cn(
+                                        "h-9 w-full justify-start gap-2.5 px-2.5 text-sm [&_svg:not([class*='size-'])]:size-4",
+                                        !showExportSubmenu &&
+                                            'hover:bg-foreground/15 hover:text-foreground dark:hover:bg-foreground/20'
+                                    )}
+                                >
+                                    <Download />
+                                    <span className="truncate">
+                                        {t('importExport')}
+                                    </span>
+                                </Button>
+                            }
                         />
-
-                        <ToolbarButton
-                            tooltip={t('savedScenes')}
-                            onClick={() => showScenePickerAction()}
-                        >
-                            <FolderOpen />
-                        </ToolbarButton>
-                        <ToolbarButton
-                            tooltip={t('saveScene')}
-                            onClick={saveNow}
-                        >
-                            <Save />
-                        </ToolbarButton>
-                        <ToolbarButton
-                            tooltip={t('newScene')}
-                            onClick={() => createNewScene()}
-                        >
-                            <FilePlus />
-                        </ToolbarButton>
+                    ),
+                },
+                {
+                    kind: 'custom',
+                    id: 'auto-save-menu',
+                    node: (
                         <AutoSaveIntervalSelector
                             show={showAutoSaveMenu}
                             onShowChange={open => {
                                 setPanel('autoSaveMenu', open);
                                 if (open) setPanel('exportSubmenu', false);
                             }}
+                            trigger={
+                                <Button
+                                    variant={
+                                        showAutoSaveMenu ? 'default' : 'ghost'
+                                    }
+                                    size="sm"
+                                    className={cn(
+                                        "h-9 w-full justify-start gap-2.5 px-2.5 text-sm [&_svg:not([class*='size-'])]:size-4",
+                                        !showAutoSaveMenu &&
+                                            'hover:bg-foreground/15 hover:text-foreground dark:hover:bg-foreground/20'
+                                    )}
+                                >
+                                    <Timer />
+                                    <span className="truncate">
+                                        {t('autoSaveInterval')}
+                                    </span>
+                                </Button>
+                            }
+                        />
+                    ),
+                },
+            ],
+        },
+        debug: {
+            title: t('toolbarCategoryDebug'),
+            rows: [
+                ...(onToggleMap
+                    ? [
+                          {
+                              kind: 'button' as const,
+                              id: 'map-toggle',
+                              icon: <Map />,
+                              label: t('mapLabel'),
+                              active: showMap,
+                              onClick: onToggleMap,
+                          },
+                      ]
+                    : []),
+                {
+                    kind: 'button',
+                    id: 'debug-panel',
+                    icon: <Bug />,
+                    label: t('debug'),
+                    active: showDebugPanel,
+                    onClick: () => {
+                        if (!showDebugPanel) trackEvent('open-debug-panel');
+                        togglePanel('debugPanel');
+                    },
+                },
+            ],
+        },
+    };
+
+    return (
+        <TooltipProvider delayDuration={200}>
+            <div
+                ref={shellRef}
+                className={cn(
+                    'pointer-events-auto absolute top-1/2 flex -translate-y-1/2 flex-col items-start gap-2',
+                    TOOLBAR_LEFT
+                )}
+            >
+                {modeLabelKey && (
+                    <button
+                        type="button"
+                        onClick={exitAllModes}
+                        className="bg-background/80 text-destructive hover:bg-destructive hover:border-destructive absolute bottom-full left-1/2 mb-2 flex -translate-x-1/2 items-center gap-1.5 rounded-full border px-3 py-1 text-xs font-medium whitespace-nowrap shadow-sm backdrop-blur-sm transition-colors hover:text-white"
+                        title={t('exitMode')}
+                    >
+                        <X className="size-3.5" />
+                        <span>{t(modeLabelKey)}</span>
+                    </button>
+                )}
+                {/* Top scroll arrow – always takes space, invisible when not needed */}
+                <div
+                    className={cn(
+                        'bg-background/80 flex justify-center self-center rounded-full border px-2 py-0.5 shadow-sm backdrop-blur-sm',
+                        canScrollUp ? 'text-foreground' : 'invisible'
+                    )}
+                >
+                    <ChevronUp className="h-4 w-4" />
+                </div>
+                <div className="relative flex items-start">
+                    <div
+                        ref={scrollRef}
+                        className={cn(
+                            'scrollbar-hide flex flex-col items-center gap-3 overflow-x-clip overflow-y-auto rounded-xl',
+                            modeLabelKey
+                                ? 'max-h-[calc(100dvh-9rem)]'
+                                : 'max-h-[calc(100dvh-6rem)]'
+                        )}
+                    >
+                        <CategoryRail
+                            activeCategory={activeCategory}
+                            modeHolderCategory={modeHolderCategory}
+                            onToggleCategory={toggleCategory}
                         />
 
-                        <Separator />
-
-                        {onToggleMap && (
-                            <ToolbarButton
-                                tooltip={showMap ? t('hideMap') : t('showMap')}
-                                active={showMap}
-                                onClick={onToggleMap}
-                            >
-                                <Map />
-                            </ToolbarButton>
-                        )}
-
-                        <ToolbarButton
-                            tooltip={
-                                showDebugPanel
-                                    ? t('closeDebug')
-                                    : t('openDebug')
+                        <SunAngleControl
+                            value={sunAngle}
+                            onChange={rs.getState().setSunAngle}
+                        />
+                        <TerrainControl
+                            visible={terrainFillVisible}
+                            onVisibleChange={
+                                rs.getState().setTerrainFillVisible
                             }
-                            active={showDebugPanel}
-                            onClick={() => {
-                                if (!showDebugPanel)
-                                    trackEvent('open-debug-panel');
-                                togglePanel('debugPanel');
-                            }}
-                        >
-                            <Bug />
-                        </ToolbarButton>
+                            opacity={terrainOpacity}
+                            onOpacityChange={rs.getState().setTerrainOpacity}
+                            whiteOcclusion={whiteOcclusion}
+                            onWhiteOcclusionChange={
+                                rs.getState().setWhiteOcclusion
+                            }
+                        />
                     </div>
 
-                    <SunAngleControl
-                        value={sunAngle}
-                        onChange={rs.getState().setSunAngle}
-                    />
-                    <TerrainControl
-                        visible={terrainFillVisible}
-                        onVisibleChange={rs.getState().setTerrainFillVisible}
-                        opacity={terrainOpacity}
-                        onOpacityChange={rs.getState().setTerrainOpacity}
-                        whiteOcclusion={whiteOcclusion}
-                        onWhiteOcclusionChange={rs.getState().setWhiteOcclusion}
+                    <CategoryFlyout
+                        category={activeCategory}
+                        categories={flyoutCategories}
+                        onClose={() => setActiveCategory(null)}
+                        shellRef={shellRef}
                     />
                 </div>
                 {/* Bottom scroll arrow – always takes space, invisible when not needed */}
                 <div
                     className={cn(
-                        'bg-background/80 mt-2 flex justify-center rounded-full border px-2 py-0.5 shadow-sm backdrop-blur-sm',
+                        'bg-background/80 flex justify-center self-center rounded-full border px-2 py-0.5 shadow-sm backdrop-blur-sm',
                         canScrollDown ? 'text-foreground' : 'invisible'
                     )}
                 >
@@ -1176,7 +1225,8 @@ export function BananaToolbar({
                 />
             )}
 
-            <div className="pointer-events-auto absolute top-3 right-3">
+            <div className="pointer-events-auto absolute top-3 right-3 flex items-center gap-2">
+                <ThemeToggle />
                 <LanguageSwitcher />
             </div>
 

--- a/apps/banana/src/components/toolbar/CategoryFlyout.tsx
+++ b/apps/banana/src/components/toolbar/CategoryFlyout.tsx
@@ -1,0 +1,107 @@
+import type { ReactNode, RefObject } from 'react';
+import { useEffect } from 'react';
+
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { ToolbarCategory } from '@/stores/toolbar-ui-store';
+
+export type FlyoutRow =
+    | {
+          kind: 'button';
+          id: string;
+          icon: ReactNode;
+          label: string;
+          active?: boolean;
+          disabled?: boolean;
+          onClick: () => void;
+      }
+    | {
+          kind: 'custom';
+          id: string;
+          node: ReactNode;
+      };
+
+export type FlyoutCategory = {
+    title: string;
+    rows: FlyoutRow[];
+};
+
+type CategoryFlyoutProps = {
+    category: ToolbarCategory | null;
+    categories: Record<ToolbarCategory, FlyoutCategory>;
+    onClose: () => void;
+    shellRef: RefObject<HTMLElement | null>;
+};
+
+export function CategoryFlyout({
+    category,
+    categories,
+    onClose,
+    shellRef,
+}: CategoryFlyoutProps) {
+    useEffect(() => {
+        if (!category) return;
+
+        const handlePointerDown = (e: PointerEvent) => {
+            const target = e.target as Element | null;
+            if (!target) return;
+            if (shellRef.current?.contains(target)) return;
+            // Radix dropdowns portal their content outside the shell.
+            if (target.closest('[data-radix-popper-content-wrapper]')) return;
+            if (target.closest('[role="menu"]')) return;
+            onClose();
+        };
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === 'Escape') onClose();
+        };
+
+        document.addEventListener('pointerdown', handlePointerDown);
+        document.addEventListener('keydown', handleKeyDown);
+        return () => {
+            document.removeEventListener('pointerdown', handlePointerDown);
+            document.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [category, onClose, shellRef]);
+
+    if (!category) return null;
+
+    const { title, rows } = categories[category];
+
+    return (
+        <div
+            className="bg-background/80 absolute top-0 left-full ml-3 flex w-60 flex-col rounded-xl border shadow-lg backdrop-blur-sm"
+            role="menu"
+            aria-label={title}
+        >
+            <div className="text-muted-foreground border-b px-3 py-2 text-xs font-semibold tracking-wide uppercase">
+                {title}
+            </div>
+            <div className="flex max-h-[70vh] flex-col gap-0.5 overflow-y-auto p-1.5">
+                {rows.map(row =>
+                    row.kind === 'button' ? (
+                        <Button
+                            key={row.id}
+                            variant={row.active ? 'default' : 'ghost'}
+                            size="sm"
+                            disabled={row.disabled}
+                            onClick={row.onClick}
+                            className={cn(
+                                "h-9 w-full justify-start gap-2.5 px-2.5 text-sm [&_svg:not([class*='size-'])]:size-4",
+                                !row.active &&
+                                    'hover:bg-foreground/15 hover:text-foreground dark:hover:bg-foreground/20'
+                            )}
+                        >
+                            {row.icon}
+                            <span className="truncate">{row.label}</span>
+                        </Button>
+                    ) : (
+                        <div key={row.id} className="flex w-full items-center">
+                            {row.node}
+                        </div>
+                    )
+                )}
+            </div>
+        </div>
+    );
+}

--- a/apps/banana/src/components/toolbar/CategoryRail.tsx
+++ b/apps/banana/src/components/toolbar/CategoryRail.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from 'react-i18next';
+
+import {
+    FolderOpen,
+    Landmark,
+    Pencil,
+    Settings2,
+    TrainFront,
+} from '@/assets/icons';
+import type { ToolbarCategory } from '@/stores/toolbar-ui-store';
+
+import { ToolbarButton } from './ToolbarButton';
+
+type CategoryRailProps = {
+    activeCategory: ToolbarCategory | null;
+    modeHolderCategory: ToolbarCategory | null;
+    onToggleCategory: (category: ToolbarCategory) => void;
+};
+
+export function CategoryRail({
+    activeCategory,
+    modeHolderCategory,
+    onToggleCategory,
+}: CategoryRailProps) {
+    const { t } = useTranslation();
+
+    const entries: Array<{
+        id: ToolbarCategory;
+        label: string;
+        icon: React.ReactNode;
+    }> = [
+        {
+            id: 'drawing',
+            label: t('toolbarCategoryDrawing'),
+            icon: <Pencil />,
+        },
+        {
+            id: 'trains',
+            label: t('toolbarCategoryTrains'),
+            icon: <TrainFront />,
+        },
+        {
+            id: 'infra',
+            label: t('toolbarCategoryInfra'),
+            icon: <Landmark />,
+        },
+        {
+            id: 'scene',
+            label: t('toolbarCategoryScene'),
+            icon: <FolderOpen />,
+        },
+        {
+            id: 'debug',
+            label: t('toolbarCategoryDebug'),
+            icon: <Settings2 />,
+        },
+    ];
+
+    return (
+        <div className="bg-background/80 flex flex-col items-center gap-1 rounded-xl border p-1.5 shadow-lg backdrop-blur-sm">
+            {entries.map(entry => (
+                <div key={entry.id} className="relative">
+                    <ToolbarButton
+                        tooltip={entry.label}
+                        active={activeCategory === entry.id}
+                        onClick={() => onToggleCategory(entry.id)}
+                    >
+                        {entry.icon}
+                    </ToolbarButton>
+                    {modeHolderCategory === entry.id && (
+                        <span
+                            className="ring-background pointer-events-none absolute top-0.5 right-0.5 size-2 rounded-full bg-orange-500 ring-2"
+                            aria-hidden
+                        />
+                    )}
+                </div>
+            ))}
+        </div>
+    );
+}

--- a/apps/banana/src/components/toolbar/ExportSubmenu.tsx
+++ b/apps/banana/src/components/toolbar/ExportSubmenu.tsx
@@ -1,3 +1,4 @@
+import type { ReactElement } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import {
@@ -33,6 +34,8 @@ type ExportSubmenuProps = {
     onImportTerrain: () => void;
     onImportCarDefinition: () => void;
     onImportCarDefinitionFromLibrary: () => void;
+    /** Custom trigger element — overrides the default icon button. */
+    trigger?: ReactElement;
 };
 
 export function ExportSubmenu({
@@ -47,22 +50,25 @@ export function ExportSubmenu({
     onImportTerrain,
     onImportCarDefinition,
     onImportCarDefinitionFromLibrary,
+    trigger,
 }: ExportSubmenuProps) {
     const { t } = useTranslation();
 
     return (
         <DropdownMenu open={show} onOpenChange={onShowChange}>
             <DropdownMenuTrigger asChild>
-                <Button
-                    variant="ghost"
-                    size="icon-lg"
-                    className={cn(
-                        "[&_svg:not([class*='size-'])]:size-5",
-                        show && 'bg-accent'
-                    )}
-                >
-                    <Download />
-                </Button>
+                {trigger ?? (
+                    <Button
+                        variant="ghost"
+                        size="icon-lg"
+                        className={cn(
+                            "[&_svg:not([class*='size-'])]:size-5",
+                            show && 'bg-accent'
+                        )}
+                    >
+                        <Download />
+                    </Button>
+                )}
             </DropdownMenuTrigger>
             <DropdownMenuContent
                 side="right"

--- a/apps/banana/src/components/toolbar/ToolbarButton.tsx
+++ b/apps/banana/src/components/toolbar/ToolbarButton.tsx
@@ -38,7 +38,11 @@ export function ToolbarButton({
                     onClick={onClick}
                     className={cn(
                         "[&_svg:not([class*='size-'])]:size-5",
-                        destructiveMuted && !active &&
+                        !active &&
+                            !destructive &&
+                            'hover:bg-foreground/15 hover:text-foreground dark:hover:bg-foreground/20',
+                        destructiveMuted &&
+                            !active &&
                             'text-destructive/70 hover:text-destructive hover:bg-destructive/10'
                     )}
                 >

--- a/apps/banana/src/components/ui/theme-toggle.tsx
+++ b/apps/banana/src/components/ui/theme-toggle.tsx
@@ -1,0 +1,66 @@
+import { useEffect, useState } from 'react';
+
+import { Moon, Sun } from '@/assets/icons';
+import { Button } from '@/components/ui/button';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'banana-theme';
+
+function getInitialTheme(): Theme {
+    if (typeof window === 'undefined') return 'light';
+    const stored = window.localStorage.getItem(STORAGE_KEY) as Theme | null;
+    if (stored === 'light' || stored === 'dark') return stored;
+    return window.matchMedia('(prefers-color-scheme: dark)').matches
+        ? 'dark'
+        : 'light';
+}
+
+function applyTheme(theme: Theme) {
+    const root = document.documentElement;
+    if (theme === 'dark') root.classList.add('dark');
+    else root.classList.remove('dark');
+}
+
+type ThemeToggleProps = {
+    className?: string;
+};
+
+export function ThemeToggle({ className }: ThemeToggleProps) {
+    const [theme, setTheme] = useState<Theme>(() => getInitialTheme());
+
+    useEffect(() => {
+        applyTheme(theme);
+        window.localStorage.setItem(STORAGE_KEY, theme);
+    }, [theme]);
+
+    const toggle = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={toggle}
+                    aria-label={theme === 'dark' ? 'Light mode' : 'Dark mode'}
+                    className={cn(
+                        "bg-background/80 hover:bg-background text-muted-foreground hover:text-foreground border shadow-lg backdrop-blur-sm transition-colors [&_svg:not([class*='size-'])]:size-3.5",
+                        className
+                    )}
+                >
+                    {theme === 'dark' ? <Sun /> : <Moon />}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="left">
+                {theme === 'dark' ? 'Light mode' : 'Dark mode'}
+            </TooltipContent>
+        </Tooltip>
+    );
+}

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -2,11 +2,29 @@ import { iconHandoff as iconHandoffStringsEn } from './icon-handoff-en';
 
 const en = {
     translation: {
+        // Toolbar - Category Rail
+        toolbarCategoryDrawing: 'Drawing Tools',
+        toolbarCategoryTrains: 'Train Management',
+        toolbarCategoryInfra: 'Infrastructure & Visualization',
+        toolbarCategoryScene: 'Scene & Files',
+        toolbarCategoryDebug: 'Debug & View',
+
         // Toolbar - Layout
         startLayout: 'Start Layout',
         endLayout: 'End Layout',
         deleteTrack: 'Delete Track',
         endDeletion: 'End Deletion',
+        duplicateTrackToSide: 'Duplicate Track to Side',
+
+        // Toolbar - Mode Exit Chip
+        exitMode: 'Exit',
+        modeDrawingLayout: 'Drawing Tracks',
+        modeDeletingTrack: 'Deleting Tracks',
+        modePlacingTrain: 'Placing Train',
+        modePlacingStation: 'Placing Station',
+        modeDuplicatingTrack: 'Duplicating Track',
+        modePlacingBuilding: 'Placing Building',
+        modeDeletingBuilding: 'Deleting Building',
 
         // Toolbar - Train
         placeTrain: 'Place Train',
@@ -33,6 +51,10 @@ const en = {
         hideElevationGradient: 'Hide Elevation Gradient',
         showPreviewCurveArcs: 'Show Preview Curve Arcs',
         hidePreviewCurveArcs: 'Hide Preview Curve Arcs',
+        elevationGradientLabel: 'Elevation Gradient',
+        curveArcsLabel: 'Curve Arcs',
+        mapLabel: 'Map',
+        importExport: 'Import / Export',
         showMap: 'Show Map',
         hideMap: 'Hide Map',
         openDebug: 'Open Debug',

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -2,11 +2,29 @@ import { iconHandoff as iconHandoffStringsEn } from './icon-handoff-en';
 
 const ja = {
     translation: {
+        // Toolbar - Category Rail
+        toolbarCategoryDrawing: '作図ツール',
+        toolbarCategoryTrains: '列車管理',
+        toolbarCategoryInfra: 'インフラ & 表示',
+        toolbarCategoryScene: 'シーン & ファイル',
+        toolbarCategoryDebug: 'デバッグ & 表示',
+
         // Toolbar - Layout
         startLayout: 'レイアウト開始',
         endLayout: 'レイアウト終了',
         deleteTrack: '線路を削除',
         endDeletion: '削除終了',
+        duplicateTrackToSide: '線路を側方に複製',
+
+        // Toolbar - Mode Exit Chip
+        exitMode: '終了',
+        modeDrawingLayout: '線路を敷設中',
+        modeDeletingTrack: '線路を削除中',
+        modePlacingTrain: '列車を配置中',
+        modePlacingStation: '駅を配置中',
+        modeDuplicatingTrack: '線路を複製中',
+        modePlacingBuilding: '建物を配置中',
+        modeDeletingBuilding: '建物を削除中',
 
         // Toolbar - Train
         placeTrain: '列車を配置',
@@ -33,6 +51,10 @@ const ja = {
         hideElevationGradient: '標高グラデーションを非表示',
         showPreviewCurveArcs: 'プレビュー曲線弧を表示',
         hidePreviewCurveArcs: 'プレビュー曲線弧を非表示',
+        elevationGradientLabel: '標高グラデーション',
+        curveArcsLabel: '曲線弧',
+        mapLabel: '地図',
+        importExport: 'インポート / エクスポート',
         showMap: '地図を表示',
         hideMap: '地図を非表示',
         openDebug: 'デバッグを開く',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -2,11 +2,29 @@ import { iconHandoff as iconHandoffStringsZhTW } from './icon-handoff-zh-TW';
 
 const zhTW = {
     translation: {
+        // Toolbar - Category Rail
+        toolbarCategoryDrawing: '繪製工具',
+        toolbarCategoryTrains: '列車管理',
+        toolbarCategoryInfra: '基礎設施 & 顯示',
+        toolbarCategoryScene: '場景 & 檔案',
+        toolbarCategoryDebug: '除錯 & 檢視',
+
         // Toolbar - Layout
         startLayout: '開始佈軌',
         endLayout: '結束佈軌',
         deleteTrack: '刪除軌道',
         endDeletion: '結束刪除',
+        duplicateTrackToSide: '複製軌道到側邊',
+
+        // Toolbar - Mode Exit Chip
+        exitMode: '結束',
+        modeDrawingLayout: '佈軌中',
+        modeDeletingTrack: '刪除軌道中',
+        modePlacingTrain: '放置列車中',
+        modePlacingStation: '放置車站中',
+        modeDuplicatingTrack: '複製軌道中',
+        modePlacingBuilding: '放置建築中',
+        modeDeletingBuilding: '刪除建築中',
 
         // Toolbar - Train
         placeTrain: '放置列車',
@@ -33,6 +51,10 @@ const zhTW = {
         hideElevationGradient: '隱藏高度漸層',
         showPreviewCurveArcs: '顯示預覽曲線弧',
         hidePreviewCurveArcs: '隱藏預覽曲線弧',
+        elevationGradientLabel: '高度漸層',
+        curveArcsLabel: '曲線弧',
+        mapLabel: '地圖',
+        importExport: '匯入 / 匯出',
         showMap: '顯示地圖',
         hideMap: '隱藏地圖',
         openDebug: '開啟除錯選項',

--- a/apps/banana/src/stores/toolbar-ui-store.ts
+++ b/apps/banana/src/stores/toolbar-ui-store.ts
@@ -14,6 +14,13 @@ export type PanelName =
     | 'exportSubmenu'
     | 'autoSaveMenu';
 
+export type ToolbarCategory =
+    | 'drawing'
+    | 'trains'
+    | 'infra'
+    | 'scene'
+    | 'debug';
+
 type PanelState = {
     showDepot: boolean;
     showTrainPanel: boolean;
@@ -40,6 +47,7 @@ const PANEL_KEY_MAP: Record<PanelName, keyof PanelState> = {
 
 type ToolbarUIState = PanelState & {
     mode: AppMode;
+    activeCategory: ToolbarCategory | null;
 };
 
 type ToolbarUIActions = {
@@ -47,6 +55,8 @@ type ToolbarUIActions = {
     togglePanel: (panel: PanelName) => void;
     setPanel: (panel: PanelName, open: boolean) => void;
     closeAllPanels: () => void;
+    setActiveCategory: (category: ToolbarCategory | null) => void;
+    toggleCategory: (category: ToolbarCategory) => void;
 };
 
 export type ToolbarUIStore = ToolbarUIState & ToolbarUIActions;
@@ -65,22 +75,32 @@ const INITIAL_PANEL_STATE: PanelState = {
 
 export const useToolbarUIStore = create<ToolbarUIStore>()(
     devtools(
-        (set) => ({
+        set => ({
             mode: 'idle',
+            activeCategory: null,
             ...INITIAL_PANEL_STATE,
 
-            setMode: (mode) => set({ mode }),
+            setMode: mode => set({ mode }),
 
-            togglePanel: (panel) =>
-                set((state) => {
+            togglePanel: panel =>
+                set(state => {
                     const key = PANEL_KEY_MAP[panel];
                     return { [key]: !state[key] };
                 }),
 
-            setPanel: (panel, open) =>
-                set({ [PANEL_KEY_MAP[panel]]: open }),
+            setPanel: (panel, open) => set({ [PANEL_KEY_MAP[panel]]: open }),
 
             closeAllPanels: () => set(INITIAL_PANEL_STATE),
+
+            setActiveCategory: category => set({ activeCategory: category }),
+
+            toggleCategory: category =>
+                set(state => ({
+                    activeCategory:
+                        state.activeCategory === category ? null : category,
+                    showExportSubmenu: false,
+                    showAutoSaveMenu: false,
+                })),
         }),
         { name: 'banana-toolbar-ui' }
     )


### PR DESCRIPTION
## Summary
- Collapse the ~20-button left toolbar into a 5-category rail (Drawing, Trains, Infra, Scene, Debug) that opens a labeled flyout panel to the right.
- Add an orange dot on the category that owns the currently active mode, plus a one-click "exit mode" chip floating above the rail so mutually-exclusive modes can be cancelled without diving into the flyout.
- Strengthen ghost-button hover contrast for both the category rail and the flyout rows.
- Introduce a reusable `ThemeToggle` component (Sun/Moon, persisted to localStorage) placed next to the language switcher.

## Test plan
- [ ] Each category opens its flyout; re-clicking closes it.
- [ ] Drawing/Trains categories show a dot when their mode is active; the exit chip appears and `exitAllModes()` works.
- [ ] All mode toggles (layout, train placement, station placement, duplicate) still disable each other correctly.
- [ ] Scene flyout: Save / New / Saved Scenes, plus nested `ExportSubmenu` and `AutoSaveIntervalSelector` dropdowns all work without closing the flyout.
- [ ] Theme toggle flips `.dark` on `<html>`, persists across reloads, and doesn't collide with the language switcher.
- [ ] Sun Angle / Terrain controls and bottom/top scroll chevrons still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)