### PR TITLE
fix(banana): draw track shadows above same-band drawables

### DIFF
--- a/apps/banana/src/world-render-system.ts
+++ b/apps/banana/src/world-render-system.ts
@@ -44,17 +44,22 @@ export const findElevationInterval = (elevation: number): { interval: [ELEVATION
 /**
  * Sublayer types within each elevation band.
  *
- * Draw order (bottom to top): shadow → bed → drawable → rail → onTrack → catenary.
+ * Draw order (bottom to top): bed → drawable → rail → onTrack → catenary → shadow.
+ *
+ * Shadow is drawn last within its band so a higher track's shadow (placed in
+ * the band one level below the track) paints over tracks/rails at that lower
+ * level. Terrain occlusion for the next band still hides it because occlusion
+ * containers sit between bands in the parent z-order.
  */
 export type BandSublayer = 'drawable' | 'rail' | 'onTrack' | 'catenary';
 
 /** Z-index constants for band sublayers. Shadow and bed are shared containers; the rest are sortable. */
-const SUBLAYER_SHADOW = 0;
-const SUBLAYER_BED = 1;
-const SUBLAYER_DRAWABLE = 2;
-const SUBLAYER_RAIL = 3;
-const SUBLAYER_ON_TRACK = 4;
-const SUBLAYER_CATENARY = 5;
+const SUBLAYER_BED = 0;
+const SUBLAYER_DRAWABLE = 1;
+const SUBLAYER_RAIL = 2;
+const SUBLAYER_ON_TRACK = 3;
+const SUBLAYER_CATENARY = 4;
+const SUBLAYER_SHADOW = 5;
 
 const SUBLAYER_MAP: Record<BandSublayer, number> = {
     drawable: SUBLAYER_DRAWABLE,


### PR DESCRIPTION
## Summary
- Track shadow for a track at elevation band N is placed in band N−1. Within each band, the shadow sublayer used to render first (`zIndex=0`), so the drawable sublayer at band N−1 painted over it — meaning the track directly one level below the shadow source was *not* covered by the shadow, while tracks two or more levels below (sitting in entirely earlier bands) still got covered.
- Moved `SUBLAYER_SHADOW` to draw last within its band. Terrain occlusion still works because occlusion containers sit between bands in the parent z-order, so the upper track's shadow continues to be hidden by terrain at its own elevation.

## Test plan
- [ ] Place a track at ABOVE_2 crossing a track at ABOVE_1 and confirm the shadow falls over the lower track
- [ ] Verify terrain at ABOVE_2 still occludes the ABOVE_2 track's shadow (tunnel/cut rendering unchanged)
- [ ] Verify building shadows on ground still render correctly
- [ ] `bunx nx test banana` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)