### PR TITLE
refactor(banana): abstract public-facing app name into branding constant

### DIFF
--- a/apps/banana/src/branding.ts
+++ b/apps/banana/src/branding.ts
@@ -1,0 +1,8 @@
+/**
+ * Single source of truth for the public-facing app name.
+ *
+ * Internal code, storage keys, file paths, and type names still use the
+ * code name "banana". Change this constant to swap the display name when
+ * the app gets its official public release name.
+ */
+export const APP_DISPLAY_NAME = 'Banana';

--- a/apps/banana/src/i18n/locales/icon-handoff-en.ts
+++ b/apps/banana/src/i18n/locales/icon-handoff-en.ts
@@ -4,7 +4,7 @@
 export const iconHandoff = {
     title: 'Icon handoff',
     intro:
-        'Visual inventory for the Banana app: each row shows the icon as implemented today, a slot for the designer-delivered SVG, and what it is used for. Lucide reference:',
+        'Visual inventory for the {{appName}} app: each row shows the icon as implemented today, a slot for the designer-delivered SVG, and what it is used for. Lucide reference:',
     lucideLinkLabel: 'lucide.dev',
     introClosing: '.',
     backToLanding: '← Back to landing',
@@ -82,7 +82,7 @@ export const iconHandoff = {
             'Train panel: focus camera on the selected train (animated zoom/pan to train).',
         Gauge:
             'Export submenu: import car definition from train editor (speedometer metaphor for vehicle spec).',
-        Github: 'Landing page footer: link to Banana app source on GitHub.',
+        Github: 'Landing page footer: link to {{appName}} app source on GitHub.',
         GripHorizontal:
             'Train editor: toggle edit train car image mode (resize/move sprite).',
         Hash: 'Debug panel: toggle track joint numbers overlay.',
@@ -109,7 +109,7 @@ export const iconHandoff = {
             'Train editor: edit bogies mode (place/adjust wheel positions).',
         OctagonXIcon: 'Toast: error notification icon.',
         Package:
-            'Terrain editor: export terrain as scene bundle for use in the main Banana app.',
+            'Terrain editor: export terrain as scene bundle for use in the main {{appName}} app.',
         Pause:
             'Simulation time control: pause the world clock (shown while running).',
         Pencil:
@@ -140,7 +140,7 @@ export const iconHandoff = {
             'Main toolbar: depot panel (car stock). Also used for station placement mode (warehouse / yard metaphor).',
         X: 'Close draggable panels. Station list: cancel platform-picking mode.',
         favicon:
-            'Browser tab favicon for Banana (public/favicon.svg). Replace the shipped favicon when branding updates.',
+            'Browser tab favicon for {{appName}} (public/favicon.svg). Replace the shipped favicon when branding updates.',
         languageChevron:
             'Tiny inline SVG beside the locale label in LanguageSwitcher.tsx (opens language menu). Not part of the Lucide barrel.',
     },

--- a/apps/banana/src/i18n/locales/icon-handoff-zh-TW.ts
+++ b/apps/banana/src/i18n/locales/icon-handoff-zh-TW.ts
@@ -4,7 +4,7 @@
 export const iconHandoff = {
     title: '圖示交付（設計用）',
     intro:
-        'Banana 應用程式的視覺化圖示清單：每一列顯示目前實作的圖示、設計師交付用 SVG 的預留位置，以及用途說明。Lucide 參考：',
+        '{{appName}} 應用程式的視覺化圖示清單：每一列顯示目前實作的圖示、設計師交付用 SVG 的預留位置，以及用途說明。Lucide 參考：',
     lucideLinkLabel: 'lucide.dev',
     introClosing: '。',
     backToLanding: '← 返回首頁',
@@ -75,7 +75,7 @@ export const iconHandoff = {
         Focus: '列車面板：將攝影機聚焦所選列車（縮放／平移動畫）。',
         Gauge:
             '匯出子選單：從列車編輯器匯入車輛定義（儀表隱喻）。',
-        Github: '首頁頁尾：連結至 GitHub 上的 Banana 原始碼。',
+        Github: '首頁頁尾：連結至 GitHub 上的 {{appName}} 原始碼。',
         GripHorizontal: '列車編輯器：切換編輯車體圖片模式（縮放／移動精靈圖）。',
         Hash: '除錯面板：切換軌道接點編號疊加層。',
         Image: '列車編輯器：匯入點陣圖至車體。',
@@ -99,7 +99,7 @@ export const iconHandoff = {
             '地形控制：地形填色顯示開關。匯出子選單：匯入地形資料。',
         MousePointer2: '列車編輯器：編輯轉向架模式（放置／調整輪位）。',
         OctagonXIcon: 'Toast：錯誤通知圖示。',
-        Package: '地形編輯器：將地形匯出為場景包，供主程式 Banana 使用。',
+        Package: '地形編輯器：將地形匯出為場景包，供主程式 {{appName}} 使用。',
         Pause: '模擬時間控制：暫停世界時鐘（執行中時顯示）。',
         Pencil:
             '車庫：重新命名庫存車輛。編組編輯器：重新命名編組（觸發行內編輯）。',

--- a/apps/banana/src/main-react.tsx
+++ b/apps/banana/src/main-react.tsx
@@ -3,6 +3,7 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router';
 
+import { APP_DISPLAY_NAME } from '@/branding';
 import { AnalyticsNotice } from '@/components/analytics-notice';
 import { Toaster } from '@/components/ui/sonner';
 import '@/i18n';
@@ -22,6 +23,8 @@ declare module '@ue-too/board-pixi-react-integration' {
         components: BananaAppComponents;
     }
 }
+
+document.title = APP_DISPLAY_NAME;
 
 const rootElement = document.getElementById('root');
 

--- a/apps/banana/src/pages/icon-handoff/icon-handoff-page.tsx
+++ b/apps/banana/src/pages/icon-handoff/icon-handoff-page.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 
+import { APP_DISPLAY_NAME } from '@/branding';
 import { LanguageSwitcher } from '@/components/toolbar/LanguageSwitcher';
 import { cn } from '@/lib/utils';
 
@@ -125,7 +126,9 @@ function HandoffTable({
                                             />
                                         </td>
                                         <td className="text-muted-foreground align-top px-3 py-3 leading-relaxed">
-                                            {t(`desc.${row.descKey}`)}
+                                            {t(`desc.${row.descKey}`, {
+                                                appName: APP_DISPLAY_NAME,
+                                            })}
                                         </td>
                                     </tr>
                                 );
@@ -155,7 +158,9 @@ function HandoffTable({
                                         />
                                     </td>
                                     <td className="text-muted-foreground align-top px-3 py-3 leading-relaxed">
-                                        {t(`desc.${row.exportName}`)}
+                                        {t(`desc.${row.exportName}`, {
+                                            appName: APP_DISPLAY_NAME,
+                                        })}
                                     </td>
                                 </tr>
                             );
@@ -195,7 +200,7 @@ export function IconHandoffPage(): ReactNode {
                             {t('title')}
                         </h1>
                         <p className="text-muted-foreground mt-2 max-w-2xl text-sm leading-relaxed">
-                            {t('intro')}{' '}
+                            {t('intro', { appName: APP_DISPLAY_NAME })}{' '}
                             <a
                                 href="https://lucide.dev/icons/"
                                 className="text-primary underline-offset-2 hover:underline"

--- a/apps/banana/src/pages/landing.tsx
+++ b/apps/banana/src/pages/landing.tsx
@@ -2,6 +2,7 @@ import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { Trans, useTranslation } from 'react-i18next';
 import { Link } from 'react-router';
 import { Github } from '@/assets/icons';
+import { APP_DISPLAY_NAME } from '@/branding';
 
 import { LedMarquee } from '@/components/led-marquee';
 import { LanguageSwitcher } from '@/components/toolbar/LanguageSwitcher';
@@ -233,7 +234,7 @@ export function LandingPage(): React.ReactNode {
                                     {t('nextStop')}
                                 </span>
                                 <LedMarquee
-                                    text="Banana"
+                                    text={APP_DISPLAY_NAME}
                                     rows={24}
                                     visibleCols={80}
                                     height={120}
@@ -377,7 +378,7 @@ export function LandingPage(): React.ReactNode {
                                     href="https://github.com/ue-too/ue-too/tree/main/apps/banana"
                                     target="_blank"
                                     rel="noopener noreferrer"
-                                    aria-label="Banana source on GitHub"
+                                    aria-label={`${APP_DISPLAY_NAME} source on GitHub`}
                                     className="hover:text-foreground ml-1 inline-flex items-center align-middle transition-colors whitespace-nowrap"
                                 >
                                     <Github className="h-3.5 w-3.5" />


### PR DESCRIPTION
## Summary
- Adds `apps/banana/src/branding.ts` exporting `APP_DISPLAY_NAME = 'Banana'` as the single source of truth for the user-facing app name.
- Routes the five user-visible references through the constant: browser tab title (set via `document.title` in `main-react.tsx`), landing page LED marquee, GitHub link aria-label, and the icon-handoff page intro + Github/Package/favicon descriptions (via i18next `{{appName}}` interpolation in both `en` and `zh-TW`).
- Leaves all internal code symbols (`BananaToolbar`, `useBananaApp`, `BananaAppComponents`, `openBananaDb`), storage keys (`banana-*` localStorage, `banana-scenes` IndexedDB), and the `apps/banana/` path untouched so beta users' save files carry over on public release.

When the official name arrives, edit one constant in `branding.ts`.

## Test plan
- [x] `dev:banana` + browser verification: title shows "Banana", landing page GitHub aria-label reads "Banana source on GitHub"
- [x] `/icon-handoff` (en): intro interpolates to "Visual inventory for the Banana app…"
- [x] `/icon-handoff` (zh-TW): intro interpolates to "Banana 應用程式的視覺化圖示清單…"
- [ ] Swap `APP_DISPLAY_NAME` to a test value locally and confirm all five surfaces update with no stale "Banana" strings

🤖 Generated with [Claude Code](https://claude.com/claude-code)