### PR TITLE
feat(banana): catenary layout tool

### DIFF
--- a/apps/banana/src/assets/icons/lucide.ts
+++ b/apps/banana/src/assets/icons/lucide.ts
@@ -68,4 +68,5 @@ export {
     Upload,
     Warehouse,
     X,
+    Zap,
 } from 'lucide-react';

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -14,6 +14,7 @@ import {
     Clock,
     Copy,
     Download,
+    Zap,
     FilePlus,
     FolderOpen,
     Landmark,
@@ -396,6 +397,17 @@ export function BananaToolbar({
         }
     }, [app, mode, exitAllModes]);
 
+    const handleCatenaryLayoutToggle = useCallback(() => {
+        if (!app) return;
+        if (mode === 'catenary-layout') {
+            exitAllModes();
+        } else {
+            exitAllModes();
+            app.kmtStateMachineExpansion.happens('switchToCatenary');
+            setMode('catenary-layout');
+        }
+    }, [app, mode, exitAllModes]);
+
     const handlePointerDown = useCallback(
         (event: PointerEvent) => {
             if (event.button !== 0 || !app) return;
@@ -716,7 +728,8 @@ export function BananaToolbar({
         mode === 'layout' ||
         mode === 'layout-deletion' ||
         mode === 'station-placement' ||
-        mode === 'duplicate-to-side'
+        mode === 'duplicate-to-side' ||
+        mode === 'catenary-layout'
             ? 'drawing'
             : mode === 'train-placement'
               ? 'trains'
@@ -733,7 +746,9 @@ export function BananaToolbar({
                   ? 'modePlacingStation'
                   : mode === 'duplicate-to-side'
                     ? 'modeDuplicatingTrack'
-                    : mode === 'building-placement'
+                    : mode === 'catenary-layout'
+                      ? 'modeCatenaryLayout'
+                      : mode === 'building-placement'
                       ? 'modePlacingBuilding'
                       : mode === 'building-deletion'
                         ? 'modeDeletingBuilding'
@@ -769,6 +784,15 @@ export function BananaToolbar({
                     active: mode === 'duplicate-to-side',
                     disabled: mode !== 'idle' && mode !== 'duplicate-to-side',
                     onClick: handleDuplicateToSideToggle,
+                },
+                {
+                    kind: 'button',
+                    id: 'catenary-layout',
+                    icon: <Zap />,
+                    label: t('catenaryLayout'),
+                    active: mode === 'catenary-layout',
+                    disabled: mode !== 'idle' && mode !== 'catenary-layout',
+                    onClick: handleCatenaryLayoutToggle,
                 },
             ],
         },

--- a/apps/banana/src/components/toolbar/types.ts
+++ b/apps/banana/src/components/toolbar/types.ts
@@ -8,6 +8,7 @@ export type AppMode =
     | 'building-deletion'
     | 'station-placement'
     | 'duplicate-to-side'
+    | 'catenary-layout'
     | 'stress-pick';
 
 /** Shared left offset for left-aligned toolbars (main toolbar, layout deletion toolbar). */

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -15,6 +15,7 @@ const en = {
         deleteTrack: 'Delete Track',
         endDeletion: 'End Deletion',
         duplicateTrackToSide: 'Duplicate Track to Side',
+        catenaryLayout: 'Catenary Layout',
 
         // Toolbar - Mode Exit Chip
         exitMode: 'Exit',
@@ -23,6 +24,7 @@ const en = {
         modePlacingTrain: 'Placing Train',
         modePlacingStation: 'Placing Station',
         modeDuplicatingTrack: 'Duplicating Track',
+        modeCatenaryLayout: 'Placing Catenary',
         modePlacingBuilding: 'Placing Building',
         modeDeletingBuilding: 'Deleting Building',
 

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -15,6 +15,7 @@ const ja = {
         deleteTrack: '線路を削除',
         endDeletion: '削除終了',
         duplicateTrackToSide: '線路を側方に複製',
+        catenaryLayout: '架線配置',
 
         // Toolbar - Mode Exit Chip
         exitMode: '終了',
@@ -23,6 +24,7 @@ const ja = {
         modePlacingTrain: '列車を配置中',
         modePlacingStation: '駅を配置中',
         modeDuplicatingTrack: '線路を複製中',
+        modeCatenaryLayout: '架線を配置中',
         modePlacingBuilding: '建物を配置中',
         modeDeletingBuilding: '建物を削除中',
 

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -15,6 +15,7 @@ const zhTW = {
         deleteTrack: '刪除軌道',
         endDeletion: '結束刪除',
         duplicateTrackToSide: '複製軌道到側邊',
+        catenaryLayout: '架線佈置',
 
         // Toolbar - Mode Exit Chip
         exitMode: '結束',
@@ -23,6 +24,7 @@ const zhTW = {
         modePlacingTrain: '放置列車中',
         modePlacingStation: '放置車站中',
         modeDuplicatingTrack: '複製軌道中',
+        modeCatenaryLayout: '架線佈置中',
         modePlacingBuilding: '放置建築中',
         modeDeletingBuilding: '刪除建築中',
 

--- a/apps/banana/src/trains/input-state-machine/catenary-layout-engine.ts
+++ b/apps/banana/src/trains/input-state-machine/catenary-layout-engine.ts
@@ -1,0 +1,217 @@
+import {
+    Observable,
+    Observer,
+    SubscriptionOptions,
+    SynchronousObservable,
+} from '@ue-too/board';
+import type { Point } from '@ue-too/math';
+
+import { TrackGraph } from '../tracks/track';
+import { CatenaryLayoutContext } from './catenary-layout-state-machine';
+
+/**
+ * Highlight payload for the catenary layout tool.
+ * `hover` = candidate under the cursor while no source is selected.
+ * `selected` = the currently locked-in source while a preview is shown.
+ */
+export type CatenaryHighlightState = {
+    segmentNumber: number;
+    kind: 'hover' | 'selected';
+} | null;
+
+/**
+ * Preview payload emitted while the user is choosing a side.
+ */
+export type CatenaryPreviewState = {
+    segmentNumber: number;
+    side: 1 | -1;
+} | null;
+
+export class CatenaryLayoutEngine implements CatenaryLayoutContext {
+    private _trackGraph: TrackGraph;
+    private _convert2WorldPosition: (position: Point) => Point;
+
+    private _sourceSegmentNumber: number | null = null;
+    private _side: 1 | -1 = 1;
+    private _lastHoverSegmentNumber: number | null = null;
+
+    private _previewObservable: Observable<[CatenaryPreviewState]> =
+        new SynchronousObservable<[CatenaryPreviewState]>();
+
+    private _highlightObservable: Observable<[CatenaryHighlightState]> =
+        new SynchronousObservable<[CatenaryHighlightState]>();
+
+    constructor(
+        trackGraph: TrackGraph,
+        convert2WorldPosition: (position: Point) => Point
+    ) {
+        this._trackGraph = trackGraph;
+        this._convert2WorldPosition = convert2WorldPosition;
+    }
+
+    setup(): void {}
+
+    cleanup(): void {}
+
+    get hasPreview(): boolean {
+        return this._sourceSegmentNumber !== null;
+    }
+
+    convert2WorldPosition(position: Point): Point {
+        return this._convert2WorldPosition(position);
+    }
+
+    onPreviewChange(
+        observer: Observer<[CatenaryPreviewState]>,
+        options?: SubscriptionOptions
+    ) {
+        this._previewObservable.subscribe(observer, options);
+    }
+
+    onHighlightChange(
+        observer: Observer<[CatenaryHighlightState]>,
+        options?: SubscriptionOptions
+    ) {
+        this._highlightObservable.subscribe(observer, options);
+    }
+
+    updateCursor(position: Point): void {
+        if (this._sourceSegmentNumber !== null) {
+            return;
+        }
+
+        const res = this._trackGraph.project(position);
+        let hoverSegment: number | null = null;
+        if (res.hit) {
+            if (res.hitType === 'curve' || res.hitType === 'edge') {
+                hoverSegment = res.curve;
+            } else if (res.hitType === 'joint') {
+                const joint = this._trackGraph.getJoint(res.jointNumber);
+                const first = joint?.connections.values().next().value;
+                if (first !== undefined) {
+                    hoverSegment = first;
+                }
+            }
+        }
+
+        if (hoverSegment === this._lastHoverSegmentNumber) {
+            return;
+        }
+        this._lastHoverSegmentNumber = hoverSegment;
+        this._highlightObservable.notify(
+            hoverSegment === null
+                ? null
+                : { segmentNumber: hoverSegment, kind: 'hover' }
+        );
+    }
+
+    selectSource(position: Point): boolean {
+        const res = this._trackGraph.project(position);
+        if (!res.hit) {
+            return false;
+        }
+
+        let segmentNumber: number | null = null;
+        let projectionPoint: Point | null = null;
+        let tangentAtProjection: Point | null = null;
+
+        if (res.hitType === 'curve' || res.hitType === 'edge') {
+            segmentNumber = res.curve;
+            projectionPoint = res.projectionPoint;
+            tangentAtProjection = res.tangent;
+        } else if (res.hitType === 'joint') {
+            const joint = this._trackGraph.getJoint(res.jointNumber);
+            if (joint === null) return false;
+            const firstConnectedSegment = joint.connections
+                .values()
+                .next().value;
+            if (firstConnectedSegment === undefined) return false;
+            segmentNumber = firstConnectedSegment;
+            projectionPoint = res.projectionPoint;
+            tangentAtProjection = res.tangent;
+        }
+
+        if (
+            segmentNumber === null ||
+            projectionPoint === null ||
+            tangentAtProjection === null
+        ) {
+            return false;
+        }
+
+        this._sourceSegmentNumber = segmentNumber;
+        this._side = sideFromCursor(
+            position,
+            projectionPoint,
+            tangentAtProjection
+        );
+        this._lastHoverSegmentNumber = null;
+        this._highlightObservable.notify({
+            segmentNumber,
+            kind: 'selected',
+        });
+        this._emitPreview();
+        return true;
+    }
+
+    flipSide(): void {
+        this._side = this._side === 1 ? -1 : 1;
+        this._emitPreview();
+    }
+
+    commitCatenary(): boolean {
+        if (this._sourceSegmentNumber === null) {
+            return false;
+        }
+
+        const segmentNumber = this._sourceSegmentNumber;
+        const side = this._side;
+
+        this.cancelPreview();
+
+        this._commitObservable.notify({ segmentNumber, side });
+        return true;
+    }
+
+    cancelPreview(): void {
+        this._sourceSegmentNumber = null;
+        this._lastHoverSegmentNumber = null;
+        this._previewObservable.notify(null);
+        this._highlightObservable.notify(null);
+    }
+
+    // --- Commit observable (render system subscribes to this) ---
+
+    private _commitObservable: Observable<
+        [{ segmentNumber: number; side: 1 | -1 }]
+    > = new SynchronousObservable<[{ segmentNumber: number; side: 1 | -1 }]>();
+
+    onCommit(
+        observer: Observer<[{ segmentNumber: number; side: 1 | -1 }]>,
+        options?: SubscriptionOptions
+    ) {
+        this._commitObservable.subscribe(observer, options);
+    }
+
+    private _emitPreview(): void {
+        if (this._sourceSegmentNumber === null) {
+            this._previewObservable.notify(null);
+            return;
+        }
+        this._previewObservable.notify({
+            segmentNumber: this._sourceSegmentNumber,
+            side: this._side,
+        });
+    }
+}
+
+function sideFromCursor(
+    cursor: Point,
+    projection: Point,
+    tangent: Point
+): 1 | -1 {
+    const dx = cursor.x - projection.x;
+    const dy = cursor.y - projection.y;
+    const dot = dx * -tangent.y + dy * tangent.x;
+    return dot >= 0 ? 1 : -1;
+}

--- a/apps/banana/src/trains/input-state-machine/catenary-layout-state-machine.ts
+++ b/apps/banana/src/trains/input-state-machine/catenary-layout-state-machine.ts
@@ -1,0 +1,193 @@
+import type {
+    BaseContext,
+    CreateStateType,
+    EventGuards,
+    EventReactions,
+    Guard,
+    StateMachine,
+} from '@ue-too/being';
+import { NO_OP, TemplateState, TemplateStateMachine } from '@ue-too/being';
+import type { Point } from '@ue-too/math';
+
+export const CATENARY_LAYOUT_STATES = [
+    'IDLE_FOR_SOURCE',
+    'PREVIEWING',
+] as const;
+
+export type CatenaryLayoutStates = CreateStateType<
+    typeof CATENARY_LAYOUT_STATES
+>;
+
+export type CatenaryLayoutEvents = {
+    leftPointerUp: { x: number; y: number };
+    pointerMove: { x: number; y: number };
+    escapeKey: {};
+    F: {};
+    startCatenary: {};
+    endCatenary: {};
+};
+
+export interface CatenaryLayoutContext extends BaseContext {
+    /** Try to pick a segment at the given world position. Returns true if a source was selected. */
+    selectSource: (position: Point) => boolean;
+    /** Called on pointer move so the engine can track cursor position. */
+    updateCursor: (position: Point) => void;
+    /** Flip which side of the track the catenary poles are placed on. */
+    flipSide: () => void;
+    /** Commit the catenary onto the selected segment. Returns true on success. */
+    commitCatenary: () => boolean;
+    /** Discard the current preview and clear the source. */
+    cancelPreview: () => void;
+    /** Convert raw window coordinates to world space. */
+    convert2WorldPosition: (position: Point) => Point;
+    /** Whether the engine currently holds a previewable source. */
+    readonly hasPreview: boolean;
+}
+
+export class CatenaryLayoutIdleForSourceState extends TemplateState<
+    CatenaryLayoutEvents,
+    CatenaryLayoutContext,
+    CatenaryLayoutStates
+> {
+    protected _eventReactions: EventReactions<
+        CatenaryLayoutEvents,
+        CatenaryLayoutContext,
+        CatenaryLayoutStates
+    > = {
+        leftPointerUp: {
+            action: (context, event) => {
+                const position = context.convert2WorldPosition(event);
+                context.selectSource(position);
+            },
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+        pointerMove: {
+            action: (context, event) => {
+                const position = context.convert2WorldPosition(event);
+                context.updateCursor(position);
+            },
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+        startCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+        endCatenary: {
+            action: (context) => {
+                context.cancelPreview();
+            },
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+    };
+
+    protected _guards: Guard<CatenaryLayoutContext, string> = {
+        hasPreview: (context) => context.hasPreview,
+    };
+
+    protected _eventGuards: Partial<
+        EventGuards<
+            CatenaryLayoutEvents,
+            CatenaryLayoutStates,
+            CatenaryLayoutContext,
+            Guard<CatenaryLayoutContext, string>
+        >
+    > = {
+        leftPointerUp: [
+            {
+                guard: 'hasPreview',
+                target: 'PREVIEWING',
+            },
+        ],
+    };
+}
+
+export class CatenaryLayoutPreviewingState extends TemplateState<
+    CatenaryLayoutEvents,
+    CatenaryLayoutContext,
+    CatenaryLayoutStates
+> {
+    protected _eventReactions: EventReactions<
+        CatenaryLayoutEvents,
+        CatenaryLayoutContext,
+        CatenaryLayoutStates
+    > = {
+        leftPointerUp: {
+            action: (context, event) => {
+                const position = context.convert2WorldPosition(event);
+                const pickedNewSource = context.selectSource(position);
+                if (!pickedNewSource) {
+                    context.commitCatenary();
+                }
+            },
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+        pointerMove: {
+            action: (context, event) => {
+                const position = context.convert2WorldPosition(event);
+                context.updateCursor(position);
+            },
+            defaultTargetState: 'PREVIEWING',
+        },
+        F: {
+            action: (context) => {
+                context.flipSide();
+            },
+            defaultTargetState: 'PREVIEWING',
+        },
+        escapeKey: {
+            action: (context) => {
+                context.cancelPreview();
+            },
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+        endCatenary: {
+            action: (context) => {
+                context.cancelPreview();
+            },
+            defaultTargetState: 'IDLE_FOR_SOURCE',
+        },
+    };
+
+    protected _guards: Guard<CatenaryLayoutContext, string> = {
+        hasPreview: (context) => context.hasPreview,
+    };
+
+    protected _eventGuards: Partial<
+        EventGuards<
+            CatenaryLayoutEvents,
+            CatenaryLayoutStates,
+            CatenaryLayoutContext,
+            Guard<CatenaryLayoutContext, string>
+        >
+    > = {
+        leftPointerUp: [
+            {
+                guard: 'hasPreview',
+                target: 'PREVIEWING',
+            },
+        ],
+    };
+}
+
+export type CatenaryLayoutStateMachine = StateMachine<
+    CatenaryLayoutEvents,
+    CatenaryLayoutContext,
+    CatenaryLayoutStates
+>;
+
+export function createCatenaryLayoutStateMachine(
+    context: CatenaryLayoutContext
+): CatenaryLayoutStateMachine {
+    return new TemplateStateMachine<
+        CatenaryLayoutEvents,
+        CatenaryLayoutContext,
+        CatenaryLayoutStates
+    >(
+        {
+            IDLE_FOR_SOURCE: new CatenaryLayoutIdleForSourceState(),
+            PREVIEWING: new CatenaryLayoutPreviewingState(),
+        },
+        'IDLE_FOR_SOURCE',
+        context
+    );
+}

--- a/apps/banana/src/trains/input-state-machine/kmt-state-machine-extension.ts
+++ b/apps/banana/src/trains/input-state-machine/kmt-state-machine-extension.ts
@@ -6,6 +6,7 @@ import { createLayoutStateMachine } from "./utils";
 import { CurveCreationEngine } from "./curve-engine";
 import { createToolSwitcherStateMachine, ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStateMachine } from "./tool-switcher-state-machine";
 import { TrainPlacementStateMachine } from "./train-kmt-state-machine";
+import { CatenaryLayoutStateMachine } from "./catenary-layout-state-machine";
 import { DuplicateToSideStateMachine } from "./duplicate-to-side-state-machine";
 import { StationPlacementStateMachine } from "@/stations/station-placement-state-machine";
 
@@ -21,7 +22,7 @@ class KmtStateMachineExtensionIdleState extends TemplateState<KmtStateMachineEve
     private _originalEventReactions: EventReactions<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>;
     private _toolSwitcherSubStateMachine: ToolSwitcherStateMachine;
 
-    constructor(layoutSubStateMachine: LayoutStateMachine, trainSubStateMachine: TrainPlacementStateMachine, stationSubStateMachine: StationPlacementStateMachine, duplicateSubStateMachine: DuplicateToSideStateMachine) {
+    constructor(layoutSubStateMachine: LayoutStateMachine, trainSubStateMachine: TrainPlacementStateMachine, stationSubStateMachine: StationPlacementStateMachine, duplicateSubStateMachine: DuplicateToSideStateMachine, catenarySubStateMachine: CatenaryLayoutStateMachine) {
         super();
         const originalIdleState = new KmtIdleState();
         this._originalEventReactions = originalIdleState.eventReactions as unknown as EventReactions<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>;
@@ -45,7 +46,7 @@ class KmtStateMachineExtensionIdleState extends TemplateState<KmtStateMachineEve
 
         this._guards = originalIdleState.guards as unknown as Guard<KmtStateMachineExtensionContext>;
 
-        this._toolSwitcherSubStateMachine = createToolSwitcherStateMachine(layoutSubStateMachine, trainSubStateMachine, stationSubStateMachine, duplicateSubStateMachine);
+        this._toolSwitcherSubStateMachine = createToolSwitcherStateMachine(layoutSubStateMachine, trainSubStateMachine, stationSubStateMachine, duplicateSubStateMachine, catenarySubStateMachine);
     }
 
     protected _defer: Defer<KmtStateMachineExtensionContext, KmtStateMachineEventWithToolSwitcher, KmtInputStates, KmtInputEventOutputMapping> = {
@@ -109,10 +110,11 @@ export function createKmtInputStateMachineExpansion(
     trainSubStateMachine: TrainPlacementStateMachine,
     stationSubStateMachine: StationPlacementStateMachine,
     duplicateSubStateMachine: DuplicateToSideStateMachine,
+    catenarySubStateMachine: CatenaryLayoutStateMachine,
     context: KmtStateMachineExtensionContext
 ): KmtExpandedStateMachine {
     const states = {
-        IDLE: new KmtStateMachineExtensionIdleState(layoutSubStateMachine, trainSubStateMachine, stationSubStateMachine, duplicateSubStateMachine),
+        IDLE: new KmtStateMachineExtensionIdleState(layoutSubStateMachine, trainSubStateMachine, stationSubStateMachine, duplicateSubStateMachine, catenarySubStateMachine),
         READY_TO_PAN_VIA_SPACEBAR: expandState(
             new ReadyToPanViaSpaceBarState()
         ),

--- a/apps/banana/src/trains/input-state-machine/tool-switcher-state-machine.ts
+++ b/apps/banana/src/trains/input-state-machine/tool-switcher-state-machine.ts
@@ -1,10 +1,11 @@
 import { BaseContext, CreateStateType, DefaultOutputMapping, Defer, EventReactions, NO_OP, StateMachine, TemplateState, TemplateStateMachine } from "@ue-too/being";
 import { LayoutStateMachine } from "./layout-kmt-state-machine";
 import { createLayoutStateMachine, CurveCreationEngine, TrainPlacementStateMachine } from ".";
+import { CatenaryLayoutStateMachine } from "./catenary-layout-state-machine";
 import { DuplicateToSideStateMachine } from "./duplicate-to-side-state-machine";
 import { StationPlacementStateMachine } from "@/stations/station-placement-state-machine";
 
-export const TOOL_SWITCHER_STATES = ['LAYOUT', 'TRAIN', 'STATION', 'DUPLICATE', 'IDLE'] as const;
+export const TOOL_SWITCHER_STATES = ['LAYOUT', 'TRAIN', 'STATION', 'DUPLICATE', 'CATENARY', 'IDLE'] as const;
 
 export type ToolSwitcherStates = CreateStateType<typeof TOOL_SWITCHER_STATES>;
 
@@ -13,6 +14,7 @@ export type ToolSwitcherEvents = {
     "switchToTrain": {};
     "switchToStation": {};
     "switchToDuplicate": {};
+    "switchToCatenary": {};
     "switchToIdle": {};
 }
 
@@ -27,6 +29,7 @@ export type ToolSwitcherEventOutputMapping = {
     switchToTrain: void;
     switchToStation: void;
     switchToDuplicate: void;
+    switchToCatenary: void;
     switchToIdle: void;
 }
 
@@ -51,6 +54,10 @@ class ToolSwitcherIdleState extends TemplateState<ToolSwitcherEvents, ToolSwitch
         switchToDuplicate: {
             action: NO_OP,
             defaultTargetState: 'DUPLICATE',
+        },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
         },
         switchToIdle: {
             action: NO_OP,
@@ -109,6 +116,10 @@ class ToolSwitcherLayoutState extends TemplateState<ToolSwitcherEvents, ToolSwit
             action: NO_OP,
             defaultTargetState: 'DUPLICATE',
         },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
@@ -140,6 +151,10 @@ class ToolSwitcherTrainState extends TemplateState<ToolSwitcherEvents, ToolSwitc
         switchToDuplicate: {
             action: NO_OP,
             defaultTargetState: 'DUPLICATE',
+        },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
         },
         switchToIdle: {
             action: NO_OP,
@@ -195,6 +210,10 @@ class ToolSwitcherStationState extends TemplateState<ToolSwitcherEvents, ToolSwi
             action: NO_OP,
             defaultTargetState: 'DUPLICATE',
         },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
@@ -245,6 +264,10 @@ class ToolSwitcherDuplicateState extends TemplateState<ToolSwitcherEvents, ToolS
             action: NO_OP,
             defaultTargetState: 'DUPLICATE',
         },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
@@ -270,11 +293,66 @@ class ToolSwitcherDuplicateState extends TemplateState<ToolSwitcherEvents, ToolS
     };
 };
 
+class ToolSwitcherCatenaryState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+    private _catenarySubStateMachine: CatenaryLayoutStateMachine;
+
+    constructor(catenarySubStateMachine: CatenaryLayoutStateMachine) {
+        super();
+        this._catenarySubStateMachine = catenarySubStateMachine;
+    }
+
+    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+        switchToLayout: {
+            action: NO_OP,
+            defaultTargetState: 'LAYOUT',
+        },
+        switchToTrain: {
+            action: NO_OP,
+            defaultTargetState: 'TRAIN',
+        },
+        switchToStation: {
+            action: NO_OP,
+            defaultTargetState: 'STATION',
+        },
+        switchToDuplicate: {
+            action: NO_OP,
+            defaultTargetState: 'DUPLICATE',
+        },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
+        },
+        switchToIdle: {
+            action: NO_OP,
+            defaultTargetState: 'IDLE',
+        }
+    }
+
+    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
+        this._catenarySubStateMachine.happens('startCatenary');
+    }
+
+    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
+        this._catenarySubStateMachine.happens('endCatenary');
+    }
+
+    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+        action: (context, event, eventKey, stateMachine) => {
+            const result = this._catenarySubStateMachine.happens(eventKey, event);
+            if (result.handled) {
+                return { handled: true, output: result.output };
+            }
+            return { handled: false };
+        },
+    };
+};
+
 export const createToolSwitcherStateMachine = (
     layoutSubStateMachine: LayoutStateMachine,
     trainSubStateMachine: TrainPlacementStateMachine,
     stationSubStateMachine: StationPlacementStateMachine,
     duplicateSubStateMachine: DuplicateToSideStateMachine,
+    catenarySubStateMachine: CatenaryLayoutStateMachine,
 ): ToolSwitcherStateMachine => {
     return new TemplateStateMachine<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates>({
         IDLE: new ToolSwitcherIdleState(),
@@ -282,6 +360,7 @@ export const createToolSwitcherStateMachine = (
         TRAIN: new ToolSwitcherTrainState(trainSubStateMachine),
         STATION: new ToolSwitcherStationState(stationSubStateMachine),
         DUPLICATE: new ToolSwitcherDuplicateState(duplicateSubStateMachine),
+        CATENARY: new ToolSwitcherCatenaryState(catenarySubStateMachine),
     }, 'IDLE', {
         setup: () => { },
         cleanup: () => { },

--- a/apps/banana/src/trains/tracks/render-system.ts
+++ b/apps/banana/src/trains/tracks/render-system.ts
@@ -4,6 +4,7 @@ import { BCurve } from '@ue-too/curve';
 import { Point, PointCal } from '@ue-too/math';
 import { CurveCreationEngine } from '../input-state-machine';
 import { DeletionHighlightState } from '../input-state-machine/curve-engine';
+import { CatenaryHighlightState, CatenaryLayoutEngine, CatenaryPreviewState } from '../input-state-machine/catenary-layout-engine';
 import { DuplicateHighlightState, DuplicateToSideEngine } from '../input-state-machine/duplicate-to-side-engine';
 import { ELEVATION, ELEVATION_MAX, ELEVATION_MIN, ELEVATION_VALUES, ProjectionPositiveResult, TrackSegmentDrawData, TrackSegmentWithCollision, TrackStyle } from './types';
 import { LEVEL_HEIGHT } from './constants';
@@ -97,6 +98,12 @@ export class TrackRenderSystem {
 
     /** World-space overlay stroke drawn on the track under the cursor in delete mode. */
     private _deletionHighlightGraphics: Graphics = new Graphics();
+
+    /** World-space overlay stroke drawn on the track under the cursor / selected source in catenary mode. */
+    private _catenaryHighlightGraphics: Graphics = new Graphics();
+
+    /** World-space preview graphics for catenary poles while the user is choosing a side. */
+    private _catenaryPreviewGraphics: Graphics = new Graphics();
 
     private _showPreviewCurveArcs: boolean = false;
     private _latestPreviewDrawDataList:
@@ -201,6 +208,7 @@ export class TrackRenderSystem {
         textureRenderer?: TrackTextureRenderer | null,
         terrainData?: TerrainData | null,
         duplicateToSideEngine?: DuplicateToSideEngine,
+        catenaryLayoutEngine?: CatenaryLayoutEngine,
     ) {
         this._worldRenderSystem = worldRenderSystem;
         this._terrainData = terrainData ?? null;
@@ -220,9 +228,18 @@ export class TrackRenderSystem {
             duplicateToSideEngine.onPreviewDrawDataChange(this._onPreviewDrawDataChange.bind(this), { signal: this._abortController.signal });
             duplicateToSideEngine.onHighlightChange(this._onDuplicateHighlightChange.bind(this), { signal: this._abortController.signal });
         }
+        if (catenaryLayoutEngine) {
+            catenaryLayoutEngine.onHighlightChange(this._onCatenaryHighlightChange.bind(this), { signal: this._abortController.signal });
+            catenaryLayoutEngine.onPreviewChange(this._onCatenaryPreviewChange.bind(this), { signal: this._abortController.signal });
+            catenaryLayoutEngine.onCommit((payload) => {
+                this.applyCatenary(payload.segmentNumber, payload.side);
+            }, { signal: this._abortController.signal });
+        }
 
         this._topLevelContainer.addChild(this._duplicateHighlightGraphics);
         this._topLevelContainer.addChild(this._deletionHighlightGraphics);
+        this._topLevelContainer.addChild(this._catenaryHighlightGraphics);
+        this._topLevelContainer.addChild(this._catenaryPreviewGraphics);
 
         this._previewStartProjection.visible = false;
         this._previewEndProjection.visible = false;
@@ -287,6 +304,80 @@ export class TrackRenderSystem {
 
     set electrified(value: boolean) {
         this._electrified = value;
+    }
+
+    /**
+     * Apply catenary electrification to an existing track segment on a given side.
+     * Updates all draw data entries belonging to that segment, then rebuilds catenary graphics.
+     */
+    applyCatenary(segmentNumber: number, side: 1 | -1): void {
+        // Stamp the canonical segment so serialization picks it up.
+        const segment = this._trackCurveManager.getTrackSegmentWithJoints(segmentNumber);
+        if (segment) {
+            segment.electrified = true;
+            segment.catenarySide = side;
+        }
+
+        const drawDataList = this._trackCurveManager.persistedDrawData;
+        for (const drawData of drawDataList) {
+            if (drawData.originalTrackSegment.trackSegmentNumber === segmentNumber) {
+                drawData.electrified = true;
+                drawData.catenarySide = side;
+
+                const key = JSON.stringify({
+                    trackSegmentNumber: drawData.originalTrackSegment.trackSegmentNumber,
+                    tValInterval: drawData.originalTrackSegment.tValInterval,
+                });
+
+                // Remove existing catenary graphics if present.
+                const existing = this._catenaryMap.get(key);
+                if (existing !== undefined) {
+                    const removed = this._worldRenderSystem.removeFromBand(`__catenary__${key}`);
+                    removed?.destroy({ children: true });
+                    this._catenaryMap.delete(key);
+                }
+
+                // Rebuild catenary graphics on the new side.
+                const catenaryContainer = this._buildCatenaryForDrawData(drawData);
+                const bandIndex = this._drawDataBandMap.get(key);
+                if (bandIndex !== undefined) {
+                    this._worldRenderSystem.addToBand(`__catenary__${key}`, catenaryContainer, bandIndex, 'catenary');
+                    this._catenaryMap.set(key, catenaryContainer);
+                }
+            }
+        }
+    }
+
+    /**
+     * Remove catenary electrification from an existing track segment.
+     * Clears electrified/catenarySide from all draw data entries belonging to that segment.
+     */
+    removeCatenary(segmentNumber: number): void {
+        const segment = this._trackCurveManager.getTrackSegmentWithJoints(segmentNumber);
+        if (segment) {
+            segment.electrified = false;
+            segment.catenarySide = undefined;
+        }
+
+        const drawDataList = this._trackCurveManager.persistedDrawData;
+        for (const drawData of drawDataList) {
+            if (drawData.originalTrackSegment.trackSegmentNumber === segmentNumber) {
+                drawData.electrified = false;
+                drawData.catenarySide = undefined;
+
+                const key = JSON.stringify({
+                    trackSegmentNumber: drawData.originalTrackSegment.trackSegmentNumber,
+                    tValInterval: drawData.originalTrackSegment.tValInterval,
+                });
+
+                const existing = this._catenaryMap.get(key);
+                if (existing !== undefined) {
+                    const removed = this._worldRenderSystem.removeFromBand(`__catenary__${key}`);
+                    removed?.destroy({ children: true });
+                    this._catenaryMap.delete(key);
+                }
+            }
+        }
     }
 
     /** Total width of the gravel bed foundation for newly laid tracks (meters). */
@@ -619,8 +710,8 @@ export class TrackRenderSystem {
         // Mast offset from track center (outside the track).
         const mastOffset = gauge / 2 + 2;
 
-        // Alternate which side the pole appears on.
-        let side = 1;
+        // Use stored side (all poles on one side) or default to +1.
+        const side = drawData.catenarySide ?? 1;
 
         for (let i = 0; i <= poleCount; i++) {
             const t = poleCount === 0 ? 0.5 : i / poleCount;
@@ -646,8 +737,6 @@ export class TrackRenderSystem {
             // Contact wire dot at track center.
             g.circle(point.x, point.y, 0.04);
             g.fill(0x404040);
-
-            side *= -1;
         }
 
         // Draw the catenary wire along the full curve.
@@ -1874,6 +1963,84 @@ export class TrackRenderSystem {
             g.lineTo(pt.x, pt.y);
         }
         g.stroke({ color: 0xff3b30, width: 0.9, alpha: 0.85 });
+    }
+
+    private _onCatenaryHighlightChange(state: CatenaryHighlightState) {
+        const g = this._catenaryHighlightGraphics;
+        g.clear();
+        if (state === null) {
+            return;
+        }
+        const curve = this._trackCurveManager.getTrackSegment(state.segmentNumber);
+        if (curve === null) {
+            return;
+        }
+
+        const SAMPLE_COUNT = 32;
+        const first = curve.get(0);
+        g.moveTo(first.x, first.y);
+        for (let i = 1; i <= SAMPLE_COUNT; i++) {
+            const pt = curve.get(i / SAMPLE_COUNT);
+            g.lineTo(pt.x, pt.y);
+        }
+
+        if (state.kind === 'hover') {
+            g.stroke({ color: 0x66bb6a, width: 0.6, alpha: 0.75 });
+        } else {
+            g.stroke({ color: 0x43a047, width: 1.0, alpha: 0.95 });
+        }
+    }
+
+    private _onCatenaryPreviewChange(state: CatenaryPreviewState) {
+        const g = this._catenaryPreviewGraphics;
+        g.clear();
+        if (state === null) {
+            return;
+        }
+
+        const curve = this._trackCurveManager.getTrackSegment(state.segmentNumber);
+        if (curve === null) {
+            return;
+        }
+
+        // Draw a preview of poles on the chosen side.
+        const curveLength = curve.fullLength;
+        const poleSpacing = 25;
+        const poleCount = Math.max(1, Math.floor(curveLength / poleSpacing));
+        // Use the default gauge (approximation for preview).
+        const gauge = 1.067;
+        const mastOffset = gauge / 2 + 2;
+        const side = state.side;
+
+        for (let i = 0; i <= poleCount; i++) {
+            const t = poleCount === 0 ? 0.5 : i / poleCount;
+            const point = curve.getPointbyPercentage(t);
+            const derivative = curve.derivativeByPercentage(t);
+            const tangent = PointCal.unitVector(derivative);
+            const nx = -tangent.y;
+            const ny = tangent.x;
+
+            const mastX = point.x + nx * mastOffset * side;
+            const mastY = point.y + ny * mastOffset * side;
+
+            g.circle(mastX, mastY, 0.15);
+            g.fill({ color: 0x43a047, alpha: 0.7 });
+
+            g.moveTo(mastX, mastY);
+            g.lineTo(point.x, point.y);
+            g.stroke({ color: 0x66bb6a, width: 0.08, alpha: 0.6 });
+        }
+
+        // Draw wire preview.
+        const wireSteps = Math.max(10, Math.ceil(curveLength / 1));
+        const first = curve.get(0);
+        g.moveTo(first.x, first.y);
+        for (let i = 1; i <= wireSteps; i++) {
+            const t = i / wireSteps;
+            const p = curve.getPointbyPercentage(t);
+            g.lineTo(p.x, p.y);
+        }
+        g.stroke({ color: 0x43a047, width: 0.05, alpha: 0.5 });
     }
 
     private _onPreviewDrawDataChange(drawDataList: { index: number, drawData: TrackSegmentDrawData & { positiveOffsets: Point[]; negativeOffsets: Point[] } }[] | undefined) {

--- a/apps/banana/src/trains/tracks/track.ts
+++ b/apps/banana/src/trains/tracks/track.ts
@@ -1299,7 +1299,7 @@ export class TrackGraph {
                     segment.elevation.to,
                     segment.gauge,
                     segment.splits,
-                    { trackStyle: segment.trackStyle, electrified: segment.electrified, bed: segment.bed }
+                    { trackStyle: segment.trackStyle, electrified: segment.electrified, catenarySide: segment.catenarySide, bed: segment.bed }
                 );
             }
             options?.onProgress?.(end, segments.length);

--- a/apps/banana/src/trains/tracks/trackcurve-manager.ts
+++ b/apps/banana/src/trains/tracks/trackcurve-manager.ts
@@ -99,12 +99,12 @@ export class TrackCurveManager {
         return this._persistedDrawData;
     }
 
-    getVisualPropsForSegment(segmentNumber: number): { trackStyle?: TrackStyle; electrified?: boolean; bed?: boolean } | undefined {
+    getVisualPropsForSegment(segmentNumber: number): { trackStyle?: TrackStyle; electrified?: boolean; catenarySide?: 1 | -1; bed?: boolean } | undefined {
         const drawData = this._persistedDrawData.find(
             entry => entry.originalTrackSegment.trackSegmentNumber === segmentNumber
         );
         if (drawData === undefined) return undefined;
-        return { trackStyle: drawData.trackStyle, electrified: drawData.electrified, bed: drawData.bed };
+        return { trackStyle: drawData.trackStyle, electrified: drawData.electrified, catenarySide: drawData.catenarySide, bed: drawData.bed };
     }
 
     getTrackSegment(segmentNumber: number): BCurve | null {
@@ -406,7 +406,7 @@ export class TrackCurveManager {
         gauge: number = 1.067,
         excludeSegmentsForCollisionCheck: Set<number> = new Set(),
         bedWidth?: number,
-        visualProps?: { trackStyle?: TrackStyle; electrified?: boolean; bed?: boolean }
+        visualProps?: { trackStyle?: TrackStyle; electrified?: boolean; catenarySide?: 1 | -1; bed?: boolean }
     ): number {
         const experimentPositiveOffsets = offset2(curve, gauge / 2);
         const experimentNegativeOffsets = offset2(curve, -gauge / 2);
@@ -590,6 +590,7 @@ export class TrackCurveManager {
             bedWidth: bedWidth ?? (this._bedEnabled ? this._bedWidth : undefined),
             trackStyle: visualProps?.trackStyle,
             electrified: visualProps?.electrified,
+            catenarySide: visualProps?.catenarySide,
             bed: visualProps?.bed,
             splits: insertionT,
             splitCurves: splits,
@@ -953,6 +954,7 @@ export class TrackCurveManager {
                     splits: [...entity.segment.splits],
                     trackStyle: entity.segment.trackStyle ?? visualProps?.trackStyle,
                     electrified: entity.segment.electrified ?? visualProps?.electrified,
+                    catenarySide: entity.segment.catenarySide ?? visualProps?.catenarySide,
                     bed: entity.segment.bed ?? visualProps?.bed,
                 };
             });
@@ -972,7 +974,7 @@ export class TrackCurveManager {
         t1Elevation: ELEVATION,
         gauge: number,
         splitTValues: number[],
-        visualProps?: { trackStyle?: TrackStyle; electrified?: boolean; bed?: boolean }
+        visualProps?: { trackStyle?: TrackStyle; electrified?: boolean; catenarySide?: 1 | -1; bed?: boolean }
     ): void {
         const experimentPositiveOffsets = offset2(curve, gauge / 2);
         const experimentNegativeOffsets = offset2(curve, -gauge / 2);
@@ -1082,6 +1084,7 @@ export class TrackCurveManager {
             gauge,
             trackStyle: visualProps?.trackStyle,
             electrified: visualProps?.electrified,
+            catenarySide: visualProps?.catenarySide,
             bed: visualProps?.bed,
             splits: splitTValues,
             splitCurves: splits,
@@ -1142,7 +1145,7 @@ export class TrackCurveManager {
                 segment.elevation.to,
                 segment.gauge,
                 segment.splits,
-                { trackStyle: segment.trackStyle, electrified: segment.electrified, bed: segment.bed }
+                { trackStyle: segment.trackStyle, electrified: segment.electrified, catenarySide: segment.catenarySide, bed: segment.bed }
             );
         }
         return manager;

--- a/apps/banana/src/trains/tracks/types.ts
+++ b/apps/banana/src/trains/tracks/types.ts
@@ -34,6 +34,8 @@ export type TrackSegment = {
     trackStyle?: TrackStyle;
     /** Whether this track segment has overhead catenary electrification. */
     electrified?: boolean;
+    /** Which side of the track the catenary poles are placed on (1 = left, -1 = right relative to curve direction). */
+    catenarySide?: 1 | -1;
     /** Whether this track segment should render a bed (gravel foundation below the ballast). */
     bed?: boolean;
     splits: number[];
@@ -100,6 +102,8 @@ export type TrackSegmentDrawData = {
     trackStyle?: TrackStyle;
     /** Whether this track segment has overhead catenary electrification. */
     electrified?: boolean;
+    /** Which side of the track the catenary poles are placed on (1 = left, -1 = right relative to curve direction). */
+    catenarySide?: 1 | -1;
     /** Total width of the gravel bed foundation in world units (meters). Used for snapping. */
     bedWidth?: number;
     /** Whether this track segment should render a bed (gravel foundation below the ballast). */
@@ -212,6 +216,7 @@ export type SerializedTrackSegment = {
     splits: number[];
     trackStyle?: TrackStyle;
     electrified?: boolean;
+    catenarySide?: 1 | -1;
     bed?: boolean;
 };
 

--- a/apps/banana/src/trains/tracks/utils.ts
+++ b/apps/banana/src/trains/tracks/utils.ts
@@ -226,6 +226,7 @@ export const makeTrackSegmentDrawDataFromSplit = (split: TrackSegmentSplit, orig
         bedWidth: originalTrackSegment.bedWidth,
         trackStyle: originalTrackSegment.trackStyle,
         electrified: originalTrackSegment.electrified,
+        catenarySide: originalTrackSegment.catenarySide,
         bed: originalTrackSegment.bed,
     }
 };

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -7,6 +7,8 @@ import type { JointDirectionManager } from '@/trains/input-state-machine/train-k
 import { DefaultJointDirectionManager, TrainPlacementEngine, TrainPlacementStateMachine } from '@/trains/input-state-machine/train-kmt-state-machine';
 import { LayoutStateMachine } from '@/trains/input-state-machine/layout-kmt-state-machine';
 import { CurveCreationEngine } from '@/trains/input-state-machine/curve-engine';
+import { CatenaryLayoutEngine } from '@/trains/input-state-machine/catenary-layout-engine';
+import { createCatenaryLayoutStateMachine } from '@/trains/input-state-machine/catenary-layout-state-machine';
 import { DuplicateToSideEngine } from '@/trains/input-state-machine/duplicate-to-side-engine';
 import { createDuplicateToSideStateMachine } from '@/trains/input-state-machine/duplicate-to-side-state-machine';
 import { createLayoutStateMachine } from '@/trains/input-state-machine/utils';
@@ -227,6 +229,7 @@ export type BananaAppComponents = BaseAppComponents & {
   timetableRef: { current: TimetableManager };
   curveEngine: CurveCreationEngine;
   duplicateToSideEngine: DuplicateToSideEngine;
+  catenaryLayoutEngine: CatenaryLayoutEngine;
   worldRenderSystem: WorldRenderSystem;
   terrainData: TerrainData;
   terrainRenderSystem: TerrainRenderSystem;
@@ -462,6 +465,12 @@ export const initApp = async (
   );
   const duplicateSubStateMachine = createDuplicateToSideStateMachine(duplicateToSideEngine);
 
+  const catenaryLayoutEngine = new CatenaryLayoutEngine(
+    curveEngine.trackGraph,
+    (position) => curveEngine.convert2WorldPosition(position),
+  );
+  const catenarySubStateMachine = createCatenaryLayoutStateMachine(catenaryLayoutEngine);
+
   const trackRenderSystem = new TrackRenderSystem(
     worldRenderSystem,
     curveEngine.trackGraph.trackCurveManager,
@@ -470,6 +479,7 @@ export const initApp = async (
     { renderer: baseComponents.app.renderer },
     terrainData,
     duplicateToSideEngine,
+    catenaryLayoutEngine,
   );
   const buildingManager = new BuildingManager();
   const buildingRenderSystem = new BuildingRenderSystem(worldRenderSystem, buildingManager);
@@ -559,7 +569,7 @@ export const initApp = async (
     formationManager.addFormation(train.formation);
   });
 
-  const kmtInputStateMachine = createKmtInputStateMachineExpansion(layoutSubStateMachine, trainStateMachine, stationStateMachine, duplicateSubStateMachine, baseComponents.observableInputTracker);
+  const kmtInputStateMachine = createKmtInputStateMachineExpansion(layoutSubStateMachine, trainStateMachine, stationStateMachine, duplicateSubStateMachine, catenarySubStateMachine, baseComponents.observableInputTracker);
   baseComponents.kmtParser.stateMachine = kmtInputStateMachine;
   baseComponents.kmtInputStateMachine = kmtInputStateMachine;
 
@@ -666,6 +676,7 @@ export const initApp = async (
     ...baseComponents,
     curveEngine,
     duplicateToSideEngine,
+    catenaryLayoutEngine,
     worldRenderSystem,
     terrainData,
     terrainRenderSystem,


### PR DESCRIPTION
## Summary
- Add interactive catenary layout tool that lets users select existing track segments and place overhead wire poles on a chosen side
- Press F to flip pole side, click to commit — follows the same state-machine pattern as the duplicate-to-side tool
- Persists `catenarySide` on track segments through serialization so the pole side is saved/loaded correctly

## Test plan
- [ ] Activate catenary layout tool from toolbar (Zap icon in drawing category)
- [ ] Hover over tracks — green highlight appears
- [ ] Click a track — poles preview on cursor side
- [ ] Press F — poles flip to opposite side
- [ ] Click again to commit — permanent catenary rendered
- [ ] Press Esc to cancel without committing
- [ ] Save/load scene — catenary persists with correct side
- [ ] Existing tracks laid with the old electrified toggle still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)