### PR TITLE
fix(banana): place catenary poles at track edge

### DIFF
--- a/apps/banana/src/trains/tracks/render-system.ts
+++ b/apps/banana/src/trains/tracks/render-system.ts
@@ -706,9 +706,11 @@ export class TrackRenderSystem {
         const poleSpacing = 25;
         const poleCount = Math.max(1, Math.floor(curveLength / poleSpacing));
 
-        const gauge = drawData.gauge;
-        // Mast offset from track center (outside the track).
-        const mastOffset = gauge / 2 + 2;
+        // Mast offset from track center — place at the edge of the bed (or ballast when no bed).
+        const ballastHw = ballastHalfWidth(drawData);
+        const mastOffset = drawData.bed
+            ? Math.max(ballastHw, (drawData.bedWidth ?? 3) / 2)
+            : ballastHw;
 
         // Use stored side (all poles on one side) or default to +1.
         const side = drawData.catenarySide ?? 1;
@@ -2010,9 +2012,14 @@ export class TrackRenderSystem {
         const curveLength = curve.fullLength;
         const poleSpacing = 25;
         const poleCount = Math.max(1, Math.floor(curveLength / poleSpacing));
-        // Use the default gauge (approximation for preview).
-        const gauge = 1.067;
-        const mastOffset = gauge / 2 + 2;
+        const visualProps = this._trackCurveManager.getVisualPropsForSegment(state.segmentNumber);
+        const gauge = visualProps?.gauge ?? 1.067;
+        const tieOverhang = 4;
+        const tieHw = (gauge / 2) * ((TRACK_TEX_SIZE + tieOverhang * 2) / TRACK_TEX_SIZE);
+        const bHw = tieHw + 0.15;
+        const mastOffset = visualProps?.bed
+            ? Math.max(bHw, (visualProps.bedWidth ?? 3) / 2)
+            : bHw;
         const side = state.side;
 
         for (let i = 0; i <= poleCount; i++) {

--- a/apps/banana/src/trains/tracks/trackcurve-manager.ts
+++ b/apps/banana/src/trains/tracks/trackcurve-manager.ts
@@ -99,12 +99,12 @@ export class TrackCurveManager {
         return this._persistedDrawData;
     }
 
-    getVisualPropsForSegment(segmentNumber: number): { trackStyle?: TrackStyle; electrified?: boolean; catenarySide?: 1 | -1; bed?: boolean } | undefined {
+    getVisualPropsForSegment(segmentNumber: number): { trackStyle?: TrackStyle; electrified?: boolean; catenarySide?: 1 | -1; bed?: boolean; gauge?: number; bedWidth?: number } | undefined {
         const drawData = this._persistedDrawData.find(
             entry => entry.originalTrackSegment.trackSegmentNumber === segmentNumber
         );
         if (drawData === undefined) return undefined;
-        return { trackStyle: drawData.trackStyle, electrified: drawData.electrified, catenarySide: drawData.catenarySide, bed: drawData.bed };
+        return { trackStyle: drawData.trackStyle, electrified: drawData.electrified, catenarySide: drawData.catenarySide, bed: drawData.bed, gauge: drawData.gauge, bedWidth: drawData.bedWidth };
     }
 
     getTrackSegment(segmentNumber: number): BCurve | null {


### PR DESCRIPTION
## Summary
- Position catenary masts at the ballast edge (or bed edge when a bed is present) instead of a hardcoded `gauge/2 + 2` offset
- Fix the catenary placement preview to use the same edge-aligned logic by reading actual segment visual props (gauge, bed, bedWidth) from `getVisualPropsForSegment`

## Test plan
- [ ] Place catenary on a track without bed — poles should sit at the ballast edge
- [ ] Place catenary on a track with bed — poles should sit at the bed edge
- [ ] Verify the green preview poles in catenary layout mode match the final committed pole positions

🤖 Generated with [Claude Code](https://claude.com/claude-code)