### PR TITLE
feat(banana): multi-gauge track support

### DIFF
--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -14,7 +14,6 @@ import {
     Clock,
     Copy,
     Download,
-    Zap,
     FilePlus,
     FolderOpen,
     Landmark,
@@ -30,6 +29,7 @@ import {
     TrainTrack,
     Warehouse,
     X,
+    Zap,
 } from '@/assets/icons';
 import type { BuildingPreset } from '@/buildings/types';
 import { CarDefinitionLibraryDialog } from '@/components/car-definition-library/CarDefinitionLibraryDialog';
@@ -50,6 +50,7 @@ import {
 import { StationManager } from '@/stations/station-manager';
 import type { SerializedStationData } from '@/stations/types';
 import type { StoredCarDefinition } from '@/storage';
+import { useGaugeStore } from '@/stores/gauge-store';
 import { useRenderSettingsStore } from '@/stores/render-settings-store';
 import { useSceneStore } from '@/stores/scene-store';
 import {
@@ -197,6 +198,9 @@ export function BananaToolbar({
     );
     const rs = useRenderSettingsStore;
 
+    // Gauge store
+    const { selectedPresetId, customWidth, currentGauge } = useGaugeStore();
+
     // Local state that stays in the component
     const [elevation, setElevation] = useState<string>('N/A');
     const [tension, setTension] = useState<string>('1.0');
@@ -238,6 +242,11 @@ export function BananaToolbar({
             el.scrollTop + el.clientHeight < el.scrollHeight - threshold
         );
     }, []);
+
+    useEffect(() => {
+        if (!app) return;
+        app.curveEngine.setCurrentGauge(currentGauge);
+    }, [app, currentGauge]);
 
     useEffect(() => {
         const el = scrollRef.current;
@@ -751,10 +760,10 @@ export function BananaToolbar({
                     : mode === 'catenary-layout'
                       ? 'modeCatenaryLayout'
                       : mode === 'building-placement'
-                      ? 'modePlacingBuilding'
-                      : mode === 'building-deletion'
-                        ? 'modeDeletingBuilding'
-                        : null;
+                        ? 'modePlacingBuilding'
+                        : mode === 'building-deletion'
+                          ? 'modeDeletingBuilding'
+                          : null;
 
     const flyoutCategories: Record<ToolbarCategory, FlyoutCategory> = {
         drawing: {
@@ -1138,6 +1147,20 @@ export function BananaToolbar({
                         onBedChange={rs.getState().setBed}
                         bedWidth={bedWidth}
                         onBedWidthChange={rs.getState().setBedWidth}
+                        gaugePresetId={selectedPresetId}
+                        onGaugePresetChange={id => {
+                            if (id === 'custom') {
+                                useGaugeStore
+                                    .getState()
+                                    .setCustomGauge(customWidth ?? 1.0);
+                            } else {
+                                useGaugeStore.getState().selectPreset(id);
+                            }
+                        }}
+                        customGaugeWidth={customWidth}
+                        onCustomGaugeChange={w =>
+                            useGaugeStore.getState().setCustomGauge(w)
+                        }
                     />
                 </>
             )}

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -96,6 +96,7 @@ import { SunAngleControl } from './SunAngleControl';
 import { TerrainControl } from './TerrainControl';
 import { TerrainLegend } from './TerrainLegend';
 import { TimetablePanel } from './TimetablePanel';
+import { GaugeSelector } from './GaugeSelector';
 import { TrackStyleSelector } from './TrackStyleSelector';
 import { TrainPanel } from './TrainPanel';
 import { TOOLBAR_LEFT } from './types';
@@ -1163,6 +1164,29 @@ export function BananaToolbar({
                         }
                     />
                 </>
+            )}
+
+            {mode === 'station-placement' && (
+                <div className="pointer-events-auto absolute top-1/2 right-3 -translate-y-1/2">
+                    <div className="bg-background/80 flex flex-col gap-3 rounded-xl border p-3 shadow-lg backdrop-blur-sm">
+                        <GaugeSelector
+                            gaugePresetId={selectedPresetId}
+                            onGaugePresetChange={id => {
+                                if (id === 'custom') {
+                                    useGaugeStore
+                                        .getState()
+                                        .setCustomGauge(customWidth ?? 1.0);
+                                } else {
+                                    useGaugeStore.getState().selectPreset(id);
+                                }
+                            }}
+                            customGaugeWidth={customWidth}
+                            onCustomGaugeChange={w =>
+                                useGaugeStore.getState().setCustomGauge(w)
+                            }
+                        />
+                    </div>
+                </div>
             )}
 
             {showTrainPanel &&

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -162,6 +162,7 @@ export function BananaToolbar({
         whiteOcclusion,
         showJointNumbers,
         showSegmentIds,
+        showGaugeLabels,
         showFormationIds,
         showStationStops,
         showStationLocations,
@@ -184,6 +185,7 @@ export function BananaToolbar({
             whiteOcclusion: s.whiteOcclusion,
             showJointNumbers: s.showJointNumbers,
             showSegmentIds: s.showSegmentIds,
+            showGaugeLabels: s.showGaugeLabels,
             showFormationIds: s.showFormationIds,
             showStationStops: s.showStationStops,
             showStationLocations: s.showStationLocations,
@@ -1216,6 +1218,8 @@ export function BananaToolbar({
                     onShowJointNumbersChange={rs.getState().setShowJointNumbers}
                     showSegmentIds={showSegmentIds}
                     onShowSegmentIdsChange={rs.getState().setShowSegmentIds}
+                    showGaugeLabels={showGaugeLabels}
+                    onShowGaugeLabelsChange={rs.getState().setShowGaugeLabels}
                     showFormationIds={showFormationIds}
                     onShowFormationIdsChange={rs.getState().setShowFormationIds}
                     showStationStops={showStationStops}

--- a/apps/banana/src/components/toolbar/DebugPanel.tsx
+++ b/apps/banana/src/components/toolbar/DebugPanel.tsx
@@ -1,4 +1,4 @@
-import { Activity, ArrowLeftRight, CircleIcon, Crosshair, Eye, Hash, Landmark, Link2, ListOrdered, OctagonXIcon, TrainFront, MapPin } from '@/assets/icons';
+import { Activity, ArrowLeftRight, CircleIcon, Crosshair, Eye, Gauge, Hash, Landmark, Link2, ListOrdered, OctagonXIcon, TrainFront, MapPin } from '@/assets/icons';
 import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
@@ -11,6 +11,8 @@ type DebugPanelProps = {
     onShowJointNumbersChange: (value: boolean) => void;
     showSegmentIds: boolean;
     onShowSegmentIdsChange: (value: boolean) => void;
+    showGaugeLabels: boolean;
+    onShowGaugeLabelsChange: (value: boolean) => void;
     showFormationIds: boolean;
     onShowFormationIdsChange: (value: boolean) => void;
     showStationStops: boolean;
@@ -44,6 +46,8 @@ export function DebugPanel({
     onShowJointNumbersChange,
     showSegmentIds,
     onShowSegmentIdsChange,
+    showGaugeLabels,
+    onShowGaugeLabelsChange,
     showFormationIds,
     onShowFormationIdsChange,
     showStationStops,
@@ -100,6 +104,17 @@ export function DebugPanel({
                         aria-label="Toggle segment IDs"
                     >
                         <ListOrdered className="size-3.5" />
+                    </Toggle>
+                </div>
+                <div className="flex items-center justify-between gap-2 text-xs">
+                    <span className="text-foreground">{t('gaugeLabels')}</span>
+                    <Toggle
+                        size="sm"
+                        pressed={showGaugeLabels}
+                        onPressedChange={onShowGaugeLabelsChange}
+                        aria-label="Toggle gauge labels"
+                    >
+                        <Gauge className="size-3.5" />
                     </Toggle>
                 </div>
                 <div className="flex items-center justify-between gap-2 text-xs">

--- a/apps/banana/src/components/toolbar/GaugeSelector.tsx
+++ b/apps/banana/src/components/toolbar/GaugeSelector.tsx
@@ -1,0 +1,72 @@
+import { useTranslation } from 'react-i18next';
+
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { GAUGE_PRESETS } from '@/trains/tracks/gauge-presets';
+
+type GaugeSelectorProps = {
+    gaugePresetId: string;
+    onGaugePresetChange: (presetId: string) => void;
+    customGaugeWidth: number | null;
+    onCustomGaugeChange: (width: number) => void;
+};
+
+export function GaugeSelector({
+    gaugePresetId,
+    onGaugePresetChange,
+    customGaugeWidth,
+    onCustomGaugeChange,
+}: GaugeSelectorProps) {
+    const { t } = useTranslation();
+    return (
+        <div className="flex flex-col gap-2">
+            <span className="text-muted-foreground text-xs font-medium">
+                {t('trackGauge')}
+            </span>
+            <Select
+                value={gaugePresetId}
+                onValueChange={val => onGaugePresetChange(val)}
+            >
+                <SelectTrigger>
+                    <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                    {GAUGE_PRESETS.map(preset => (
+                        <SelectItem key={preset.id} value={preset.id}>
+                            {preset.name} ({preset.width}m)
+                        </SelectItem>
+                    ))}
+                    <SelectItem value="custom">
+                        {t('customGauge')}
+                    </SelectItem>
+                </SelectContent>
+            </Select>
+            {gaugePresetId === 'custom' && (
+                <div className="flex flex-col gap-1">
+                    <input
+                        type="range"
+                        min="0.5"
+                        max="3.0"
+                        step="0.01"
+                        value={customGaugeWidth ?? 1.0}
+                        onChange={e =>
+                            onCustomGaugeChange(Number(e.target.value))
+                        }
+                        onPointerUp={e =>
+                            (e.target as HTMLInputElement).blur()
+                        }
+                        className="h-1.5 w-24 cursor-pointer"
+                    />
+                    <span className="text-muted-foreground text-center text-[10px]">
+                        {(customGaugeWidth ?? 1.0).toFixed(3)}m
+                    </span>
+                </div>
+            )}
+        </div>
+    );
+}

--- a/apps/banana/src/components/toolbar/TrackStyleSelector.tsx
+++ b/apps/banana/src/components/toolbar/TrackStyleSelector.tsx
@@ -1,6 +1,13 @@
 import { useTranslation } from 'react-i18next';
 
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import {
+    Select,
+    SelectContent,
+    SelectItem,
+    SelectTrigger,
+    SelectValue,
+} from '@/components/ui/select';
+import { GAUGE_PRESETS } from '@/trains/tracks/gauge-presets';
 import type { TrackStyle } from '@/trains/tracks/types';
 
 type TrackStyleSelectorProps = {
@@ -14,6 +21,10 @@ type TrackStyleSelectorProps = {
     onBedChange: (value: boolean) => void;
     bedWidth: number;
     onBedWidthChange: (value: number) => void;
+    gaugePresetId: string;
+    onGaugePresetChange: (presetId: string) => void;
+    customGaugeWidth: number | null;
+    onCustomGaugeChange: (width: number) => void;
 };
 
 export function TrackStyleSelector({
@@ -27,6 +38,10 @@ export function TrackStyleSelector({
     onBedChange,
     bedWidth,
     onBedWidthChange,
+    gaugePresetId,
+    onGaugePresetChange,
+    customGaugeWidth,
+    onCustomGaugeChange,
 }: TrackStyleSelectorProps) {
     const { t } = useTranslation();
     return (
@@ -34,18 +49,69 @@ export function TrackStyleSelector({
             <div className="bg-background/80 flex flex-col gap-3 rounded-xl border p-3 shadow-lg backdrop-blur-sm">
                 <div className="flex flex-col gap-2">
                     <span className="text-muted-foreground text-xs font-medium">
-                        {t('trackStyle')}
+                        {t('trackGauge')}
                     </span>
-                    <Select value={value} onValueChange={(val) => onChange(val as TrackStyle)}>
+                    <Select
+                        value={gaugePresetId}
+                        onValueChange={val => onGaugePresetChange(val)}
+                    >
                         <SelectTrigger>
                             <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
-                            <SelectItem value="ballasted">{t('ballasted')}</SelectItem>
-                            <SelectItem value="slab">{t('slabElevated')}</SelectItem>
+                            {GAUGE_PRESETS.map(preset => (
+                                <SelectItem key={preset.id} value={preset.id}>
+                                    {preset.name} ({preset.width}m)
+                                </SelectItem>
+                            ))}
+                            <SelectItem value="custom">
+                                {t('customGauge')}
+                            </SelectItem>
                         </SelectContent>
                     </Select>
-                    <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                    {gaugePresetId === 'custom' && (
+                        <div className="flex flex-col gap-1">
+                            <input
+                                type="range"
+                                min="0.5"
+                                max="3.0"
+                                step="0.01"
+                                value={customGaugeWidth ?? 1.0}
+                                onChange={e =>
+                                    onCustomGaugeChange(Number(e.target.value))
+                                }
+                                onPointerUp={e =>
+                                    (e.target as HTMLInputElement).blur()
+                                }
+                                className="h-1.5 w-24 cursor-pointer"
+                            />
+                            <span className="text-muted-foreground text-center text-[10px]">
+                                {(customGaugeWidth ?? 1.0).toFixed(3)}m
+                            </span>
+                        </div>
+                    )}
+                </div>
+                <div className="flex flex-col gap-2">
+                    <span className="text-muted-foreground text-xs font-medium">
+                        {t('trackStyle')}
+                    </span>
+                    <Select
+                        value={value}
+                        onValueChange={val => onChange(val as TrackStyle)}
+                    >
+                        <SelectTrigger>
+                            <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                            <SelectItem value="ballasted">
+                                {t('ballasted')}
+                            </SelectItem>
+                            <SelectItem value="slab">
+                                {t('slabElevated')}
+                            </SelectItem>
+                        </SelectContent>
+                    </Select>
+                    <label className="flex cursor-pointer items-center gap-1.5 text-xs">
                         <input
                             type="checkbox"
                             checked={electrified}
@@ -53,9 +119,11 @@ export function TrackStyleSelector({
                             onClick={() => onElectrifiedChange(!electrified)}
                             className="size-3.5 rounded"
                         />
-                        <span className="text-foreground">{t('electrified')}</span>
+                        <span className="text-foreground">
+                            {t('electrified')}
+                        </span>
                     </label>
-                    <label className="flex items-center gap-1.5 text-xs cursor-pointer">
+                    <label className="flex cursor-pointer items-center gap-1.5 text-xs">
                         <input
                             type="checkbox"
                             checked={bed}
@@ -94,7 +162,9 @@ export function TrackStyleSelector({
                         max="3"
                         step="0.1"
                         value={projectionBuffer}
-                        onChange={e => onProjectionBufferChange(Number(e.target.value))}
+                        onChange={e =>
+                            onProjectionBufferChange(Number(e.target.value))
+                        }
                         onPointerUp={e => (e.target as HTMLInputElement).blur()}
                         className="h-1.5 w-24 cursor-pointer"
                     />

--- a/apps/banana/src/components/toolbar/TrackStyleSelector.tsx
+++ b/apps/banana/src/components/toolbar/TrackStyleSelector.tsx
@@ -7,8 +7,9 @@ import {
     SelectTrigger,
     SelectValue,
 } from '@/components/ui/select';
-import { GAUGE_PRESETS } from '@/trains/tracks/gauge-presets';
 import type { TrackStyle } from '@/trains/tracks/types';
+
+import { GaugeSelector } from './GaugeSelector';
 
 type TrackStyleSelectorProps = {
     value: TrackStyle;
@@ -47,50 +48,12 @@ export function TrackStyleSelector({
     return (
         <div className="pointer-events-auto absolute top-1/2 right-3 -translate-y-1/2">
             <div className="bg-background/80 flex flex-col gap-3 rounded-xl border p-3 shadow-lg backdrop-blur-sm">
-                <div className="flex flex-col gap-2">
-                    <span className="text-muted-foreground text-xs font-medium">
-                        {t('trackGauge')}
-                    </span>
-                    <Select
-                        value={gaugePresetId}
-                        onValueChange={val => onGaugePresetChange(val)}
-                    >
-                        <SelectTrigger>
-                            <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                            {GAUGE_PRESETS.map(preset => (
-                                <SelectItem key={preset.id} value={preset.id}>
-                                    {preset.name} ({preset.width}m)
-                                </SelectItem>
-                            ))}
-                            <SelectItem value="custom">
-                                {t('customGauge')}
-                            </SelectItem>
-                        </SelectContent>
-                    </Select>
-                    {gaugePresetId === 'custom' && (
-                        <div className="flex flex-col gap-1">
-                            <input
-                                type="range"
-                                min="0.5"
-                                max="3.0"
-                                step="0.01"
-                                value={customGaugeWidth ?? 1.0}
-                                onChange={e =>
-                                    onCustomGaugeChange(Number(e.target.value))
-                                }
-                                onPointerUp={e =>
-                                    (e.target as HTMLInputElement).blur()
-                                }
-                                className="h-1.5 w-24 cursor-pointer"
-                            />
-                            <span className="text-muted-foreground text-center text-[10px]">
-                                {(customGaugeWidth ?? 1.0).toFixed(3)}m
-                            </span>
-                        </div>
-                    )}
-                </div>
+                <GaugeSelector
+                    gaugePresetId={gaugePresetId}
+                    onGaugePresetChange={onGaugePresetChange}
+                    customGaugeWidth={customGaugeWidth}
+                    onCustomGaugeChange={onCustomGaugeChange}
+                />
                 <div className="flex flex-col gap-2">
                     <span className="text-muted-foreground text-xs font-medium">
                         {t('trackStyle')}

--- a/apps/banana/src/hooks/use-render-sync.ts
+++ b/apps/banana/src/hooks/use-render-sync.ts
@@ -73,6 +73,11 @@ export function useRenderSync(app: BananaAppComponents | null): void {
                     state.showSegmentIds
                 );
             }
+            if (state.showGaugeLabels !== prev.showGaugeLabels) {
+                app.debugOverlayRenderSystem.setShowGaugeDebug(
+                    state.showGaugeLabels
+                );
+            }
             if (state.showFormationIds !== prev.showFormationIds) {
                 app.debugOverlayRenderSystem.setShowFormationDebug(
                     state.showFormationIds
@@ -128,6 +133,7 @@ function applyAll(
     app.terrainRenderSystem.whiteOcclusion = state.whiteOcclusion;
     app.debugOverlayRenderSystem.setShowJointDebug(state.showJointNumbers);
     app.debugOverlayRenderSystem.setShowSegmentDebug(state.showSegmentIds);
+    app.debugOverlayRenderSystem.setShowGaugeDebug(state.showGaugeLabels);
     app.debugOverlayRenderSystem.setShowFormationDebug(
         state.showFormationIds
     );

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -154,6 +154,9 @@ const en = {
         bed: 'Bed',
         bedWidth: 'Bed Width',
         snapBuffer: 'Snap Buffer',
+        trackGauge: 'Track Gauge',
+        customGauge: 'Custom',
+        gaugeLabels: 'Gauge Labels',
 
         // Building Options Panel
         building: 'Building',

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -155,6 +155,9 @@ const ja = {
         bed: '路盤',
         bedWidth: '路盤幅',
         snapBuffer: 'スナップ距離',
+        trackGauge: '軌間',
+        customGauge: 'カスタム',
+        gaugeLabels: '軌間ラベル',
 
         // Building Options Panel
         building: '建物',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -152,6 +152,9 @@ const zhTW = {
         bed: '路基',
         bedWidth: '路基寬度',
         snapBuffer: '吸附距離',
+        trackGauge: '軌距',
+        customGauge: '自訂',
+        gaugeLabels: '軌距標籤',
 
         // Building Options Panel
         building: '建築',

--- a/apps/banana/src/stations/station-factory.ts
+++ b/apps/banana/src/stations/station-factory.ts
@@ -1,7 +1,10 @@
 import type { Point } from '@ue-too/math';
 import { PointCal } from '@ue-too/math';
+
 import type { TrackGraph } from '@/trains/tracks/track';
 import type { ELEVATION } from '@/trains/tracks/types';
+import { DEFAULT_GAUGE_PRESET } from '@/trains/tracks/gauge-presets';
+
 import type { StationManager } from './station-manager';
 import type { Platform, StopPosition } from './types';
 
@@ -9,27 +12,28 @@ import type { Platform, StopPosition } from './types';
  * Must be larger than ballast half-width (~0.75m) to create a gap between track and platform. */
 const DEFAULT_PLATFORM_OFFSET = 1.2;
 
-/** Default track gauge in meters (narrow gauge, matches the rest of the app). */
-const DEFAULT_GAUGE = 1.067;
+/** Default track gauge in meters (from preset registry). */
+const DEFAULT_GAUGE = DEFAULT_GAUGE_PRESET.width;
 
 /** Default platform width (meters). Typical island platform is ~8–10m wide. */
 const DEFAULT_PLATFORM_WIDTH = 8;
 
 /** Distance between the two track centerlines of an island-platform station (meters). */
-const DEFAULT_TRACK_SPACING = DEFAULT_PLATFORM_WIDTH + 2 * DEFAULT_PLATFORM_OFFSET;
+const DEFAULT_TRACK_SPACING =
+    DEFAULT_PLATFORM_WIDTH + 2 * DEFAULT_PLATFORM_OFFSET;
 
 export type CreateIslandStationOptions = {
-  /** Center position of the station in world coordinates. */
-  position: Point;
-  /** Unit tangent direction the tracks run along. */
-  direction: Point;
-  /** Length of the station / platform (meters). */
-  length: number;
-  elevation: ELEVATION;
-  name?: string;
-  gauge?: number;
-  trackSpacing?: number;
-  platformOffset?: number;
+    /** Center position of the station in world coordinates. */
+    position: Point;
+    /** Unit tangent direction the tracks run along. */
+    direction: Point;
+    /** Length of the station / platform (meters). */
+    length: number;
+    elevation: ELEVATION;
+    name?: string;
+    gauge?: number;
+    trackSpacing?: number;
+    platformOffset?: number;
 };
 
 /**
@@ -41,105 +45,111 @@ export type CreateIslandStationOptions = {
  * Side-effects: creates 4 joints and 2 track segments in the TrackGraph.
  */
 export function createIslandStation(
-  trackGraph: TrackGraph,
-  stationManager: StationManager,
-  options: CreateIslandStationOptions,
+    trackGraph: TrackGraph,
+    stationManager: StationManager,
+    options: CreateIslandStationOptions
 ): number {
-  const {
-    position,
-    direction,
-    length,
-    elevation,
-    name = 'Station',
-    gauge = DEFAULT_GAUGE,
-    trackSpacing = DEFAULT_TRACK_SPACING,
-    platformOffset = DEFAULT_PLATFORM_OFFSET,
-  } = options;
+    const {
+        position,
+        direction,
+        length,
+        elevation,
+        name = 'Station',
+        gauge = DEFAULT_GAUGE,
+        trackSpacing = DEFAULT_TRACK_SPACING,
+        platformOffset = DEFAULT_PLATFORM_OFFSET,
+    } = options;
 
-  const dir = PointCal.unitVector(direction);
-  // Normal is perpendicular to the track direction (rotated 90° CCW).
-  const normal: Point = { x: -dir.y, y: dir.x };
+    const dir = PointCal.unitVector(direction);
+    // Normal is perpendicular to the track direction (rotated 90° CCW).
+    const normal: Point = { x: -dir.y, y: dir.x };
 
-  const halfLength = length / 2;
-  const halfSpacing = trackSpacing / 2;
+    const halfLength = length / 2;
+    const halfSpacing = trackSpacing / 2;
 
-  // ----- Track 1 (left of center) -----
-  const t1Start: Point = {
-    x: position.x + dir.x * -halfLength + normal.x * halfSpacing,
-    y: position.y + dir.y * -halfLength + normal.y * halfSpacing,
-  };
-  const t1End: Point = {
-    x: position.x + dir.x * halfLength + normal.x * halfSpacing,
-    y: position.y + dir.y * halfLength + normal.y * halfSpacing,
-  };
+    // ----- Track 1 (left of center) -----
+    const t1Start: Point = {
+        x: position.x + dir.x * -halfLength + normal.x * halfSpacing,
+        y: position.y + dir.y * -halfLength + normal.y * halfSpacing,
+    };
+    const t1End: Point = {
+        x: position.x + dir.x * halfLength + normal.x * halfSpacing,
+        y: position.y + dir.y * halfLength + normal.y * halfSpacing,
+    };
 
-  // ----- Track 2 (right of center) -----
-  const t2Start: Point = {
-    x: position.x + dir.x * -halfLength + normal.x * -halfSpacing,
-    y: position.y + dir.y * -halfLength + normal.y * -halfSpacing,
-  };
-  const t2End: Point = {
-    x: position.x + dir.x * halfLength + normal.x * -halfSpacing,
-    y: position.y + dir.y * halfLength + normal.y * -halfSpacing,
-  };
+    // ----- Track 2 (right of center) -----
+    const t2Start: Point = {
+        x: position.x + dir.x * -halfLength + normal.x * -halfSpacing,
+        y: position.y + dir.y * -halfLength + normal.y * -halfSpacing,
+    };
+    const t2End: Point = {
+        x: position.x + dir.x * halfLength + normal.x * -halfSpacing,
+        y: position.y + dir.y * halfLength + normal.y * -halfSpacing,
+    };
 
-  // Create joints (empty, at station elevation)
-  const j1Start = trackGraph.createNewEmptyJoint(t1Start, dir, elevation);
-  const j1End = trackGraph.createNewEmptyJoint(t1End, dir, elevation);
-  const j2Start = trackGraph.createNewEmptyJoint(t2Start, dir, elevation);
-  const j2End = trackGraph.createNewEmptyJoint(t2End, dir, elevation);
+    // Create joints (empty, at station elevation)
+    const j1Start = trackGraph.createNewEmptyJoint(t1Start, dir, elevation);
+    const j1End = trackGraph.createNewEmptyJoint(t1End, dir, elevation);
+    const j2Start = trackGraph.createNewEmptyJoint(t2Start, dir, elevation);
+    const j2End = trackGraph.createNewEmptyJoint(t2End, dir, elevation);
 
-  // Connect joints with straight segments (one midpoint control point for a valid quadratic BCurve)
-  const t1Mid: Point = { x: (t1Start.x + t1End.x) / 2, y: (t1Start.y + t1End.y) / 2 };
-  const t2Mid: Point = { x: (t2Start.x + t2End.x) / 2, y: (t2Start.y + t2End.y) / 2 };
-  trackGraph.connectJoints(j1Start, j1End, [t1Mid], gauge);
-  trackGraph.connectJoints(j2Start, j2End, [t2Mid], gauge);
+    // Connect joints with straight segments (one midpoint control point for a valid quadratic BCurve)
+    const t1Mid: Point = {
+        x: (t1Start.x + t1End.x) / 2,
+        y: (t1Start.y + t1End.y) / 2,
+    };
+    const t2Mid: Point = {
+        x: (t2Start.x + t2End.x) / 2,
+        y: (t2Start.y + t2End.y) / 2,
+    };
+    trackGraph.connectJoints(j1Start, j1End, [t1Mid], gauge);
+    trackGraph.connectJoints(j2Start, j2End, [t2Mid], gauge);
 
-  // Resolve segment IDs from the joints' connection maps
-  const j1StartJoint = trackGraph.getJoint(j1Start)!;
-  const j2StartJoint = trackGraph.getJoint(j2Start)!;
-  const seg1 = j1StartJoint.connections.get(j1End)!;
-  const seg2 = j2StartJoint.connections.get(j2End)!;
+    // Resolve segment IDs from the joints' connection maps
+    const j1StartJoint = trackGraph.getJoint(j1Start)!;
+    const j2StartJoint = trackGraph.getJoint(j2Start)!;
+    const seg1 = j1StartJoint.connections.get(j1End)!;
+    const seg2 = j2StartJoint.connections.get(j2End)!;
 
-  const joints = [j1Start, j1End, j2Start, j2End];
-  const trackSegments = [seg1, seg2];
+    const joints = [j1Start, j1End, j2Start, j2End];
+    const trackSegments = [seg1, seg2];
 
-  const platformWidth = (trackSpacing - 2 * platformOffset) / 2;
+    const platformWidth = (trackSpacing - 2 * platformOffset) / 2;
 
-  // Platform 1: serves track 1, extends toward center (negative normal = -1)
-  const platform1: Platform = {
-    id: 0,
-    track: seg1,
-    width: platformWidth,
-    offset: platformOffset,
-    side: -1,
-    stopPositions: [
-      { trackSegmentId: seg1, direction: 'tangent', tValue: 0.5 },
-      { trackSegmentId: seg1, direction: 'reverseTangent', tValue: 0.5 },
-    ],
-  };
+    // Platform 1: serves track 1, extends toward center (negative normal = -1)
+    const platform1: Platform = {
+        id: 0,
+        track: seg1,
+        width: platformWidth,
+        offset: platformOffset,
+        side: -1,
+        stopPositions: [
+            { trackSegmentId: seg1, direction: 'tangent', tValue: 0.5 },
+            { trackSegmentId: seg1, direction: 'reverseTangent', tValue: 0.5 },
+        ],
+    };
 
-  // Platform 2: serves track 2, extends toward center (positive normal = 1)
-  const platform2: Platform = {
-    id: 1,
-    track: seg2,
-    width: platformWidth,
-    offset: platformOffset,
-    side: 1,
-    stopPositions: [
-      { trackSegmentId: seg2, direction: 'tangent', tValue: 0.5 },
-      { trackSegmentId: seg2, direction: 'reverseTangent', tValue: 0.5 },
-    ],
-  };
+    // Platform 2: serves track 2, extends toward center (positive normal = 1)
+    const platform2: Platform = {
+        id: 1,
+        track: seg2,
+        width: platformWidth,
+        offset: platformOffset,
+        side: 1,
+        stopPositions: [
+            { trackSegmentId: seg2, direction: 'tangent', tValue: 0.5 },
+            { trackSegmentId: seg2, direction: 'reverseTangent', tValue: 0.5 },
+        ],
+    };
 
-  const stationId = stationManager.createStation({
-    name,
-    position,
-    elevation,
-    platforms: [platform1, platform2],
-    trackSegments,
-    joints,
-  });
+    const stationId = stationManager.createStation({
+        name,
+        position,
+        elevation,
+        platforms: [platform1, platform2],
+        trackSegments,
+        joints,
+    });
 
-  return stationId;
+    return stationId;
 }

--- a/apps/banana/src/stations/station-placement-state-machine.ts
+++ b/apps/banana/src/stations/station-placement-state-machine.ts
@@ -1,42 +1,49 @@
 import {
-  BaseContext,
-  EventReactions,
-  NO_OP,
-  TemplateState,
-  TemplateStateMachine,
+    BaseContext,
+    EventReactions,
+    NO_OP,
+    TemplateState,
+    TemplateStateMachine,
 } from '@ue-too/being';
+import {
+    Canvas,
+    ObservableBoardCamera,
+    ObservableInputTracker,
+    convertFromCanvas2ViewPort,
+    convertFromCanvas2Window,
+    convertFromViewPort2Canvas,
+    convertFromViewport2World,
+    convertFromWindow2Canvas,
+    convertFromWorld2Viewport,
+} from '@ue-too/board';
 import type { Point } from '@ue-too/math';
 import { PointCal } from '@ue-too/math';
-import {
-  Canvas,
-  ObservableBoardCamera,
-  ObservableInputTracker,
-  convertFromCanvas2ViewPort,
-  convertFromCanvas2Window,
-  convertFromViewPort2Canvas,
-  convertFromViewport2World,
-  convertFromWindow2Canvas,
-  convertFromWorld2Viewport,
-} from '@ue-too/board';
+
 import type { TrackGraph } from '@/trains/tracks/track';
 import { ELEVATION } from '@/trains/tracks/types';
+
+import { useGaugeStore } from '@/stores/gauge-store';
+
+import { createIslandStation } from './station-factory';
 import type { StationManager } from './station-manager';
 import type { StationRenderSystem } from './station-render-system';
-import { createIslandStation } from './station-factory';
 
 // ---------------------------------------------------------------------------
 // States & Events
 // ---------------------------------------------------------------------------
 
-export type StationPlacementStates = 'IDLE' | 'HOVER_FOR_START' | 'HOVER_FOR_END';
+export type StationPlacementStates =
+    | 'IDLE'
+    | 'HOVER_FOR_START'
+    | 'HOVER_FOR_END';
 
 export type StationPlacementEvents = {
-  leftPointerDown: { x: number; y: number };
-  leftPointerUp: { x: number; y: number };
-  pointerMove: { x: number; y: number };
-  escapeKey: {};
-  startPlacement: {};
-  endPlacement: {};
+    leftPointerDown: { x: number; y: number };
+    leftPointerUp: { x: number; y: number };
+    pointerMove: { x: number; y: number };
+    escapeKey: {};
+    startPlacement: {};
+    endPlacement: {};
 };
 
 // ---------------------------------------------------------------------------
@@ -44,12 +51,12 @@ export type StationPlacementEvents = {
 // ---------------------------------------------------------------------------
 
 export interface StationPlacementContext extends BaseContext {
-  startDrag: (position: Point) => void;
-  updateDrag: (position: Point) => void;
-  finishDrag: (position: Point) => void;
-  cancelPlacement: () => void;
-  convert2WorldPosition: (position: Point) => Point;
-  convert2WindowPosition: (position: Point) => Point;
+    startDrag: (position: Point) => void;
+    updateDrag: (position: Point) => void;
+    finishDrag: (position: Point) => void;
+    cancelPlacement: () => void;
+    convert2WorldPosition: (position: Point) => Point;
+    convert2WindowPosition: (position: Point) => Point;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,134 +64,135 @@ export interface StationPlacementContext extends BaseContext {
 // ---------------------------------------------------------------------------
 
 export class StationPlacementEngine
-  extends ObservableInputTracker
-  implements StationPlacementContext
+    extends ObservableInputTracker
+    implements StationPlacementContext
 {
-  private _trackGraph: TrackGraph;
-  private _stationManager: StationManager;
-  private _stationRenderSystem: StationRenderSystem;
-  private _camera: ObservableBoardCamera;
+    private _trackGraph: TrackGraph;
+    private _stationManager: StationManager;
+    private _stationRenderSystem: StationRenderSystem;
+    private _camera: ObservableBoardCamera;
 
-  private _dragStart: Point | null = null;
-  /** Track spacing matching the factory defaults (platformWidth + 2*offset). */
-  /** Track spacing matching the factory defaults (platformWidth + 2*offset = 8 + 2*1.2). */
-  private _trackSpacing = 10.4;
+    private _dragStart: Point | null = null;
+    /** Track spacing matching the factory defaults (platformWidth + 2*offset). */
+    /** Track spacing matching the factory defaults (platformWidth + 2*offset = 8 + 2*1.2). */
+    private _trackSpacing = 10.4;
 
-  constructor(
-    canvas: Canvas,
-    trackGraph: TrackGraph,
-    camera: ObservableBoardCamera,
-    stationManager: StationManager,
-    stationRenderSystem: StationRenderSystem,
-  ) {
-    super(canvas);
-    this._trackGraph = trackGraph;
-    this._camera = camera;
-    this._stationManager = stationManager;
-    this._stationRenderSystem = stationRenderSystem;
-  }
+    constructor(
+        canvas: Canvas,
+        trackGraph: TrackGraph,
+        camera: ObservableBoardCamera,
+        stationManager: StationManager,
+        stationRenderSystem: StationRenderSystem
+    ) {
+        super(canvas);
+        this._trackGraph = trackGraph;
+        this._camera = camera;
+        this._stationManager = stationManager;
+        this._stationRenderSystem = stationRenderSystem;
+    }
 
-  startDrag(position: Point): void {
-    this._dragStart = position;
-    this._stationRenderSystem.showPreview(
-      position,
-      { x: 1, y: 0 },
-      0.5,
-      this._trackSpacing,
-    );
-  }
+    startDrag(position: Point): void {
+        this._dragStart = position;
+        this._stationRenderSystem.showPreview(
+            position,
+            { x: 1, y: 0 },
+            0.5,
+            this._trackSpacing
+        );
+    }
 
-  updateDrag(position: Point): void {
-    if (this._dragStart === null) return;
+    updateDrag(position: Point): void {
+        if (this._dragStart === null) return;
 
-    const dx = position.x - this._dragStart.x;
-    const dy = position.y - this._dragStart.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
+        const dx = position.x - this._dragStart.x;
+        const dy = position.y - this._dragStart.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
 
-    if (dist < 0.5) return;
+        if (dist < 0.5) return;
 
-    const direction = { x: dx / dist, y: dy / dist };
-    const center = {
-      x: (this._dragStart.x + position.x) / 2,
-      y: (this._dragStart.y + position.y) / 2,
-    };
+        const direction = { x: dx / dist, y: dy / dist };
+        const center = {
+            x: (this._dragStart.x + position.x) / 2,
+            y: (this._dragStart.y + position.y) / 2,
+        };
 
-    this._stationRenderSystem.showPreview(
-      center,
-      direction,
-      dist,
-      this._trackSpacing,
-    );
-  }
+        this._stationRenderSystem.showPreview(
+            center,
+            direction,
+            dist,
+            this._trackSpacing
+        );
+    }
 
-  finishDrag(position: Point): void {
-    if (this._dragStart === null) return;
+    finishDrag(position: Point): void {
+        if (this._dragStart === null) return;
 
-    const start = this._dragStart;
-    const dx = position.x - start.x;
-    const dy = position.y - start.y;
-    const dist = Math.sqrt(dx * dx + dy * dy);
+        const start = this._dragStart;
+        const dx = position.x - start.x;
+        const dy = position.y - start.y;
+        const dist = Math.sqrt(dx * dx + dy * dy);
 
-    this._stationRenderSystem.hidePreview();
-    this._dragStart = null;
+        this._stationRenderSystem.hidePreview();
+        this._dragStart = null;
 
-    if (dist < 2) return; // too short, cancel
+        if (dist < 2) return; // too short, cancel
 
-    const direction = { x: dx / dist, y: dy / dist };
-    const center = {
-      x: (start.x + position.x) / 2,
-      y: (start.y + position.y) / 2,
-    };
+        const direction = { x: dx / dist, y: dy / dist };
+        const center = {
+            x: (start.x + position.x) / 2,
+            y: (start.y + position.y) / 2,
+        };
 
-    const stationId = createIslandStation(
-      this._trackGraph,
-      this._stationManager,
-      {
-        position: center,
-        direction,
-        length: dist,
-        elevation: ELEVATION.GROUND,
-      },
-    );
-    this._stationRenderSystem.addStation(stationId);
-  }
+        const stationId = createIslandStation(
+            this._trackGraph,
+            this._stationManager,
+            {
+                position: center,
+                direction,
+                length: dist,
+                elevation: ELEVATION.GROUND,
+                gauge: useGaugeStore.getState().currentGauge,
+            }
+        );
+        this._stationRenderSystem.addStation(stationId);
+    }
 
-  cancelPlacement(): void {
-    this._stationRenderSystem.hidePreview();
-    this._dragStart = null;
-  }
+    cancelPlacement(): void {
+        this._stationRenderSystem.hidePreview();
+        this._dragStart = null;
+    }
 
-  setup(): void {}
-  cleanup(): void {}
+    setup(): void {}
+    cleanup(): void {}
 
-  convert2WorldPosition(position: Point): Point {
-    const pointInCanvas = convertFromWindow2Canvas(position, this.canvas);
-    const pointInViewPort = convertFromCanvas2ViewPort(pointInCanvas, {
-      x: this.canvas.width / 2,
-      y: this.canvas.height / 2,
-    });
-    return convertFromViewport2World(
-      pointInViewPort,
-      this._camera.position,
-      this._camera.zoomLevel,
-      this._camera.rotation,
-      false,
-    );
-  }
+    convert2WorldPosition(position: Point): Point {
+        const pointInCanvas = convertFromWindow2Canvas(position, this.canvas);
+        const pointInViewPort = convertFromCanvas2ViewPort(pointInCanvas, {
+            x: this.canvas.width / 2,
+            y: this.canvas.height / 2,
+        });
+        return convertFromViewport2World(
+            pointInViewPort,
+            this._camera.position,
+            this._camera.zoomLevel,
+            this._camera.rotation,
+            false
+        );
+    }
 
-  convert2WindowPosition(position: Point): Point {
-    const pointInViewPort = convertFromWorld2Viewport(
-      position,
-      this._camera.position,
-      this._camera.zoomLevel,
-      this._camera.rotation,
-    );
-    const pointInCanvas = convertFromViewPort2Canvas(pointInViewPort, {
-      x: this.canvas.width / 2,
-      y: this.canvas.height / 2,
-    });
-    return convertFromCanvas2Window(pointInCanvas, this.canvas);
-  }
+    convert2WindowPosition(position: Point): Point {
+        const pointInViewPort = convertFromWorld2Viewport(
+            position,
+            this._camera.position,
+            this._camera.zoomLevel,
+            this._camera.rotation
+        );
+        const pointInCanvas = convertFromViewPort2Canvas(pointInViewPort, {
+            x: this.canvas.width / 2,
+            y: this.canvas.height / 2,
+        });
+        return convertFromCanvas2Window(pointInCanvas, this.canvas);
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -192,85 +200,94 @@ export class StationPlacementEngine
 // ---------------------------------------------------------------------------
 
 class StationPlacementIdleState extends TemplateState<
-  StationPlacementEvents,
-  StationPlacementContext,
-  StationPlacementStates
-> {
-  protected _eventReactions: EventReactions<
     StationPlacementEvents,
     StationPlacementContext,
     StationPlacementStates
-  > = {
-    startPlacement: {
-      action: NO_OP,
-      defaultTargetState: 'HOVER_FOR_START',
-    },
-  };
+> {
+    protected _eventReactions: EventReactions<
+        StationPlacementEvents,
+        StationPlacementContext,
+        StationPlacementStates
+    > = {
+        startPlacement: {
+            action: NO_OP,
+            defaultTargetState: 'HOVER_FOR_START',
+        },
+    };
 }
 
 /** Waiting for the first click to set the start point. */
 class StationPlacementHoverForStartState extends TemplateState<
-  StationPlacementEvents,
-  StationPlacementContext,
-  StationPlacementStates
-> {
-  protected _eventReactions: EventReactions<
     StationPlacementEvents,
     StationPlacementContext,
     StationPlacementStates
-  > = {
-    leftPointerUp: {
-      action: (context, event) => {
-        const worldPos = context.convert2WorldPosition({ x: event.x, y: event.y });
-        context.startDrag(worldPos);
-      },
-      defaultTargetState: 'HOVER_FOR_END',
-    },
-    endPlacement: {
-      action: (context) => context.cancelPlacement(),
-      defaultTargetState: 'IDLE',
-    },
-    escapeKey: {
-      action: (context) => context.cancelPlacement(),
-      defaultTargetState: 'IDLE',
-    },
-  };
+> {
+    protected _eventReactions: EventReactions<
+        StationPlacementEvents,
+        StationPlacementContext,
+        StationPlacementStates
+    > = {
+        leftPointerUp: {
+            action: (context, event) => {
+                const worldPos = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                context.startDrag(worldPos);
+            },
+            defaultTargetState: 'HOVER_FOR_END',
+        },
+        endPlacement: {
+            action: context => context.cancelPlacement(),
+            defaultTargetState: 'IDLE',
+        },
+        escapeKey: {
+            action: context => context.cancelPlacement(),
+            defaultTargetState: 'IDLE',
+        },
+    };
 }
 
 /** Start point set; following pointer to show preview. Click to place. */
 class StationPlacementHoverForEndState extends TemplateState<
-  StationPlacementEvents,
-  StationPlacementContext,
-  StationPlacementStates
-> {
-  protected _eventReactions: EventReactions<
     StationPlacementEvents,
     StationPlacementContext,
     StationPlacementStates
-  > = {
-    pointerMove: {
-      action: (context, event) => {
-        const worldPos = context.convert2WorldPosition({ x: event.x, y: event.y });
-        context.updateDrag(worldPos);
-      },
-      defaultTargetState: 'HOVER_FOR_END',
-    },
-    leftPointerUp: {
-      action: (context, event) => {
-        const worldPos = context.convert2WorldPosition({ x: event.x, y: event.y });
-        context.finishDrag(worldPos);
-      },
-      defaultTargetState: 'HOVER_FOR_START',
-    },
-    escapeKey: {
-      action: (context) => context.cancelPlacement(),
-      defaultTargetState: 'HOVER_FOR_START',
-    },
-    endPlacement: {
-      action: (context) => context.cancelPlacement(),
-      defaultTargetState: 'IDLE',
-    },
-  };
+> {
+    protected _eventReactions: EventReactions<
+        StationPlacementEvents,
+        StationPlacementContext,
+        StationPlacementStates
+    > = {
+        pointerMove: {
+            action: (context, event) => {
+                const worldPos = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                context.updateDrag(worldPos);
+            },
+            defaultTargetState: 'HOVER_FOR_END',
+        },
+        leftPointerUp: {
+            action: (context, event) => {
+                const worldPos = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                context.finishDrag(worldPos);
+            },
+            defaultTargetState: 'HOVER_FOR_START',
+        },
+        escapeKey: {
+            action: context => context.cancelPlacement(),
+            defaultTargetState: 'HOVER_FOR_START',
+        },
+        endPlacement: {
+            action: context => context.cancelPlacement(),
+            defaultTargetState: 'IDLE',
+        },
+    };
 }
 
 // ---------------------------------------------------------------------------
@@ -278,19 +295,19 @@ class StationPlacementHoverForEndState extends TemplateState<
 // ---------------------------------------------------------------------------
 
 export class StationPlacementStateMachine extends TemplateStateMachine<
-  StationPlacementEvents,
-  StationPlacementContext,
-  StationPlacementStates
+    StationPlacementEvents,
+    StationPlacementContext,
+    StationPlacementStates
 > {
-  constructor(context: StationPlacementContext) {
-    super(
-      {
-        IDLE: new StationPlacementIdleState(),
-        HOVER_FOR_START: new StationPlacementHoverForStartState(),
-        HOVER_FOR_END: new StationPlacementHoverForEndState(),
-      },
-      'IDLE',
-      context,
-    );
-  }
+    constructor(context: StationPlacementContext) {
+        super(
+            {
+                IDLE: new StationPlacementIdleState(),
+                HOVER_FOR_START: new StationPlacementHoverForStartState(),
+                HOVER_FOR_END: new StationPlacementHoverForEndState(),
+            },
+            'IDLE',
+            context
+        );
+    }
 }

--- a/apps/banana/src/stores/gauge-store.ts
+++ b/apps/banana/src/stores/gauge-store.ts
@@ -1,0 +1,53 @@
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+import { GAUGE_PRESETS, DEFAULT_GAUGE_PRESET } from '@/trains/tracks/gauge-presets';
+
+const MIN_CUSTOM_GAUGE = 0.5;
+const MAX_CUSTOM_GAUGE = 3.0;
+
+type GaugeState = {
+    selectedPresetId: string;
+    customWidth: number | null;
+    currentGauge: number;
+};
+
+type GaugeActions = {
+    selectPreset: (presetId: string) => void;
+    setCustomGauge: (width: number) => void;
+};
+
+export type GaugeStore = GaugeState & GaugeActions;
+
+export const useGaugeStore = create<GaugeStore>()(
+    devtools(
+        (set, get) => ({
+            selectedPresetId: DEFAULT_GAUGE_PRESET.id,
+            customWidth: null,
+            currentGauge: DEFAULT_GAUGE_PRESET.width,
+
+            selectPreset: (presetId: string) => {
+                const preset = GAUGE_PRESETS.find((p) => p.id === presetId);
+                if (!preset) return;
+                set({
+                    selectedPresetId: preset.id,
+                    customWidth: null,
+                    currentGauge: preset.width,
+                });
+            },
+
+            setCustomGauge: (width: number) => {
+                const clamped = Math.min(
+                    MAX_CUSTOM_GAUGE,
+                    Math.max(MIN_CUSTOM_GAUGE, width)
+                );
+                set({
+                    selectedPresetId: 'custom',
+                    customWidth: clamped,
+                    currentGauge: clamped,
+                });
+            },
+        }),
+        { name: 'banana-gauge' }
+    )
+);

--- a/apps/banana/src/stores/render-settings-store.ts
+++ b/apps/banana/src/stores/render-settings-store.ts
@@ -18,6 +18,7 @@ type RenderSettingsState = {
     whiteOcclusion: boolean;
     showJointNumbers: boolean;
     showSegmentIds: boolean;
+    showGaugeLabels: boolean;
     showFormationIds: boolean;
     showStationStops: boolean;
     showStationLocations: boolean;
@@ -41,6 +42,7 @@ type RenderSettingsActions = {
     setWhiteOcclusion: (v: boolean) => void;
     setShowJointNumbers: (v: boolean) => void;
     setShowSegmentIds: (v: boolean) => void;
+    setShowGaugeLabels: (v: boolean) => void;
     setShowFormationIds: (v: boolean) => void;
     setShowStationStops: (v: boolean) => void;
     setShowStationLocations: (v: boolean) => void;
@@ -69,6 +71,7 @@ export const useRenderSettingsStore = create<RenderSettingsStore>()(
             whiteOcclusion: false,
             showJointNumbers: false,
             showSegmentIds: false,
+            showGaugeLabels: false,
             showFormationIds: false,
             showStationStops: false,
             showStationLocations: false,
@@ -91,6 +94,7 @@ export const useRenderSettingsStore = create<RenderSettingsStore>()(
             setWhiteOcclusion: (v) => set({ whiteOcclusion: v }),
             setShowJointNumbers: (v) => set({ showJointNumbers: v }),
             setShowSegmentIds: (v) => set({ showSegmentIds: v }),
+            setShowGaugeLabels: (v) => set({ showGaugeLabels: v }),
             setShowFormationIds: (v) => set({ showFormationIds: v }),
             setShowStationStops: (v) => set({ showStationStops: v }),
             setShowStationLocations: (v) => set({ showStationLocations: v }),

--- a/apps/banana/src/trains/input-state-machine/curve-engine.ts
+++ b/apps/banana/src/trains/input-state-machine/curve-engine.ts
@@ -569,6 +569,17 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 this.cancelCurrentCurve();
                 return null;
             }
+            if (
+                !gaugesAreCompatible(
+                    this._newStartJoint.constraint.jointNumber,
+                    this._previewCurveGauge,
+                    this._trackGraph
+                )
+            ) {
+                console.warn('gauge mismatch at start joint');
+                this.cancelCurrentCurve();
+                return null;
+            }
         }
 
         if (this._newEndJoint.type === 'extendingTrack') {
@@ -591,6 +602,17 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 )
             ) {
                 console.warn('extend track not possible for end joint');
+                this.cancelCurrentCurve();
+                return null;
+            }
+            if (
+                !gaugesAreCompatible(
+                    this._newEndJoint.constraint.jointNumber,
+                    this._previewCurveGauge,
+                    this._trackGraph
+                )
+            ) {
+                console.warn('gauge mismatch at end joint');
                 this.cancelCurrentCurve();
                 return null;
             }
@@ -625,6 +647,62 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                     this.cancelCurrentCurve();
                     return null;
                 }
+            }
+        }
+
+        if (this._newStartJoint.type === 'branchJoint') {
+            if (
+                !gaugesAreCompatible(
+                    this._newStartJoint.constraint.jointNumber,
+                    this._previewCurveGauge,
+                    this._trackGraph
+                )
+            ) {
+                console.warn('gauge mismatch at start branch joint');
+                this.cancelCurrentCurve();
+                return null;
+            }
+        }
+
+        if (this._newEndJoint.type === 'branchJoint') {
+            if (
+                !gaugesAreCompatible(
+                    this._newEndJoint.constraint.jointNumber,
+                    this._previewCurveGauge,
+                    this._trackGraph
+                )
+            ) {
+                console.warn('gauge mismatch at end branch joint');
+                this.cancelCurrentCurve();
+                return null;
+            }
+        }
+
+        if (this._newStartJoint.type === 'branchCurve') {
+            const branchedSegment = this._trackGraph.getTrackSegmentWithJoints(
+                this._newStartJoint.constraint.curve
+            );
+            if (
+                branchedSegment !== null &&
+                Math.abs(branchedSegment.gauge - this._previewCurveGauge) > 1e-6
+            ) {
+                console.warn('gauge mismatch: cannot branch from segment with different gauge');
+                this.cancelCurrentCurve();
+                return null;
+            }
+        }
+
+        if (this._newEndJoint.type === 'branchCurve') {
+            const branchedSegment = this._trackGraph.getTrackSegmentWithJoints(
+                this._newEndJoint.constraint.curve
+            );
+            if (
+                branchedSegment !== null &&
+                Math.abs(branchedSegment.gauge - this._previewCurveGauge) > 1e-6
+            ) {
+                console.warn('gauge mismatch: cannot branch from segment with different gauge');
+                this.cancelCurrentCurve();
+                return null;
             }
         }
 
@@ -714,7 +792,12 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
             return null;
         }
 
-        this._trackGraph.connectJoints(startJointNumber, endJointNumber, cps);
+        this._trackGraph.connectJoints(
+            startJointNumber,
+            endJointNumber,
+            cps,
+            this._previewCurveGauge
+        );
         // this._trackGraph.logJoints();
         console.log('---track segments---');
         this._trackGraph.logTrackSegments();
@@ -859,4 +942,22 @@ function extendTrackIsPossible(
     }
 
     return false;
+}
+
+function gaugesAreCompatible(
+    jointNumber: number,
+    incomingGauge: number,
+    trackGraph: TrackGraph
+): boolean {
+    const joint = trackGraph.getJoint(jointNumber);
+    if (joint === null) return true;
+    const epsilon = 1e-6;
+    for (const [, segmentNumber] of joint.connections) {
+        const segment = trackGraph.getTrackSegmentWithJoints(segmentNumber);
+        if (segment === null) continue;
+        if (Math.abs(segment.gauge - incomingGauge) > epsilon) {
+            return false;
+        }
+    }
+    return true;
 }

--- a/apps/banana/src/trains/input-state-machine/curve-engine.ts
+++ b/apps/banana/src/trains/input-state-machine/curve-engine.ts
@@ -342,7 +342,7 @@ export class CurveCreationEngine
         this._deletionHighlightObservable.subscribe(observer, options);
     }
 
-    hoverForStartingPoint(position: Point, gauge: number = 1.067) {
+    hoverForStartingPoint(position: Point) {
         const res = this._trackGraph.project(position);
         const elevation =
             this._currentJointElevation != null
@@ -359,7 +359,6 @@ export class CurveCreationEngine
             this._previewStartProjection = null;
         }
 
-        this._previewCurveGauge = gauge;
         this._previewStartProjectionObservable.notify(res.hit ? res : null);
     }
 

--- a/apps/banana/src/trains/input-state-machine/curve-engine.ts
+++ b/apps/banana/src/trains/input-state-machine/curve-engine.ts
@@ -1,4 +1,32 @@
-import { Canvas, convertFromCanvas2ViewPort, convertFromCanvas2Window, convertFromViewPort2Canvas, convertFromViewport2World, convertFromWindow2Canvas, convertFromWorld2Viewport, Observable, ObservableBoardCamera, ObservableInputTracker, Observer, SubscriptionOptions, SynchronousObservable } from '@ue-too/board';
+import {
+    Canvas,
+    Observable,
+    ObservableBoardCamera,
+    ObservableInputTracker,
+    Observer,
+    SubscriptionOptions,
+    SynchronousObservable,
+    convertFromCanvas2ViewPort,
+    convertFromCanvas2Window,
+    convertFromViewPort2Canvas,
+    convertFromViewport2World,
+    convertFromWindow2Canvas,
+    convertFromWorld2Viewport,
+} from '@ue-too/board';
+import { BCurve } from '@ue-too/curve';
+import { type Point, directionAlignedToTangent } from '@ue-too/math';
+import { PointCal } from '@ue-too/math';
+
+import { PreviewCurveCalculator, TENSION_STEP } from '../tracks/new-joint';
+import { TrackGraph } from '../tracks/track';
+import {
+    ELEVATION,
+    ProjectionPositiveResult,
+    ProjectionResult,
+    TrackSegmentDrawData,
+} from '../tracks/types';
+import { LayoutContext } from './layout-kmt-state-machine';
+import { NewJointType } from './types';
 
 /**
  * Highlight payload for the curve deletion tool.
@@ -7,31 +35,24 @@ import { Canvas, convertFromCanvas2ViewPort, convertFromCanvas2Window, convertFr
 export type DeletionHighlightState = {
     segmentNumber: number;
 } | null;
-import { BCurve } from '@ue-too/curve';
-import { type Point, directionAlignedToTangent } from '@ue-too/math';
-import { PointCal } from '@ue-too/math';
 
-import { PreviewCurveCalculator, TENSION_STEP } from '../tracks/new-joint';
-import {
-    ELEVATION,
-    ProjectionPositiveResult,
-    ProjectionResult,
-    TrackSegmentDrawData,
-} from '../tracks/types';
-import { TrackGraph } from '../tracks/track';
-import { LayoutContext } from './layout-kmt-state-machine';
-import { NewJointType } from './types';
-
-export class CurveCreationEngine extends ObservableInputTracker implements LayoutContext {
+export class CurveCreationEngine
+    extends ObservableInputTracker
+    implements LayoutContext
+{
     private _trackGraph: TrackGraph;
 
     private _newStartJoint: NewJointType | null = null;
     private _newEndJoint: NewJointType | null = null;
 
     private _previewStartProjection: ProjectionPositiveResult | null = null;
-    private _previewStartProjectionObservable: Observable<[ProjectionPositiveResult | null]> = new SynchronousObservable<[ProjectionPositiveResult | null]>();
+    private _previewStartProjectionObservable: Observable<
+        [ProjectionPositiveResult | null]
+    > = new SynchronousObservable<[ProjectionPositiveResult | null]>();
     private _previewEndProjection: ProjectionPositiveResult | null = null;
-    private _previewEndProjectionObservable: Observable<[ProjectionPositiveResult | null]> = new SynchronousObservable<[ProjectionPositiveResult | null]>();
+    private _previewEndProjectionObservable: Observable<
+        [ProjectionPositiveResult | null]
+    > = new SynchronousObservable<[ProjectionPositiveResult | null]>();
 
     private _previewCurve: {
         curve: BCurve;
@@ -61,8 +82,29 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
     private _tensionObservable: Observable<[number]> =
         new SynchronousObservable<[number]>();
 
-    private _previewDrawDataObservable: Observable<[{ index: number, drawData: TrackSegmentDrawData & { positiveOffsets: Point[]; negativeOffsets: Point[] } }[] | undefined]> =
-        new SynchronousObservable<[{ index: number, drawData: TrackSegmentDrawData & { positiveOffsets: Point[]; negativeOffsets: Point[] } }[] | undefined]>();
+    private _previewDrawDataObservable: Observable<
+        [
+            | {
+                  index: number;
+                  drawData: TrackSegmentDrawData & {
+                      positiveOffsets: Point[];
+                      negativeOffsets: Point[];
+                  };
+              }[]
+            | undefined,
+        ]
+    > = new SynchronousObservable<
+        [
+            | {
+                  index: number;
+                  drawData: TrackSegmentDrawData & {
+                      positiveOffsets: Point[];
+                      negativeOffsets: Point[];
+                  };
+              }[]
+            | undefined,
+        ]
+    >();
 
     private _camera: ObservableBoardCamera;
 
@@ -88,8 +130,8 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
         const res =
             this._previewCurveForDeletion !== null
                 ? this._trackGraph.getTrackSegmentCurve(
-                    this._previewCurveForDeletion
-                )
+                      this._previewCurveForDeletion
+                  )
                 : null;
         return res;
     }
@@ -108,7 +150,6 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
     setCurrentGauge(gauge: number) {
         this._previewCurveGauge = gauge;
     }
-
 
     bumpStartJointElevation() {
         if (
@@ -347,13 +388,13 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 previewStartAndEndSwitched: newPreviewCurve.startAndEndSwitched,
                 elevation: newPreviewCurve.startAndEndSwitched
                     ? {
-                        from: endJoint.elevation,
-                        to: startJoint.elevation,
-                    }
+                          from: endJoint.elevation,
+                          to: startJoint.elevation,
+                      }
                     : {
-                        from: startJoint.elevation,
-                        to: endJoint.elevation,
-                    },
+                          from: startJoint.elevation,
+                          to: endJoint.elevation,
+                      },
                 gauge: this._previewCurveGauge,
             };
         } else {
@@ -362,13 +403,13 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 newPreviewCurve.startAndEndSwitched;
             this._previewCurve.elevation = newPreviewCurve.startAndEndSwitched
                 ? {
-                    from: endJoint.elevation,
-                    to: startJoint.elevation,
-                }
+                      from: endJoint.elevation,
+                      to: startJoint.elevation,
+                  }
                 : {
-                    from: startJoint.elevation,
-                    to: endJoint.elevation,
-                };
+                      from: startJoint.elevation,
+                      to: endJoint.elevation,
+                  };
         }
 
         const previewCurve = this._previewCurve.curve;
@@ -381,7 +422,10 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
             excludeSegmentsForCollisionCheck.add(startJoint.constraint.curve);
         }
 
-        if (startJoint.type === 'branchJoint' || startJoint.type === 'extendingTrack') {
+        if (
+            startJoint.type === 'branchJoint' ||
+            startJoint.type === 'extendingTrack'
+        ) {
             const startJointNumber = startJoint.constraint.jointNumber;
             const startTrackJoint = this._trackGraph.getJoint(startJointNumber);
             if (startTrackJoint !== null) {
@@ -396,7 +440,10 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
             excludeSegmentsForCollisionCheck.add(endJoint.constraint.curve);
         }
 
-        if (endJoint.type === 'branchJoint' || endJoint.type === 'extendingTrack') {
+        if (
+            endJoint.type === 'branchJoint' ||
+            endJoint.type === 'extendingTrack'
+        ) {
             const endJointNumber = endJoint.constraint.jointNumber;
             const endTrackJoint = this._trackGraph.getJoint(endJointNumber);
             if (endTrackJoint !== null) {
@@ -407,12 +454,32 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
             }
         }
 
-        const drawData = this._trackGraph.trackCurveManager.getPreviewDrawData(previewCurve, startElevation, endElevation, this._previewCurve.gauge, excludeSegmentsForCollisionCheck);
+        const drawData = this._trackGraph.trackCurveManager.getPreviewDrawData(
+            previewCurve,
+            startElevation,
+            endElevation,
+            this._previewCurve.gauge,
+            excludeSegmentsForCollisionCheck
+        );
 
         this._previewDrawDataObservable.notify(drawData);
     }
 
-    onPreviewDrawDataChange(observer: Observer<[{ index: number, drawData: TrackSegmentDrawData & { positiveOffsets: Point[]; negativeOffsets: Point[] } }[] | undefined]>, options?: SubscriptionOptions) {
+    onPreviewDrawDataChange(
+        observer: Observer<
+            [
+                | {
+                      index: number;
+                      drawData: TrackSegmentDrawData & {
+                          positiveOffsets: Point[];
+                          negativeOffsets: Point[];
+                      };
+                  }[]
+                | undefined,
+            ]
+        >,
+        options?: SubscriptionOptions
+    ) {
         this._previewDrawDataObservable.subscribe(observer, options);
     }
 
@@ -465,11 +532,17 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
         this._updatePreviewCurve(this._newStartJoint, this._newEndJoint);
     }
 
-    onPreviewStartProjectionChange(observer: Observer<[ProjectionPositiveResult | null]>, options?: SubscriptionOptions) {
+    onPreviewStartProjectionChange(
+        observer: Observer<[ProjectionPositiveResult | null]>,
+        options?: SubscriptionOptions
+    ) {
         this._previewStartProjectionObservable.subscribe(observer, options);
     }
 
-    onPreviewEndProjectionChange(observer: Observer<[ProjectionPositiveResult | null]>, options?: SubscriptionOptions) {
+    onPreviewEndProjectionChange(
+        observer: Observer<[ProjectionPositiveResult | null]>,
+        options?: SubscriptionOptions
+    ) {
         this._previewEndProjectionObservable.subscribe(observer, options);
     }
 
@@ -590,9 +663,9 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 ._previewCurve.previewStartAndEndSwitched
                 ? this._previewCurve.curve.derivative(0)
                 : PointCal.multiplyVectorByScalar(
-                    this._previewCurve.curve.derivative(1),
-                    -1
-                );
+                      this._previewCurve.curve.derivative(1),
+                      -1
+                  );
             if (
                 !extendTrackIsPossible(
                     startJointNumber,
@@ -686,7 +759,9 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 branchedSegment !== null &&
                 Math.abs(branchedSegment.gauge - this._previewCurveGauge) > 1e-6
             ) {
-                console.warn('gauge mismatch: cannot branch from segment with different gauge');
+                console.warn(
+                    'gauge mismatch: cannot branch from segment with different gauge'
+                );
                 this.cancelCurrentCurve();
                 return null;
             }
@@ -700,7 +775,9 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                 branchedSegment !== null &&
                 Math.abs(branchedSegment.gauge - this._previewCurveGauge) > 1e-6
             ) {
-                console.warn('gauge mismatch: cannot branch from segment with different gauge');
+                console.warn(
+                    'gauge mismatch: cannot branch from segment with different gauge'
+                );
                 this.cancelCurrentCurve();
                 return null;
             }
@@ -741,11 +818,11 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
                     this._previewCurve.previewStartAndEndSwitched;
                 const endTangent = previewCurveStartAndEndSwitched
                     ? PointCal.unitVector(
-                        this._previewCurve.curve.derivative(0)
-                    )
+                          this._previewCurve.curve.derivative(0)
+                      )
                     : PointCal.unitVector(
-                        this._previewCurve.curve.derivative(1)
-                    );
+                          this._previewCurve.curve.derivative(1)
+                      );
                 const previewCurveCPs =
                     this._previewCurve.curve.getControlPoints();
                 const endPosition = previewCurveStartAndEndSwitched
@@ -839,9 +916,9 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
         this._deletionHighlightObservable.notify(null);
     }
 
-    setup() { }
+    setup() {}
 
-    cleanup() { }
+    cleanup() {}
 
     get trackGraph(): TrackGraph {
         return this._trackGraph;
@@ -902,20 +979,37 @@ export class CurveCreationEngine extends ObservableInputTracker implements Layou
     clearEndPoint() {
         this._newEndJoint = null;
         this._previewCurve = null;
-        this._previewDrawDataObservable.notify(undefined)
+        this._previewDrawDataObservable.notify(undefined);
     }
 
     // position is in raw window coordinates space
     convert2WorldPosition(position: Point): Point {
         const pointInCanvas = convertFromWindow2Canvas(position, this.canvas);
-        const pointInViewPort = convertFromCanvas2ViewPort(pointInCanvas, { x: this.canvas.width / 2, y: this.canvas.height / 2 });
-        return convertFromViewport2World(pointInViewPort, this._camera.position, this._camera.zoomLevel, this._camera.rotation, false);
+        const pointInViewPort = convertFromCanvas2ViewPort(pointInCanvas, {
+            x: this.canvas.width / 2,
+            y: this.canvas.height / 2,
+        });
+        return convertFromViewport2World(
+            pointInViewPort,
+            this._camera.position,
+            this._camera.zoomLevel,
+            this._camera.rotation,
+            false
+        );
     }
 
     // position is in the world space
     convert2WindowPosition(position: Point): Point {
-        const pointInViewPort = convertFromWorld2Viewport(position, this._camera.position, this._camera.zoomLevel, this._camera.rotation);
-        const pointInCanvas = convertFromViewPort2Canvas(pointInViewPort, { x: this.canvas.width / 2, y: this.canvas.height / 2 });
+        const pointInViewPort = convertFromWorld2Viewport(
+            position,
+            this._camera.position,
+            this._camera.zoomLevel,
+            this._camera.rotation
+        );
+        const pointInCanvas = convertFromViewPort2Canvas(pointInViewPort, {
+            x: this.canvas.width / 2,
+            y: this.canvas.height / 2,
+        });
         return convertFromCanvas2Window(pointInCanvas, this.canvas);
     }
 }
@@ -944,6 +1038,10 @@ function extendTrackIsPossible(
     return false;
 }
 
+// TODO: When train-gauge compatibility is implemented, trains should carry a
+// `gauge` property and the routing/pathfinding system should filter segments
+// by gauge match to prevent narrow-gauge rolling stock from running on
+// standard-gauge track.
 function gaugesAreCompatible(
     jointNumber: number,
     incomingGauge: number,

--- a/apps/banana/src/trains/tracks/debug-overlay-render-system.ts
+++ b/apps/banana/src/trains/tracks/debug-overlay-render-system.ts
@@ -3,6 +3,7 @@ import { CameraState, CameraZoomEventPayload, ObservableBoardCamera } from '@ue-
 import { PointCal } from '@ue-too/math';
 import { WorldRenderSystem } from '@/world-render-system';
 import type { TrackGraph } from './track';
+import { findPresetByWidth } from './gauge-presets';
 import type { PlacedTrainEntry } from '@/trains/train-manager';
 import type { ProximityDetector } from '@/trains/proximity-detector';
 import type { StationManager } from '@/stations/station-manager';
@@ -27,6 +28,9 @@ const JOINT_CIRCLE_FILL = 0x2563eb;
 
 /** Fill color for segment label circles (debug). */
 const SEGMENT_CIRCLE_FILL = 0x16a34a;
+
+/** Fill color for gauge label pills (debug). */
+const GAUGE_LABEL_FILL = 0x0891b2;
 
 /** Fill color for formation ID label circles (debug). */
 const FORMATION_CIRCLE_FILL = 0xd97706;
@@ -61,6 +65,8 @@ export class DebugOverlayRenderSystem {
     private _proximityContainer: Container;
     private _showJointNumbers = false;
     private _showSegmentIds = false;
+    private _gaugeContainer: Container;
+    private _showGaugeLabels = false;
     private _showFormationIds = false;
     private _showStationStops = false;
     private _showStationLocations = false;
@@ -82,6 +88,8 @@ export class DebugOverlayRenderSystem {
         this._overlayContainer = new Container();
         this._jointContainer = new Container();
         this._segmentContainer = new Container();
+        this._gaugeContainer = new Container();
+        this._gaugeContainer.visible = false;
         this._formationContainer = new Container();
         this._stationStopContainer = new Container();
         this._stationLocationContainer = new Container();
@@ -92,6 +100,7 @@ export class DebugOverlayRenderSystem {
         this._proximityContainer.visible = false;
         this._overlayContainer.addChild(this._jointContainer);
         this._overlayContainer.addChild(this._segmentContainer);
+        this._overlayContainer.addChild(this._gaugeContainer);
         this._overlayContainer.addChild(this._formationContainer);
         this._overlayContainer.addChild(this._stationStopContainer);
         this._overlayContainer.addChild(this._stationLocationContainer);
@@ -119,6 +128,9 @@ export class DebugOverlayRenderSystem {
             child.scale.set(scale);
         }
         for (const child of this._segmentContainer.children) {
+            child.scale.set(scale);
+        }
+        for (const child of this._gaugeContainer.children) {
             child.scale.set(scale);
         }
         for (const child of this._formationContainer.children) {
@@ -159,6 +171,19 @@ export class DebugOverlayRenderSystem {
         this._showSegmentIds = show;
         this._segmentContainer.visible = show;
         if (show) this._rebuildSegmentLabels();
+    }
+
+    /** Whether gauge labels are visible. */
+    get showGaugeLabels(): boolean {
+        return this._showGaugeLabels;
+    }
+
+    /** Show or hide gauge label overlays on track segments. */
+    setShowGaugeDebug(show: boolean): void {
+        if (this._showGaugeLabels === show) return;
+        this._showGaugeLabels = show;
+        this._gaugeContainer.visible = show;
+        if (show) this._rebuildGaugeLabels();
     }
 
     /** Show or hide formation ID labels above each car. */
@@ -236,6 +261,7 @@ export class DebugOverlayRenderSystem {
     refresh(): void {
         if (this._showJointNumbers) this._rebuildJointLabels();
         if (this._showSegmentIds) this._rebuildSegmentLabels();
+        if (this._showGaugeLabels) this._rebuildGaugeLabels();
         if (this._showStationStops) this._rebuildStationStopLabels();
         if (this._showStationLocations) this._rebuildStationLocationLabels();
     }
@@ -278,6 +304,32 @@ export class DebugOverlayRenderSystem {
                 positiveDir,
             );
             this._segmentContainer.addChild(node);
+        }
+    }
+
+    private _rebuildGaugeLabels(): void {
+        const removed = this._gaugeContainer.removeChildren();
+        removed.forEach((c) => c.destroy({ children: true }));
+        const segmentIds = this._trackGraph.trackCurveManager.livingEntities;
+        for (const segmentNumber of segmentIds) {
+            const segment =
+                this._trackGraph.getTrackSegmentWithJoints(segmentNumber);
+            if (segment === null) continue;
+            const mid = segment.curve.get(0.5);
+            const gauge = segment.gauge;
+            const preset = findPresetByWidth(gauge);
+            const label = preset
+                ? `${preset.name} ${gauge}m`
+                : `Custom ${gauge}m`;
+            const node = this._makeLabelNode(
+                label,
+                mid.x,
+                mid.y,
+                GAUGE_LABEL_FILL,
+                null,
+                true,
+            );
+            this._gaugeContainer.addChild(node);
         }
     }
 

--- a/apps/banana/src/trains/tracks/debug-overlay-render-system.ts
+++ b/apps/banana/src/trains/tracks/debug-overlay-render-system.ts
@@ -1,12 +1,18 @@
-import { Container, Graphics, Text } from 'pixi.js';
-import { CameraState, CameraZoomEventPayload, ObservableBoardCamera } from '@ue-too/board';
+import {
+    CameraState,
+    CameraZoomEventPayload,
+    ObservableBoardCamera,
+} from '@ue-too/board';
 import { PointCal } from '@ue-too/math';
-import { WorldRenderSystem } from '@/world-render-system';
-import type { TrackGraph } from './track';
-import { findPresetByWidth } from './gauge-presets';
-import type { PlacedTrainEntry } from '@/trains/train-manager';
-import type { ProximityDetector } from '@/trains/proximity-detector';
+import { Container, Graphics, Text } from 'pixi.js';
+
 import type { StationManager } from '@/stations/station-manager';
+import type { ProximityDetector } from '@/trains/proximity-detector';
+import type { PlacedTrainEntry } from '@/trains/train-manager';
+import { WorldRenderSystem } from '@/world-render-system';
+
+import { findPresetByWidth } from './gauge-presets';
+import type { TrackGraph } from './track';
 
 /** Base radius of the circle (world units); effective size = this / zoomLevel for constant screen size. */
 const LABEL_CIRCLE_RADIUS = 8;
@@ -29,8 +35,17 @@ const JOINT_CIRCLE_FILL = 0x2563eb;
 /** Fill color for segment label circles (debug). */
 const SEGMENT_CIRCLE_FILL = 0x16a34a;
 
-/** Fill color for gauge label pills (debug). */
-const GAUGE_LABEL_FILL = 0x0891b2;
+/** Per-gauge label colors so different gauges are visually distinct in the debug overlay. */
+const GAUGE_COLOR_MAP: Record<string, number> = {
+    'narrow-cape': 0x0891b2, // cyan
+    meter: 0x8b5cf6, // purple
+    standard: 0x2563eb, // blue
+    russian: 0xd97706, // amber
+    'broad-indian': 0xdc2626, // red
+};
+
+/** Fallback color for custom (non-preset) gauges. */
+const GAUGE_LABEL_FILL_CUSTOM = 0x71717a; // gray
 
 /** Fill color for formation ID label circles (debug). */
 const FORMATION_CIRCLE_FILL = 0xd97706;
@@ -80,7 +95,7 @@ export class DebugOverlayRenderSystem {
     constructor(
         worldRenderSystem: WorldRenderSystem,
         trackGraph: TrackGraph,
-        camera: ObservableBoardCamera,
+        camera: ObservableBoardCamera
     ) {
         this._worldRenderSystem = worldRenderSystem;
         this._trackGraph = trackGraph;
@@ -108,12 +123,20 @@ export class DebugOverlayRenderSystem {
         this._worldRenderSystem.addOverlayContainer(this._overlayContainer);
 
         this._zoomLevel = this._camera.zoomLevel;
-        this._camera.on('zoom', this._onZoom.bind(this), { signal: this._abortController.signal });
+        this._camera.on('zoom', this._onZoom.bind(this), {
+            signal: this._abortController.signal,
+        });
 
         const tcm = trackGraph.trackCurveManager;
-        tcm.onAdd(() => this.refresh(), { signal: this._abortController.signal });
-        trackGraph.onSegmentRemoved(() => this.refresh(), { signal: this._abortController.signal });
-        trackGraph.onSegmentSplit(() => this.refresh(), { signal: this._abortController.signal });
+        tcm.onAdd(() => this.refresh(), {
+            signal: this._abortController.signal,
+        });
+        trackGraph.onSegmentRemoved(() => this.refresh(), {
+            signal: this._abortController.signal,
+        });
+        trackGraph.onSegmentSplit(() => this.refresh(), {
+            signal: this._abortController.signal,
+        });
     }
 
     private _onZoom(_event: CameraZoomEventPayload, state: CameraState): void {
@@ -273,13 +296,15 @@ export class DebugOverlayRenderSystem {
         for (const { jointNumber, joint } of joints) {
             const { position, tangent } = joint;
             const arrowDir =
-                PointCal.magnitude(tangent) > 1e-6 ? PointCal.unitVector(tangent) : null;
+                PointCal.magnitude(tangent) > 1e-6
+                    ? PointCal.unitVector(tangent)
+                    : null;
             const node = this._makeLabelNode(
                 String(jointNumber),
                 position.x,
                 position.y,
                 JOINT_CIRCLE_FILL,
-                arrowDir,
+                arrowDir
             );
             this._jointContainer.addChild(node);
         }
@@ -290,18 +315,21 @@ export class DebugOverlayRenderSystem {
         removed.forEach(c => c.destroy({ children: true }));
         const segmentIds = this._trackGraph.trackCurveManager.livingEntities;
         for (const segmentNumber of segmentIds) {
-            const segment = this._trackGraph.getTrackSegmentWithJoints(segmentNumber);
+            const segment =
+                this._trackGraph.getTrackSegmentWithJoints(segmentNumber);
             if (segment === null) continue;
             const mid = segment.curve.get(0.5);
             const derivative = segment.curve.derivative(0.5);
             const positiveDir =
-                PointCal.magnitude(derivative) > 1e-6 ? PointCal.unitVector(derivative) : null;
+                PointCal.magnitude(derivative) > 1e-6
+                    ? PointCal.unitVector(derivative)
+                    : null;
             const node = this._makeLabelNode(
                 String(segmentNumber),
                 mid.x,
                 mid.y,
                 SEGMENT_CIRCLE_FILL,
-                positiveDir,
+                positiveDir
             );
             this._segmentContainer.addChild(node);
         }
@@ -309,7 +337,7 @@ export class DebugOverlayRenderSystem {
 
     private _rebuildGaugeLabels(): void {
         const removed = this._gaugeContainer.removeChildren();
-        removed.forEach((c) => c.destroy({ children: true }));
+        removed.forEach(c => c.destroy({ children: true }));
         const segmentIds = this._trackGraph.trackCurveManager.livingEntities;
         for (const segmentNumber of segmentIds) {
             const segment =
@@ -321,13 +349,16 @@ export class DebugOverlayRenderSystem {
             const label = preset
                 ? `${preset.name} ${gauge}m`
                 : `Custom ${gauge}m`;
+            const color = preset
+                ? (GAUGE_COLOR_MAP[preset.id] ?? GAUGE_LABEL_FILL_CUSTOM)
+                : GAUGE_LABEL_FILL_CUSTOM;
             const node = this._makeLabelNode(
                 label,
                 mid.x,
                 mid.y,
-                GAUGE_LABEL_FILL,
+                color,
                 null,
-                true,
+                true
             );
             this._gaugeContainer.addChild(node);
         }
@@ -356,7 +387,7 @@ export class DebugOverlayRenderSystem {
                     cy,
                     FORMATION_CIRCLE_FILL,
                     null,
-                    true,
+                    true
                 );
                 this._formationContainer.addChild(node);
             }
@@ -366,7 +397,8 @@ export class DebugOverlayRenderSystem {
     private _rebuildProximityLines(): void {
         const removed = this._proximityContainer.removeChildren();
         removed.forEach(c => c.destroy({ children: true }));
-        if (this._proximityDetector === null || this._getPlacedTrains === null) return;
+        if (this._proximityDetector === null || this._getPlacedTrains === null)
+            return;
 
         const placed = this._getPlacedTrains();
         const trainMap = new Map<number, PlacedTrainEntry>();
@@ -382,14 +414,22 @@ export class DebugOverlayRenderSystem {
 
             const bogiesA = entryA.train.getBogiePositions();
             const bogiesB = entryB.train.getBogiePositions();
-            if (!bogiesA || bogiesA.length === 0 || !bogiesB || bogiesB.length === 0) continue;
+            if (
+                !bogiesA ||
+                bogiesA.length === 0 ||
+                !bogiesB ||
+                bogiesB.length === 0
+            )
+                continue;
 
-            const ptA = match.trainA.end === 'head'
-                ? bogiesA[0].point
-                : bogiesA[bogiesA.length - 1].point;
-            const ptB = match.trainB.end === 'head'
-                ? bogiesB[0].point
-                : bogiesB[bogiesB.length - 1].point;
+            const ptA =
+                match.trainA.end === 'head'
+                    ? bogiesA[0].point
+                    : bogiesA[bogiesA.length - 1].point;
+            const ptB =
+                match.trainB.end === 'head'
+                    ? bogiesB[0].point
+                    : bogiesB[bogiesB.length - 1].point;
 
             // Draw a dashed-style line between endpoints with dots at each end
             const midX = (ptA.x + ptB.x) / 2;
@@ -430,7 +470,7 @@ export class DebugOverlayRenderSystem {
                 station.position.y,
                 STATION_LOCATION_CIRCLE_FILL,
                 null,
-                true,
+                true
             );
             this._stationLocationContainer.addChild(node);
         }
@@ -444,7 +484,9 @@ export class DebugOverlayRenderSystem {
         for (const { station } of stations) {
             for (const platform of station.platforms) {
                 for (const stop of platform.stopPositions) {
-                    const curve = this._trackGraph.getTrackSegmentCurve(stop.trackSegmentId);
+                    const curve = this._trackGraph.getTrackSegmentCurve(
+                        stop.trackSegmentId
+                    );
                     if (curve === null) continue;
                     const pos = curve.get(stop.tValue);
                     const derivative = curve.derivative(stop.tValue);
@@ -453,9 +495,10 @@ export class DebugOverlayRenderSystem {
                     if (mag > 1e-6) {
                         const unit = PointCal.unitVector(derivative);
                         // 'tangent' points in derivative direction; 'reverseTangent' points opposite
-                        arrowDir = stop.direction === 'tangent'
-                            ? unit
-                            : { x: -unit.x, y: -unit.y };
+                        arrowDir =
+                            stop.direction === 'tangent'
+                                ? unit
+                                : { x: -unit.x, y: -unit.y };
                     }
                     const label = `S${stop.trackSegmentId}`;
                     const node = this._makeLabelNode(
@@ -463,7 +506,7 @@ export class DebugOverlayRenderSystem {
                         pos.x,
                         pos.y,
                         STATION_STOP_CIRCLE_FILL,
-                        arrowDir,
+                        arrowDir
                     );
                     this._stationStopContainer.addChild(node);
                 }
@@ -477,21 +520,34 @@ export class DebugOverlayRenderSystem {
         y: number,
         circleFill: number,
         arrowDirection: { x: number; y: number } | null = null,
-        pill: boolean = false,
+        pill: boolean = false
     ): Container {
         const container = new Container();
         container.position.set(x, y);
         container.scale.set(1 / this._zoomLevel);
 
         if (arrowDirection !== null) {
-            const arrow = this._makeArrowGraphic(arrowDirection.x, arrowDirection.y, circleFill);
+            const arrow = this._makeArrowGraphic(
+                arrowDirection.x,
+                arrowDirection.y,
+                circleFill
+            );
             container.addChild(arrow);
         }
 
         const bg = new Graphics();
         if (pill) {
-            const pillHalfWidth = Math.max(LABEL_CIRCLE_RADIUS, textStr.length * 4 + 6);
-            bg.roundRect(-pillHalfWidth, -LABEL_CIRCLE_RADIUS, pillHalfWidth * 2, LABEL_CIRCLE_RADIUS * 2, LABEL_CIRCLE_RADIUS);
+            const pillHalfWidth = Math.max(
+                LABEL_CIRCLE_RADIUS,
+                textStr.length * 4 + 6
+            );
+            bg.roundRect(
+                -pillHalfWidth,
+                -LABEL_CIRCLE_RADIUS,
+                pillHalfWidth * 2,
+                LABEL_CIRCLE_RADIUS * 2,
+                LABEL_CIRCLE_RADIUS
+            );
         } else {
             bg.circle(0, 0, LABEL_CIRCLE_RADIUS);
         }

--- a/apps/banana/src/trains/tracks/gauge-presets.ts
+++ b/apps/banana/src/trains/tracks/gauge-presets.ts
@@ -1,0 +1,55 @@
+/** A named track gauge preset with width in meters. */
+export type TrackGaugePreset = {
+    id: string;
+    name: string;
+    width: number;
+    description: string;
+};
+
+/** Built-in gauge presets. */
+export const GAUGE_PRESETS: readonly TrackGaugePreset[] = [
+    {
+        id: 'narrow-cape',
+        name: 'Narrow (Cape)',
+        width: 1.067,
+        description: 'Japan, South Africa, Australia',
+    },
+    {
+        id: 'meter',
+        name: 'Meter',
+        width: 1.0,
+        description: 'Southeast Asia, South America',
+    },
+    {
+        id: 'standard',
+        name: 'Standard',
+        width: 1.435,
+        description: 'Europe, China, North America',
+    },
+    {
+        id: 'russian',
+        name: 'Russian',
+        width: 1.52,
+        description: 'Russia, Finland',
+    },
+    {
+        id: 'broad-indian',
+        name: 'Broad (Indian)',
+        width: 1.676,
+        description: 'India, Argentina',
+    },
+] as const;
+
+/** Default gauge preset (narrow cape, 1.067m). */
+export const DEFAULT_GAUGE_PRESET: TrackGaugePreset = GAUGE_PRESETS[0];
+
+/** Epsilon for floating-point gauge comparison. */
+const WIDTH_EPSILON = 1e-6;
+
+/** Find a preset by its gauge width. Returns null for custom (non-preset) widths. */
+export function findPresetByWidth(width: number): TrackGaugePreset | null {
+    return (
+        GAUGE_PRESETS.find((p) => Math.abs(p.width - width) < WIDTH_EPSILON) ??
+        null
+    );
+}

--- a/apps/banana/src/trains/tracks/types.ts
+++ b/apps/banana/src/trains/tracks/types.ts
@@ -27,7 +27,6 @@ export type TrackSegment = {
     t1Joint: number;
     curve: BCurve;
     gauge: number;
-    gauges?: number[];
     /** Total width of the gravel bed foundation (meters). Used for snapping when bed is enabled. */
     bedWidth?: number;
     /** Visual style for this track segment. Preserved through splits so branching doesn't alter appearance. */

--- a/apps/banana/test/gauge-presets.test.ts
+++ b/apps/banana/test/gauge-presets.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test';
+
+import {
+    GAUGE_PRESETS,
+    DEFAULT_GAUGE_PRESET,
+    findPresetByWidth,
+} from '../src/trains/tracks/gauge-presets';
+
+describe('GAUGE_PRESETS', () => {
+    it('contains 5 built-in presets', () => {
+        expect(GAUGE_PRESETS.length).toBe(5);
+    });
+
+    it('has unique ids', () => {
+        const ids = GAUGE_PRESETS.map((p) => p.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('has unique widths', () => {
+        const widths = GAUGE_PRESETS.map((p) => p.width);
+        expect(new Set(widths).size).toBe(widths.length);
+    });
+
+    it('all widths are positive', () => {
+        for (const preset of GAUGE_PRESETS) {
+            expect(preset.width).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('DEFAULT_GAUGE_PRESET', () => {
+    it('is narrow-cape (1.067m)', () => {
+        expect(DEFAULT_GAUGE_PRESET.id).toBe('narrow-cape');
+        expect(DEFAULT_GAUGE_PRESET.width).toBe(1.067);
+    });
+});
+
+describe('findPresetByWidth', () => {
+    it('finds narrow-cape by exact width', () => {
+        const preset = findPresetByWidth(1.067);
+        expect(preset).not.toBeNull();
+        expect(preset!.id).toBe('narrow-cape');
+    });
+
+    it('finds standard by exact width', () => {
+        const preset = findPresetByWidth(1.435);
+        expect(preset).not.toBeNull();
+        expect(preset!.id).toBe('standard');
+    });
+
+    it('returns null for non-preset width', () => {
+        expect(findPresetByWidth(1.2)).toBeNull();
+    });
+
+    it('handles floating point near-match', () => {
+        const preset = findPresetByWidth(1.067 + 1e-10);
+        expect(preset).not.toBeNull();
+        expect(preset!.id).toBe('narrow-cape');
+    });
+
+    it('does not match values outside epsilon', () => {
+        expect(findPresetByWidth(1.07)).toBeNull();
+    });
+});

--- a/apps/banana/test/gauge-store.test.ts
+++ b/apps/banana/test/gauge-store.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, beforeEach } from 'bun:test';
+
+import { useGaugeStore } from '../src/stores/gauge-store';
+
+describe('useGaugeStore', () => {
+    beforeEach(() => {
+        // Reset to default state between tests
+        useGaugeStore.setState({
+            selectedPresetId: 'narrow-cape',
+            customWidth: null,
+            currentGauge: 1.067,
+        });
+    });
+
+    it('defaults to narrow-cape (1.067m)', () => {
+        const state = useGaugeStore.getState();
+        expect(state.selectedPresetId).toBe('narrow-cape');
+        expect(state.currentGauge).toBe(1.067);
+        expect(state.customWidth).toBeNull();
+    });
+
+    it('selectPreset changes gauge to preset width', () => {
+        useGaugeStore.getState().selectPreset('standard');
+        const state = useGaugeStore.getState();
+        expect(state.selectedPresetId).toBe('standard');
+        expect(state.currentGauge).toBe(1.435);
+        expect(state.customWidth).toBeNull();
+    });
+
+    it('setCustomGauge switches to custom mode', () => {
+        useGaugeStore.getState().setCustomGauge(1.2);
+        const state = useGaugeStore.getState();
+        expect(state.selectedPresetId).toBe('custom');
+        expect(state.currentGauge).toBe(1.2);
+        expect(state.customWidth).toBe(1.2);
+    });
+
+    it('clamps custom gauge to minimum 0.5', () => {
+        useGaugeStore.getState().setCustomGauge(0.1);
+        expect(useGaugeStore.getState().currentGauge).toBe(0.5);
+    });
+
+    it('clamps custom gauge to maximum 3.0', () => {
+        useGaugeStore.getState().setCustomGauge(5.0);
+        expect(useGaugeStore.getState().currentGauge).toBe(3.0);
+    });
+
+    it('selectPreset after custom resets customWidth', () => {
+        useGaugeStore.getState().setCustomGauge(1.2);
+        useGaugeStore.getState().selectPreset('meter');
+        const state = useGaugeStore.getState();
+        expect(state.selectedPresetId).toBe('meter');
+        expect(state.currentGauge).toBe(1.0);
+        expect(state.customWidth).toBeNull();
+    });
+
+    it('ignores unknown preset ids', () => {
+        useGaugeStore.getState().selectPreset('nonexistent');
+        const state = useGaugeStore.getState();
+        expect(state.selectedPresetId).toBe('narrow-cape');
+        expect(state.currentGauge).toBe(1.067);
+    });
+});


### PR DESCRIPTION
## Summary

- Add support for laying tracks with different rail gauges (widths) instead of being locked to narrow gauge (1.067m)
- 5 built-in gauge presets: Narrow/Cape (1.067m), Meter (1.0m), Standard (1.435m), Russian (1.52m), Broad/Indian (1.676m), plus a custom option (0.5–3.0m)
- Gauge selector dropdown in both track layout and station placement toolbars
- Same-gauge-only connection enforcement — cross-gauge joints are rejected
- Debug gauge label overlay with per-gauge color coding
- i18n support for en/ja/zh-TW

## Test plan

- [x] 542 unit tests passing (17 new tests for gauge presets + gauge store)
- [ ] Select different gauges in layout mode and verify rail/ballast width differences
- [ ] Verify cross-gauge connections are blocked (extending, branching from joint, branching from curve)
- [ ] Verify same-gauge connections succeed
- [ ] Test custom gauge slider (0.5m–3.0m range)
- [ ] Toggle gauge labels in debug panel — verify per-gauge colors
- [ ] Place stations with different gauges selected
- [ ] Save/load scene with mixed gauges — verify roundtrip

🤖 Generated with [Claude Code](https://claude.com/claude-code)