### PR TITLE
feat(banana): joint direction editing tool

### DIFF
--- a/apps/banana/src/assets/icons/lucide.ts
+++ b/apps/banana/src/assets/icons/lucide.ts
@@ -29,6 +29,7 @@ export {
     Focus,
     FolderOpen,
     Gauge,
+    GitFork,
     Github,
     GripHorizontal,
     Hash,

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -818,7 +818,9 @@ export function BananaToolbar({
                             ? 'modeSingleSpinePlatform'
                             : mode === 'dual-spine-platform'
                               ? 'modeDualSpinePlatform'
-                              : null;
+                              : mode === 'joint-direction'
+                                ? 'modeJointDirection'
+                                : null;
 
     const flyoutCategories: Record<ToolbarCategory, FlyoutCategory> = {
         drawing: {

--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -16,6 +16,7 @@ import {
     Download,
     FilePlus,
     FolderOpen,
+    GitFork,
     Landmark,
     Layers,
     List,
@@ -87,6 +88,7 @@ import { DebugPanel } from './DebugPanel';
 import { DepotPanel } from './DepotPanel';
 import { ExportSubmenu } from './ExportSubmenu';
 import { FormationSelector } from './FormationSelector';
+import { GaugeSelector } from './GaugeSelector';
 import { LanguageSwitcher } from './LanguageSwitcher';
 import { LayoutDeletionToolbar } from './LayoutDeletionToolbar';
 import { ScaleRuler } from './ScaleRuler';
@@ -96,7 +98,6 @@ import { SunAngleControl } from './SunAngleControl';
 import { TerrainControl } from './TerrainControl';
 import { TerrainLegend } from './TerrainLegend';
 import { TimetablePanel } from './TimetablePanel';
-import { GaugeSelector } from './GaugeSelector';
 import { TrackStyleSelector } from './TrackStyleSelector';
 import { TrainPanel } from './TrainPanel';
 import { TOOLBAR_LEFT } from './types';
@@ -316,6 +317,15 @@ export function BananaToolbar({
         }
     }, [app, buildingHeight]);
 
+    useEffect(() => {
+        if (!app) return;
+        if (mode === 'joint-direction') {
+            app.jointDirectionRenderSystem.show();
+        } else {
+            app.jointDirectionRenderSystem.hide();
+        }
+    }, [app, mode]);
+
     const exitAllModes = useCallback(() => {
         if (!app) return;
         app.kmtStateMachineExpansion.happens('switchToIdle');
@@ -420,24 +430,41 @@ export function BananaToolbar({
         }
     }, [app, mode, exitAllModes]);
 
+    const handleJointDirectionToggle = useCallback(() => {
+        if (!app) return;
+        if (mode === 'joint-direction') {
+            app.kmtStateMachineExpansion.happens('switchToIdle');
+            setMode('idle');
+        } else {
+            exitAllModes();
+            app.kmtStateMachineExpansion.happens('switchToJointDirection');
+            setMode('joint-direction');
+        }
+    }, [app, mode, exitAllModes, setMode]);
+
     const handleStartSingleSpinePlatform = useCallback(
         (stationId: number) => {
             if (!app) return;
             exitAllModes();
-            app.kmtStateMachineExpansion.happens('switchToSingleSpinePlatform', { stationId });
+            app.kmtStateMachineExpansion.happens(
+                'switchToSingleSpinePlatform',
+                { stationId }
+            );
             setMode('single-spine-platform');
         },
-        [app, exitAllModes],
+        [app, exitAllModes]
     );
 
     const handleStartDualSpinePlatform = useCallback(
         (stationId: number) => {
             if (!app) return;
             exitAllModes();
-            app.kmtStateMachineExpansion.happens('switchToDualSpinePlatform', { stationId });
+            app.kmtStateMachineExpansion.happens('switchToDualSpinePlatform', {
+                stationId,
+            });
             setMode('dual-spine-platform');
         },
-        [app, exitAllModes],
+        [app, exitAllModes]
     );
 
     const handlePointerDown = useCallback(
@@ -763,7 +790,8 @@ export function BananaToolbar({
         mode === 'duplicate-to-side' ||
         mode === 'catenary-layout' ||
         mode === 'single-spine-platform' ||
-        mode === 'dual-spine-platform'
+        mode === 'dual-spine-platform' ||
+        mode === 'joint-direction'
             ? 'drawing'
             : mode === 'train-placement'
               ? 'trains'
@@ -831,6 +859,15 @@ export function BananaToolbar({
                     active: mode === 'catenary-layout',
                     disabled: mode !== 'idle' && mode !== 'catenary-layout',
                     onClick: handleCatenaryLayoutToggle,
+                },
+                {
+                    kind: 'button',
+                    id: 'joint-direction',
+                    icon: <GitFork />,
+                    label: t('jointDirection'),
+                    active: mode === 'joint-direction',
+                    disabled: mode !== 'idle' && mode !== 'joint-direction',
+                    onClick: handleJointDirectionToggle,
                 },
             ],
         },
@@ -1263,7 +1300,9 @@ export function BananaToolbar({
                     stationManager={app.stationManager}
                     stationRenderSystem={app.stationRenderSystem}
                     trackGraph={app.curveEngine.trackGraph}
-                    trackAlignedPlatformManager={app.trackAlignedPlatformManager}
+                    trackAlignedPlatformManager={
+                        app.trackAlignedPlatformManager
+                    }
                     cameraRig={app.cameraRig}
                     onClose={() => setPanel('stationList', false)}
                     onStationChange={() =>

--- a/apps/banana/src/components/toolbar/types.ts
+++ b/apps/banana/src/components/toolbar/types.ts
@@ -11,7 +11,8 @@ export type AppMode =
     | 'catenary-layout'
     | 'single-spine-platform'
     | 'dual-spine-platform'
-    | 'stress-pick';
+    | 'stress-pick'
+    | 'joint-direction';
 
 /** Shared left offset for left-aligned toolbars (main toolbar, layout deletion toolbar). */
 export const TOOLBAR_LEFT = 'left-6';

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -30,6 +30,7 @@ const en = {
         modeDeletingBuilding: 'Deleting Building',
         modeSingleSpinePlatform: 'Placing Single-Side Platform',
         modeDualSpinePlatform: 'Placing Dual-Side Platform',
+        modeJointDirection: 'Editing Joint Direction',
 
         // Toolbar - Train
         placeTrain: 'Place Train',

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -30,7 +30,7 @@ const en = {
         modeDeletingBuilding: 'Deleting Building',
         modeSingleSpinePlatform: 'Placing Single-Side Platform',
         modeDualSpinePlatform: 'Placing Dual-Side Platform',
-        modeJointDirection: 'Editing Joint Direction',
+        modeJointDirection: 'Joint Direction',
 
         // Toolbar - Train
         placeTrain: 'Place Train',

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -16,6 +16,7 @@ const en = {
         endDeletion: 'End Deletion',
         duplicateTrackToSide: 'Duplicate Track to Side',
         catenaryLayout: 'Catenary Layout',
+        jointDirection: 'Joint Direction',
 
         // Toolbar - Mode Exit Chip
         exitMode: 'Exit',
@@ -110,13 +111,17 @@ const en = {
         // Track-aligned platform hints
         hintPickStart: 'Click on a track to set the start point',
         hintPickEnd: 'Click along the track to set the end point',
-        hintDrawOuter: 'Click to draw the platform edge — close near the start anchor to finish',
+        hintDrawOuter:
+            'Click to draw the platform edge — close near the start anchor to finish',
         hintDualPickSpineAStart: 'Click on a track to set spine A start',
         hintDualPickSpineAEnd: 'Click along the track to set spine A end',
-        hintDualPickSpineBStart: 'Click the opposite track to set spine B start',
+        hintDualPickSpineBStart:
+            'Click the opposite track to set spine B start',
         hintDualPickSpineBEnd: 'Click along the track to set spine B end',
-        hintDualDrawCap1: 'Click to draw the first end cap — close near the snap ring to finish',
-        hintDualDrawCap2: 'Click to draw the second end cap — close near the snap ring to finish',
+        hintDualDrawCap1:
+            'Click to draw the first end cap — close near the snap ring to finish',
+        hintDualDrawCap2:
+            'Click to draw the second end cap — close near the snap ring to finish',
         hintPlatformCreated: 'Platform created',
 
         // Validation errors

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -30,7 +30,7 @@ const ja = {
         modeDualSpinePlatform: '両側ホームを配置中',
         modePlacingBuilding: '建物を配置中',
         modeDeletingBuilding: '建物を削除中',
-        modeJointDirection: 'ポイント方向を編集中',
+        modeJointDirection: 'ポイント方向',
 
         // Toolbar - Train
         placeTrain: '列車を配置',

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -30,6 +30,7 @@ const ja = {
         modeDualSpinePlatform: '両側ホームを配置中',
         modePlacingBuilding: '建物を配置中',
         modeDeletingBuilding: '建物を削除中',
+        modeJointDirection: 'ポイント方向を編集中',
 
         // Toolbar - Train
         placeTrain: '列車を配置',

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -16,6 +16,7 @@ const ja = {
         endDeletion: '削除終了',
         duplicateTrackToSide: '線路を側方に複製',
         catenaryLayout: '架線配置',
+        jointDirection: 'ポイント方向',
 
         // Toolbar - Mode Exit Chip
         exitMode: '終了',
@@ -114,10 +115,13 @@ const ja = {
         hintDrawOuter: 'クリックしてホーム端を描画 — 始点アンカー付近で閉じる',
         hintDualPickSpineAStart: '線路をクリックしてスパインAの始点を設定',
         hintDualPickSpineAEnd: '線路に沿ってクリックしてスパインAの終点を設定',
-        hintDualPickSpineBStart: '反対側の線路をクリックしてスパインBの始点を設定',
+        hintDualPickSpineBStart:
+            '反対側の線路をクリックしてスパインBの始点を設定',
         hintDualPickSpineBEnd: '線路に沿ってクリックしてスパインBの終点を設定',
-        hintDualDrawCap1: 'クリックして最初の端部キャップを描画 — スナップリング付近で閉じる',
-        hintDualDrawCap2: 'クリックして2番目の端部キャップを描画 — スナップリング付近で閉じる',
+        hintDualDrawCap1:
+            'クリックして最初の端部キャップを描画 — スナップリング付近で閉じる',
+        hintDualDrawCap2:
+            'クリックして2番目の端部キャップを描画 — スナップリング付近で閉じる',
         hintPlatformCreated: 'ホームが作成されました',
 
         // Validation errors

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -30,6 +30,7 @@ const zhTW = {
         modeDualSpinePlatform: '雙側月台佈置中',
         modePlacingBuilding: '放置建築中',
         modeDeletingBuilding: '刪除建築中',
+        modeJointDirection: '編輯道岔方向中',
 
         // Toolbar - Train
         placeTrain: '放置列車',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -16,6 +16,7 @@ const zhTW = {
         endDeletion: '結束刪除',
         duplicateTrackToSide: '複製軌道到側邊',
         catenaryLayout: '架線佈置',
+        jointDirection: '道岔方向',
 
         // Toolbar - Mode Exit Chip
         exitMode: '結束',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -30,7 +30,7 @@ const zhTW = {
         modeDualSpinePlatform: '雙側月台佈置中',
         modePlacingBuilding: '放置建築中',
         modeDeletingBuilding: '刪除建築中',
-        modeJointDirection: '編輯道岔方向中',
+        modeJointDirection: '道岔方向',
 
         // Toolbar - Train
         placeTrain: '放置列車',

--- a/apps/banana/src/scene-serialization.ts
+++ b/apps/banana/src/scene-serialization.ts
@@ -1,194 +1,248 @@
+import type { SerializedSignalData } from '@/signals/types';
+import { StationManager } from '@/stations/station-manager';
+import { TrackAlignedPlatformManager } from '@/stations/track-aligned-platform-manager';
+import type { SerializedTrackAlignedPlatformData } from '@/stations/track-aligned-platform-types';
+import type { SerializedStationData } from '@/stations/types';
+import {
+    TerrainData,
+    validateSerializedTerrainData,
+} from '@/terrain/terrain-data';
+import type { SerializedTerrainData } from '@/terrain/terrain-data';
+import { TimetableManager } from '@/timetable';
+import type { SerializedTimetableData } from '@/timetable/types';
+import {
+    JointDirectionPreferenceMap,
+    type SerializedJointDirectionPreference,
+} from '@/trains/tracks/joint-direction-preference-map';
 import type { SerializedTrackData } from '@/trains/tracks/types';
 import { validateSerializedTrackData } from '@/trains/tracks/types';
 import type { SerializedTrainData } from '@/trains/train-serialization';
 import {
-  deserializeTrainData,
-  serializeTrainData,
-  validateSerializedTrainData,
+    deserializeTrainData,
+    serializeTrainData,
+    validateSerializedTrainData,
 } from '@/trains/train-serialization';
-import type { SerializedStationData } from '@/stations/types';
-import { StationManager } from '@/stations/station-manager';
-import { TrackAlignedPlatformManager } from '@/stations/track-aligned-platform-manager';
-import type { SerializedTrackAlignedPlatformData } from '@/stations/track-aligned-platform-types';
-import type { BananaAppComponents } from '@/utils/init-app';
-import { TerrainData, validateSerializedTerrainData } from '@/terrain/terrain-data';
-import type { SerializedTerrainData } from '@/terrain/terrain-data';
-import type { SerializedTimetableData } from '@/timetable/types';
-import { TimetableManager } from '@/timetable';
-import type { SerializedSignalData } from '@/signals/types';
 import { clearShadowCache } from '@/utils';
+import type { BananaAppComponents } from '@/utils/init-app';
 
 export type SerializedSceneData = {
-  tracks: SerializedTrackData;
-  trains: SerializedTrainData;
-  stations?: SerializedStationData;
-  terrain?: SerializedTerrainData;
-  timetable?: SerializedTimetableData;
-  signals?: SerializedSignalData;
-  time?: number;
-  trackAlignedPlatforms?: SerializedTrackAlignedPlatformData;
+    tracks: SerializedTrackData;
+    trains: SerializedTrainData;
+    stations?: SerializedStationData;
+    terrain?: SerializedTerrainData;
+    timetable?: SerializedTimetableData;
+    signals?: SerializedSignalData;
+    time?: number;
+    trackAlignedPlatforms?: SerializedTrackAlignedPlatformData;
+    jointDirectionPreferences?: SerializedJointDirectionPreference[];
 };
 
-export function serializeSceneData(app: BananaAppComponents): SerializedSceneData {
-  return {
-    tracks: app.curveEngine.trackGraph.serialize(),
-    trains: serializeTrainData(app.trainManager, app.formationManager, app.carStockManager),
-    stations: app.stationManager.serialize(),
-    terrain: app.terrainData.serialize(),
-    timetable: app.timetableManager.serialize(),
-    signals: app.blockSignalManager.serialize(),
-    time: app.timeManager.currentTime,
-    trackAlignedPlatforms: app.trackAlignedPlatformManager.serialize(),
-  };
+export function serializeSceneData(
+    app: BananaAppComponents
+): SerializedSceneData {
+    return {
+        tracks: app.curveEngine.trackGraph.serialize(),
+        trains: serializeTrainData(
+            app.trainManager,
+            app.formationManager,
+            app.carStockManager
+        ),
+        stations: app.stationManager.serialize(),
+        terrain: app.terrainData.serialize(),
+        timetable: app.timetableManager.serialize(),
+        signals: app.blockSignalManager.serialize(),
+        time: app.timeManager.currentTime,
+        trackAlignedPlatforms: app.trackAlignedPlatformManager.serialize(),
+        jointDirectionPreferences: app.jointDirectionPreferenceMap.serialize(),
+    };
 }
 
 export async function deserializeSceneData(
-  app: BananaAppComponents,
-  data: SerializedSceneData,
-  options?: { onProgress?: (loaded: number, total: number) => void },
+    app: BananaAppComponents,
+    data: SerializedSceneData,
+    options?: { onProgress?: (loaded: number, total: number) => void }
 ): Promise<void> {
-  // Clear caches that reference old track geometry before replacing tracks.
-  clearShadowCache();
+    // Clear caches that reference old track geometry before replacing tracks.
+    clearShadowCache();
 
-  // Load tracks first so train positions can resolve to points (batched)
-  await app.curveEngine.trackGraph.loadFromSerializedData(data.tracks, {
-    onProgress: options?.onProgress,
-  });
-  deserializeTrainData(
-    data.trains,
-    app.curveEngine.trackGraph,
-    app.jointDirectionManager,
-    app.trainManager,
-    app.formationManager,
-    app.carStockManager,
-  );
-
-  // Load terrain data if present
-  if (data.terrain) {
-    const restoredTerrain = TerrainData.deserialize(data.terrain);
-    app.terrainRenderSystem.setTerrainData(restoredTerrain);
-  }
-
-  // Load timetable data if present
-  if (data.timetable) {
-    // Dispose the current timetable manager's subscriptions
-    app.timetableManager.dispose();
-    const restored = TimetableManager.deserialize(
-      data.timetable,
-      app.curveEngine.trackGraph,
-      app.trainManager,
-      app.stationManager,
-      app.signalStateEngine,
+    // Load tracks first so train positions can resolve to points (batched)
+    await app.curveEngine.trackGraph.loadFromSerializedData(data.tracks, {
+        onProgress: options?.onProgress,
+    });
+    deserializeTrainData(
+        data.trains,
+        app.curveEngine.trackGraph,
+        app.jointDirectionManager,
+        app.trainManager,
+        app.formationManager,
+        app.carStockManager
     );
-    // Replace the timetable manager on the app components and the mutable ref
-    // so the TimeManager callback uses the new instance.
-    (app as { timetableManager: TimetableManager }).timetableManager = restored;
-    app.timetableRef.current = restored;
-  }
 
-  // Restore simulation time if present
-  if (data.time !== undefined) {
-    app.timeManager.setCurrentTime(data.time);
-  }
+    // Load terrain data if present
+    if (data.terrain) {
+        const restoredTerrain = TerrainData.deserialize(data.terrain);
+        app.terrainRenderSystem.setTerrainData(restoredTerrain);
+    }
 
-  // Load signal data if present
-  if (data.signals) {
-    app.blockSignalManager.deserialize(data.signals);
-  }
+    // Load timetable data if present
+    if (data.timetable) {
+        // Dispose the current timetable manager's subscriptions
+        app.timetableManager.dispose();
+        const restored = TimetableManager.deserialize(
+            data.timetable,
+            app.curveEngine.trackGraph,
+            app.trainManager,
+            app.stationManager,
+            app.signalStateEngine
+        );
+        // Replace the timetable manager on the app components and the mutable ref
+        // so the TimeManager callback uses the new instance.
+        (app as { timetableManager: TimetableManager }).timetableManager =
+            restored;
+        app.timetableRef.current = restored;
+    }
 
-  // Load stations and rebuild their render visuals (must come before
-  // track-aligned platforms so that station elevation lookups succeed).
-  if (data.stations) {
-    const restored = StationManager.deserialize(data.stations);
-    // Replace the current station manager's state
-    for (const { id } of app.stationManager.getStations()) {
-      app.stationRenderSystem.removeStation(id);
-      app.stationManager.destroyStation(id);
+    // Restore simulation time if present
+    if (data.time !== undefined) {
+        app.timeManager.setCurrentTime(data.time);
     }
-    for (const { id, station } of restored.getStations()) {
-      app.stationManager.createStationWithId(id, station);
-      app.stationRenderSystem.addStation(id);
-    }
-  }
 
-  // Load track-aligned platforms if present (after stations are restored)
-  if (data.trackAlignedPlatforms) {
-    const restored = TrackAlignedPlatformManager.deserialize(data.trackAlignedPlatforms);
-    // Remove existing platforms
-    for (const { id } of app.trackAlignedPlatformManager.getAllPlatforms()) {
-      app.trackAlignedPlatformRenderSystem.removePlatform(id);
-      app.trackAlignedPlatformManager.destroyPlatform(id);
+    // Load signal data if present
+    if (data.signals) {
+        app.blockSignalManager.deserialize(data.signals);
     }
-    // Add restored platforms
-    for (const { id, platform } of restored.getAllPlatforms()) {
-      app.trackAlignedPlatformManager.createPlatformWithId(id, platform);
-      const elevation = app.stationManager.getStation(platform.stationId)?.elevation ?? 0;
-      app.trackAlignedPlatformRenderSystem.addPlatform(id, elevation);
+
+    // Load stations and rebuild their render visuals (must come before
+    // track-aligned platforms so that station elevation lookups succeed).
+    if (data.stations) {
+        const restored = StationManager.deserialize(data.stations);
+        // Replace the current station manager's state
+        for (const { id } of app.stationManager.getStations()) {
+            app.stationRenderSystem.removeStation(id);
+            app.stationManager.destroyStation(id);
+        }
+        for (const { id, station } of restored.getStations()) {
+            app.stationManager.createStationWithId(id, station);
+            app.stationRenderSystem.addStation(id);
+        }
     }
-  }
+
+    // Load track-aligned platforms if present (after stations are restored)
+    if (data.trackAlignedPlatforms) {
+        const restored = TrackAlignedPlatformManager.deserialize(
+            data.trackAlignedPlatforms
+        );
+        // Remove existing platforms
+        for (const {
+            id,
+        } of app.trackAlignedPlatformManager.getAllPlatforms()) {
+            app.trackAlignedPlatformRenderSystem.removePlatform(id);
+            app.trackAlignedPlatformManager.destroyPlatform(id);
+        }
+        // Add restored platforms
+        for (const { id, platform } of restored.getAllPlatforms()) {
+            app.trackAlignedPlatformManager.createPlatformWithId(id, platform);
+            const elevation =
+                app.stationManager.getStation(platform.stationId)?.elevation ??
+                0;
+            app.trackAlignedPlatformRenderSystem.addPlatform(id, elevation);
+        }
+    }
+
+    // Load joint direction preferences if present
+    if (data.jointDirectionPreferences) {
+        app.jointDirectionPreferenceMap.clear();
+        for (const entry of data.jointDirectionPreferences) {
+            if (entry.tangent !== undefined) {
+                app.jointDirectionPreferenceMap.set(entry.joint, 'tangent', entry.tangent);
+            }
+            if (entry.reverseTangent !== undefined) {
+                app.jointDirectionPreferenceMap.set(entry.joint, 'reverseTangent', entry.reverseTangent);
+            }
+        }
+    }
 }
 
 export function validateSerializedSceneData(
-  data: unknown
+    data: unknown
 ): { valid: true } | { valid: false; error: string } {
-  if (data == null || typeof data !== 'object') {
-    return { valid: false, error: 'Data must be a non-null object' };
-  }
-  const obj = data as Record<string, unknown>;
-  const tracks = obj.tracks;
-  const trains = obj.trains;
-  const trackRes = validateSerializedTrackData(tracks);
-  if (!trackRes.valid) return { valid: false, error: `tracks: ${trackRes.error}` };
-  const trainRes = validateSerializedTrainData(trains);
-  if (!trainRes.valid) return { valid: false, error: `trains: ${trainRes.error}` };
-  // stations is optional for backwards compatibility
-  if (obj.stations !== undefined) {
-    const stationRes = validateSerializedStationData(obj.stations);
-    if (!stationRes.valid) return { valid: false, error: `stations: ${stationRes.error}` };
-  }
-  // terrain is optional for backwards compatibility
-  if (obj.terrain !== undefined) {
-    const terrainRes = validateSerializedTerrainData(obj.terrain);
-    if (!terrainRes.valid) return { valid: false, error: `terrain: ${terrainRes.error}` };
-  }
-  return { valid: true };
+    if (data == null || typeof data !== 'object') {
+        return { valid: false, error: 'Data must be a non-null object' };
+    }
+    const obj = data as Record<string, unknown>;
+    const tracks = obj.tracks;
+    const trains = obj.trains;
+    const trackRes = validateSerializedTrackData(tracks);
+    if (!trackRes.valid)
+        return { valid: false, error: `tracks: ${trackRes.error}` };
+    const trainRes = validateSerializedTrainData(trains);
+    if (!trainRes.valid)
+        return { valid: false, error: `trains: ${trainRes.error}` };
+    // stations is optional for backwards compatibility
+    if (obj.stations !== undefined) {
+        const stationRes = validateSerializedStationData(obj.stations);
+        if (!stationRes.valid)
+            return { valid: false, error: `stations: ${stationRes.error}` };
+    }
+    // terrain is optional for backwards compatibility
+    if (obj.terrain !== undefined) {
+        const terrainRes = validateSerializedTerrainData(obj.terrain);
+        if (!terrainRes.valid)
+            return { valid: false, error: `terrain: ${terrainRes.error}` };
+    }
+    return { valid: true };
 }
 
 function validateSerializedStationData(
-  data: unknown
+    data: unknown
 ): { valid: true } | { valid: false; error: string } {
-  if (data == null || typeof data !== 'object') {
-    return { valid: false, error: 'Data must be a non-null object' };
-  }
-  const obj = data as Record<string, unknown>;
-  if (!Array.isArray(obj.stations)) {
-    return { valid: false, error: 'Missing or invalid "stations" array' };
-  }
-  for (let i = 0; i < obj.stations.length; i++) {
-    const s = obj.stations[i] as Record<string, unknown>;
-    const prefix = `stations[${i}]`;
-    if (typeof s.id !== 'number') {
-      return { valid: false, error: `${prefix}.id must be a number` };
+    if (data == null || typeof data !== 'object') {
+        return { valid: false, error: 'Data must be a non-null object' };
     }
-    if (typeof s.name !== 'string') {
-      return { valid: false, error: `${prefix}.name must be a string` };
+    const obj = data as Record<string, unknown>;
+    if (!Array.isArray(obj.stations)) {
+        return { valid: false, error: 'Missing or invalid "stations" array' };
     }
-    if (s.position == null || typeof (s.position as Record<string, unknown>).x !== 'number' || typeof (s.position as Record<string, unknown>).y !== 'number') {
-      return { valid: false, error: `${prefix}.position must be {x, y}` };
+    for (let i = 0; i < obj.stations.length; i++) {
+        const s = obj.stations[i] as Record<string, unknown>;
+        const prefix = `stations[${i}]`;
+        if (typeof s.id !== 'number') {
+            return { valid: false, error: `${prefix}.id must be a number` };
+        }
+        if (typeof s.name !== 'string') {
+            return { valid: false, error: `${prefix}.name must be a string` };
+        }
+        if (
+            s.position == null ||
+            typeof (s.position as Record<string, unknown>).x !== 'number' ||
+            typeof (s.position as Record<string, unknown>).y !== 'number'
+        ) {
+            return { valid: false, error: `${prefix}.position must be {x, y}` };
+        }
+        if (typeof s.elevation !== 'number') {
+            return {
+                valid: false,
+                error: `${prefix}.elevation must be a number`,
+            };
+        }
+        if (!Array.isArray(s.platforms)) {
+            return {
+                valid: false,
+                error: `${prefix}.platforms must be an array`,
+            };
+        }
+        if (!Array.isArray(s.trackSegments)) {
+            return {
+                valid: false,
+                error: `${prefix}.trackSegments must be a number[]`,
+            };
+        }
+        if (!Array.isArray(s.joints)) {
+            return {
+                valid: false,
+                error: `${prefix}.joints must be a number[]`,
+            };
+        }
     }
-    if (typeof s.elevation !== 'number') {
-      return { valid: false, error: `${prefix}.elevation must be a number` };
-    }
-    if (!Array.isArray(s.platforms)) {
-      return { valid: false, error: `${prefix}.platforms must be an array` };
-    }
-    if (!Array.isArray(s.trackSegments)) {
-      return { valid: false, error: `${prefix}.trackSegments must be a number[]` };
-    }
-    if (!Array.isArray(s.joints)) {
-      return { valid: false, error: `${prefix}.joints must be a number[]` };
-    }
-  }
-  return { valid: true };
+    return { valid: true };
 }
-

--- a/apps/banana/src/timetable/timetable-joint-direction-manager.ts
+++ b/apps/banana/src/timetable/timetable-joint-direction-manager.ts
@@ -4,12 +4,12 @@
  *
  * @module timetable/timetable-joint-direction-manager
  */
-
-import type { TrackGraph } from '@/trains/tracks/track';
 import {
-  type JointDirectionManager,
-  DefaultJointDirectionManager,
+    DefaultJointDirectionManager,
+    type JointDirectionManager,
 } from '@/trains/input-state-machine/train-kmt-state-machine';
+import type { JointDirectionPreferenceMap } from '@/trains/tracks/joint-direction-preference-map';
+import type { TrackGraph } from '@/trains/tracks/track';
 
 import type { RouteJointStep } from './types';
 
@@ -35,100 +35,102 @@ import type { RouteJointStep } from './types';
  * ```
  */
 export class TimetableJointDirectionManager implements JointDirectionManager {
-  private _trackGraph: TrackGraph;
-  private _routeJoints: RouteJointStep[];
-  private _currentIndex: number;
-  private _fallback: DefaultJointDirectionManager;
+    private _trackGraph: TrackGraph;
+    private _routeJoints: RouteJointStep[];
+    private _currentIndex: number;
+    private _fallback: DefaultJointDirectionManager;
 
-  /**
-   * @param trackGraph - The track graph for segment lookup.
-   * @param routeJoints - Ordered joint sequence from the active route.
-   * @param startIndex - Initial position in the joint sequence.
-   */
-  constructor(
-    trackGraph: TrackGraph,
-    routeJoints: RouteJointStep[],
-    startIndex: number,
-  ) {
-    this._trackGraph = trackGraph;
-    this._routeJoints = routeJoints;
-    this._currentIndex = startIndex;
-    this._fallback = new DefaultJointDirectionManager(trackGraph);
-  }
-
-  /** Current position in the route's joint sequence. */
-  get currentIndex(): number {
-    return this._currentIndex;
-  }
-
-  /** Advance (or set) the route progress index. */
-  setCurrentIndex(index: number): void {
-    this._currentIndex = index;
-  }
-
-  /** Get the current route joint sequence. */
-  getRouteJoints(): readonly RouteJointStep[] {
-    return this._routeJoints;
-  }
-
-  /** Replace the route joints (e.g. when moving to the next leg). */
-  setRouteJoints(joints: RouteJointStep[], startIndex: number = 0): void {
-    this._routeJoints = joints;
-    this._currentIndex = startIndex;
-  }
-
-  getNextJoint(
-    jointNumber: number,
-    direction: 'tangent' | 'reverseTangent',
-    occupiedJoints?: {
-      jointNumber: number;
-      direction: 'tangent' | 'reverseTangent';
-    }[],
-    occupiedTrackSegments?: {
-      trackNumber: number;
-      inTrackDirection: 'tangent' | 'reverseTangent';
-    }[],
-  ): {
-    jointNumber: number;
-    direction: 'tangent' | 'reverseTangent';
-    curveNumber: number;
-  } | null {
-    // Search forward from the current index for the joint we're at.
-    for (let i = this._currentIndex; i < this._routeJoints.length; i++) {
-      if (this._routeJoints[i].jointNumber !== jointNumber) continue;
-
-      // Found the current joint in the route.  The next step tells us
-      // which branch to take.
-      if (i + 1 >= this._routeJoints.length) break; // at the end of route
-
-      const nextStep = this._routeJoints[i + 1];
-      const joint = this._trackGraph.getJoint(jointNumber);
-      if (joint === null) break;
-
-      // Verify that the next joint is reachable in the given direction.
-      if (!joint.direction[direction].has(nextStep.jointNumber)) break;
-
-      const curveNumber = joint.connections.get(nextStep.jointNumber);
-      if (curveNumber === undefined) break;
-
-      const nextTrackSegment =
-        this._trackGraph.getTrackSegmentWithJoints(curveNumber);
-      if (nextTrackSegment === null) break;
-
-      // Determine the direction on the next segment.
-      const nextDirection: 'tangent' | 'reverseTangent' =
-        nextTrackSegment.t0Joint === jointNumber
-          ? 'tangent'
-          : 'reverseTangent';
-
-      return {
-        jointNumber: nextStep.jointNumber,
-        direction: nextDirection,
-        curveNumber,
-      };
+    /**
+     * @param trackGraph - The track graph for segment lookup.
+     * @param routeJoints - Ordered joint sequence from the active route.
+     * @param startIndex - Initial position in the joint sequence.
+     * @param preferenceMap - Optional preference map passed to the fallback manager.
+     */
+    constructor(
+        trackGraph: TrackGraph,
+        routeJoints: RouteJointStep[],
+        startIndex: number,
+        preferenceMap?: JointDirectionPreferenceMap
+    ) {
+        this._trackGraph = trackGraph;
+        this._routeJoints = routeJoints;
+        this._currentIndex = startIndex;
+        this._fallback = new DefaultJointDirectionManager(trackGraph, preferenceMap);
     }
 
-    // Route doesn't cover this junction — fall back to default behaviour.
-    return this._fallback.getNextJoint(jointNumber, direction);
-  }
+    /** Current position in the route's joint sequence. */
+    get currentIndex(): number {
+        return this._currentIndex;
+    }
+
+    /** Advance (or set) the route progress index. */
+    setCurrentIndex(index: number): void {
+        this._currentIndex = index;
+    }
+
+    /** Get the current route joint sequence. */
+    getRouteJoints(): readonly RouteJointStep[] {
+        return this._routeJoints;
+    }
+
+    /** Replace the route joints (e.g. when moving to the next leg). */
+    setRouteJoints(joints: RouteJointStep[], startIndex: number = 0): void {
+        this._routeJoints = joints;
+        this._currentIndex = startIndex;
+    }
+
+    getNextJoint(
+        jointNumber: number,
+        direction: 'tangent' | 'reverseTangent',
+        occupiedJoints?: {
+            jointNumber: number;
+            direction: 'tangent' | 'reverseTangent';
+        }[],
+        occupiedTrackSegments?: {
+            trackNumber: number;
+            inTrackDirection: 'tangent' | 'reverseTangent';
+        }[]
+    ): {
+        jointNumber: number;
+        direction: 'tangent' | 'reverseTangent';
+        curveNumber: number;
+    } | null {
+        // Search forward from the current index for the joint we're at.
+        for (let i = this._currentIndex; i < this._routeJoints.length; i++) {
+            if (this._routeJoints[i].jointNumber !== jointNumber) continue;
+
+            // Found the current joint in the route.  The next step tells us
+            // which branch to take.
+            if (i + 1 >= this._routeJoints.length) break; // at the end of route
+
+            const nextStep = this._routeJoints[i + 1];
+            const joint = this._trackGraph.getJoint(jointNumber);
+            if (joint === null) break;
+
+            // Verify that the next joint is reachable in the given direction.
+            if (!joint.direction[direction].has(nextStep.jointNumber)) break;
+
+            const curveNumber = joint.connections.get(nextStep.jointNumber);
+            if (curveNumber === undefined) break;
+
+            const nextTrackSegment =
+                this._trackGraph.getTrackSegmentWithJoints(curveNumber);
+            if (nextTrackSegment === null) break;
+
+            // Determine the direction on the next segment.
+            const nextDirection: 'tangent' | 'reverseTangent' =
+                nextTrackSegment.t0Joint === jointNumber
+                    ? 'tangent'
+                    : 'reverseTangent';
+
+            return {
+                jointNumber: nextStep.jointNumber,
+                direction: nextDirection,
+                curveNumber,
+            };
+        }
+
+        // Route doesn't cover this junction — fall back to default behaviour.
+        return this._fallback.getNextJoint(jointNumber, direction);
+    }
 }

--- a/apps/banana/src/timetable/timetable-manager.ts
+++ b/apps/banana/src/timetable/timetable-manager.ts
@@ -4,30 +4,30 @@
  *
  * @module timetable/timetable-manager
  */
-
-import type { TrackGraph } from '@/trains/tracks/track';
-import type { Train } from '@/trains/formation';
-import type { TrainManager } from '@/trains/train-manager';
+import type { SignalStateEngine } from '@/signals/signal-state-engine';
 import type { StationManager } from '@/stations/station-manager';
 import type { TrackAlignedPlatformManager } from '@/stations/track-aligned-platform-manager';
+import type { Train } from '@/trains/formation';
 import {
-  DefaultJointDirectionManager,
-  type JointDirectionManager,
+    DefaultJointDirectionManager,
+    type JointDirectionManager,
 } from '@/trains/input-state-machine/train-kmt-state-machine';
-import type { SignalStateEngine } from '@/signals/signal-state-engine';
+import type { JointDirectionPreferenceMap } from '@/trains/tracks/joint-direction-preference-map';
+import type { TrackGraph } from '@/trains/tracks/track';
+import type { TrainManager } from '@/trains/train-manager';
 
-import { ScheduleClock } from './schedule-clock';
+import { AutoDriver } from './auto-driver';
 import { RouteManager } from './route-manager';
+import { ScheduleClock } from './schedule-clock';
 import { ShiftTemplateManager } from './shift-template-manager';
 import { TimetableJointDirectionManager } from './timetable-joint-direction-manager';
-import { AutoDriver } from './auto-driver';
 import type {
-  ActiveShiftState,
-  Route,
-  ShiftAssignment,
-  ShiftAssignmentId,
-  SerializedTimetableData,
-  SerializedShiftAssignment,
+    ActiveShiftState,
+    Route,
+    SerializedShiftAssignment,
+    SerializedTimetableData,
+    ShiftAssignment,
+    ShiftAssignmentId,
 } from './types';
 
 // ---------------------------------------------------------------------------
@@ -55,418 +55,435 @@ import type {
  * ```
  */
 export class TimetableManager {
-  private _scheduleClock: ScheduleClock;
-  private _routeManager: RouteManager;
-  private _shiftTemplateManager: ShiftTemplateManager;
-  private _assignments: Map<ShiftAssignmentId, ShiftAssignment> = new Map();
+    private _scheduleClock: ScheduleClock;
+    private _routeManager: RouteManager;
+    private _shiftTemplateManager: ShiftTemplateManager;
+    private _assignments: Map<ShiftAssignmentId, ShiftAssignment> = new Map();
 
-  /** Active auto-drivers, keyed by train ID. */
-  private _drivers: Map<number, AutoDriver> = new Map();
+    /** Active auto-drivers, keyed by train ID. */
+    private _drivers: Map<number, AutoDriver> = new Map();
 
-  /** Map from train ID → the original JointDirectionManager before we swapped it. */
-  private _originalJdms: Map<number, JointDirectionManager> = new Map();
+    /** Map from train ID → the original JointDirectionManager before we swapped it. */
+    private _originalJdms: Map<number, JointDirectionManager> = new Map();
 
-  private _trackGraph: TrackGraph;
-  private _trainManager: TrainManager;
-  private _stationManager: StationManager;
-  private _trackAlignedPlatformManager: TrackAlignedPlatformManager | null = null;
-  private _signalStateEngine: SignalStateEngine | null = null;
+    private _trackGraph: TrackGraph;
+    private _trainManager: TrainManager;
+    private _stationManager: StationManager;
+    private _trackAlignedPlatformManager: TrackAlignedPlatformManager | null =
+        null;
+    private _signalStateEngine: SignalStateEngine | null = null;
+    private _preferenceMap: JointDirectionPreferenceMap | null = null;
 
-  private _unsubTrainChanges: (() => void) | null = null;
+    private _unsubTrainChanges: (() => void) | null = null;
 
-  constructor(
-    scheduleClock: ScheduleClock,
-    trackGraph: TrackGraph,
-    trainManager: TrainManager,
-    stationManager: StationManager,
-    routeManager?: RouteManager,
-    shiftTemplateManager?: ShiftTemplateManager,
-  ) {
-    this._scheduleClock = scheduleClock;
-    this._trackGraph = trackGraph;
-    this._trainManager = trainManager;
-    this._stationManager = stationManager;
-    this._routeManager = routeManager ?? new RouteManager();
-    this._shiftTemplateManager = shiftTemplateManager ?? new ShiftTemplateManager();
+    constructor(
+        scheduleClock: ScheduleClock,
+        trackGraph: TrackGraph,
+        trainManager: TrainManager,
+        stationManager: StationManager,
+        routeManager?: RouteManager,
+        shiftTemplateManager?: ShiftTemplateManager,
+        preferenceMap?: JointDirectionPreferenceMap
+    ) {
+        this._scheduleClock = scheduleClock;
+        this._trackGraph = trackGraph;
+        this._trainManager = trainManager;
+        this._stationManager = stationManager;
+        this._routeManager = routeManager ?? new RouteManager();
+        this._shiftTemplateManager =
+            shiftTemplateManager ?? new ShiftTemplateManager();
+        this._preferenceMap = preferenceMap ?? null;
 
-    // Listen for train add/remove to handle coupling/decoupling
-    this._unsubTrainChanges = this._trainManager.subscribeToChanges(
-      (id, type) => {
-        if (type === 'remove') {
-          this._onTrainRemoved(id);
-        }
-        // Note: 'add' events for coupling-created trains are handled
-        // by the coupling logic in TrainManager which keeps the surviving
-        // train.  Decoupling creates a new train via addTrain which fires
-        // 'add' — we check for suspended assignments there.
-        if (type === 'add') {
-          this._onTrainAdded(id);
-        }
-      },
-    );
-  }
-
-  // -----------------------------------------------------------------------
-  // Public accessors
-  // -----------------------------------------------------------------------
-
-  get scheduleClock(): ScheduleClock {
-    return this._scheduleClock;
-  }
-
-  get routeManager(): RouteManager {
-    return this._routeManager;
-  }
-
-  get shiftTemplateManager(): ShiftTemplateManager {
-    return this._shiftTemplateManager;
-  }
-
-  /** Set the signal state engine for block signal awareness. */
-  set signalStateEngine(engine: SignalStateEngine | null) {
-    this._signalStateEngine = engine;
-  }
-
-  /** Set the track-aligned platform manager for resolving track-aligned stop positions. */
-  set trackAlignedPlatformManager(manager: TrackAlignedPlatformManager | null) {
-    this._trackAlignedPlatformManager = manager;
-  }
-
-  /** Get all shift assignments. */
-  getAssignments(): ShiftAssignment[] {
-    return [...this._assignments.values()];
-  }
-
-  /** Get the assignment for a specific formation, if any. */
-  getAssignmentForFormation(formationId: string): ShiftAssignment | null {
-    for (const a of this._assignments.values()) {
-      if (a.formationId === formationId) return a;
+        // Listen for train add/remove to handle coupling/decoupling
+        this._unsubTrainChanges = this._trainManager.subscribeToChanges(
+            (id, type) => {
+                if (type === 'remove') {
+                    this._onTrainRemoved(id);
+                }
+                // Note: 'add' events for coupling-created trains are handled
+                // by the coupling logic in TrainManager which keeps the surviving
+                // train.  Decoupling creates a new train via addTrain which fires
+                // 'add' — we check for suspended assignments there.
+                if (type === 'add') {
+                    this._onTrainAdded(id);
+                }
+            }
+        );
     }
-    return null;
-  }
 
-  // -----------------------------------------------------------------------
-  // Shift assignment
-  // -----------------------------------------------------------------------
+    // -----------------------------------------------------------------------
+    // Public accessors
+    // -----------------------------------------------------------------------
 
-  /**
-   * Assign a shift template to a formation.
-   *
-   * @param assignmentId - Unique ID for this assignment.
-   * @param formationId - The formation to assign the shift to.
-   * @param shiftTemplateId - The shift template to assign.
-   */
-  assignShift(
-    assignmentId: ShiftAssignmentId,
-    formationId: string,
-    shiftTemplateId: string,
-  ): void {
-    const assignment: ShiftAssignment = {
-      id: assignmentId,
-      formationId,
-      shiftTemplateId,
-      suspended: false,
-      suspendedAtStopIndex: null,
-    };
-    this._assignments.set(assignmentId, assignment);
+    get scheduleClock(): ScheduleClock {
+        return this._scheduleClock;
+    }
 
-    // If the formation is already placed as a train, activate immediately
-    this._tryActivateAssignment(assignment);
-  }
+    get routeManager(): RouteManager {
+        return this._routeManager;
+    }
 
-  /** Remove a shift assignment. Stops the auto-driver if active. */
-  unassignShift(assignmentId: ShiftAssignmentId): void {
-    const assignment = this._assignments.get(assignmentId);
-    if (!assignment) return;
+    get shiftTemplateManager(): ShiftTemplateManager {
+        return this._shiftTemplateManager;
+    }
 
-    // Find and stop the associated driver
-    for (const [trainId, driver] of this._drivers) {
-      if (driver.state.assignmentId === assignmentId) {
+    /** Set the signal state engine for block signal awareness. */
+    set signalStateEngine(engine: SignalStateEngine | null) {
+        this._signalStateEngine = engine;
+    }
+
+    /** Set the track-aligned platform manager for resolving track-aligned stop positions. */
+    set trackAlignedPlatformManager(
+        manager: TrackAlignedPlatformManager | null
+    ) {
+        this._trackAlignedPlatformManager = manager;
+    }
+
+    /** Get all shift assignments. */
+    getAssignments(): ShiftAssignment[] {
+        return [...this._assignments.values()];
+    }
+
+    /** Get the assignment for a specific formation, if any. */
+    getAssignmentForFormation(formationId: string): ShiftAssignment | null {
+        for (const a of this._assignments.values()) {
+            if (a.formationId === formationId) return a;
+        }
+        return null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Shift assignment
+    // -----------------------------------------------------------------------
+
+    /**
+     * Assign a shift template to a formation.
+     *
+     * @param assignmentId - Unique ID for this assignment.
+     * @param formationId - The formation to assign the shift to.
+     * @param shiftTemplateId - The shift template to assign.
+     */
+    assignShift(
+        assignmentId: ShiftAssignmentId,
+        formationId: string,
+        shiftTemplateId: string
+    ): void {
+        const assignment: ShiftAssignment = {
+            id: assignmentId,
+            formationId,
+            shiftTemplateId,
+            suspended: false,
+            suspendedAtStopIndex: null,
+        };
+        this._assignments.set(assignmentId, assignment);
+
+        // If the formation is already placed as a train, activate immediately
+        this._tryActivateAssignment(assignment);
+    }
+
+    /** Remove a shift assignment. Stops the auto-driver if active. */
+    unassignShift(assignmentId: ShiftAssignmentId): void {
+        const assignment = this._assignments.get(assignmentId);
+        if (!assignment) return;
+
+        // Find and stop the associated driver
+        for (const [trainId, driver] of this._drivers) {
+            if (driver.state.assignmentId === assignmentId) {
+                this._deactivateDriver(trainId);
+                break;
+            }
+        }
+
+        this._assignments.delete(assignmentId);
+    }
+
+    // -----------------------------------------------------------------------
+    // Per-frame update
+    // -----------------------------------------------------------------------
+
+    /**
+     * Called each frame (via TimeManager subscription).
+     *
+     * @param currentTime - Elapsed simulation ms from TimeManager.
+     * @param _scaledDelta - Scaled delta ms (unused here but available).
+     */
+    update(currentTime: number, _scaledDelta: number): void {
+        const virtualTime = this._scheduleClock.toWeekMs(currentTime);
+
+        for (const [trainId, driver] of this._drivers) {
+            const train = this._getTrainById(trainId);
+            if (train === null) {
+                // Train was removed without going through the event handler
+                this._drivers.delete(trainId);
+                continue;
+            }
+
+            const assignment = this._assignments.get(driver.state.assignmentId);
+            if (!assignment || assignment.suspended) continue;
+
+            const shift = this._shiftTemplateManager.getTemplate(
+                assignment.shiftTemplateId
+            );
+            if (shift === null) continue;
+
+            // Get the route for the current leg
+            const legIndex = driver.state.currentLegIndex;
+            if (legIndex >= shift.legs.length) continue;
+
+            const route = this._routeManager.getRoute(
+                shift.legs[legIndex].routeId
+            );
+            if (route === null) continue;
+
+            driver.driveStep(
+                train,
+                virtualTime,
+                shift,
+                route,
+                this._stationManager,
+                this._trackGraph,
+                this._signalStateEngine ?? undefined,
+                this._trackAlignedPlatformManager ?? undefined
+            );
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Train events
+    // -----------------------------------------------------------------------
+
+    /**
+     * When a train is removed (e.g. due to coupling), suspend its assignment.
+     */
+    private _onTrainRemoved(trainId: number): void {
+        const driver = this._drivers.get(trainId);
+        if (!driver) return;
+
+        const assignment = this._assignments.get(driver.state.assignmentId);
+        if (assignment) {
+            assignment.suspended = true;
+            assignment.suspendedAtStopIndex = driver.state.currentLegIndex;
+        }
+
         this._deactivateDriver(trainId);
-        break;
-      }
     }
 
-    this._assignments.delete(assignmentId);
-  }
+    /**
+     * When a train is added (e.g. placement or decoupling), check if its
+     * formation has a shift assignment and activate it.
+     */
+    private _onTrainAdded(trainId: number): void {
+        const train = this._getTrainById(trainId);
+        if (train === null) return;
 
-  // -----------------------------------------------------------------------
-  // Per-frame update
-  // -----------------------------------------------------------------------
+        const formationId = train.formation.id;
 
-  /**
-   * Called each frame (via TimeManager subscription).
-   *
-   * @param currentTime - Elapsed simulation ms from TimeManager.
-   * @param _scaledDelta - Scaled delta ms (unused here but available).
-   */
-  update(currentTime: number, _scaledDelta: number): void {
-    const virtualTime = this._scheduleClock.toWeekMs(currentTime);
-
-    for (const [trainId, driver] of this._drivers) {
-      const train = this._getTrainById(trainId);
-      if (train === null) {
-        // Train was removed without going through the event handler
-        this._drivers.delete(trainId);
-        continue;
-      }
-
-      const assignment = this._assignments.get(driver.state.assignmentId);
-      if (!assignment || assignment.suspended) continue;
-
-      const shift = this._shiftTemplateManager.getTemplate(
-        assignment.shiftTemplateId,
-      );
-      if (shift === null) continue;
-
-      // Get the route for the current leg
-      const legIndex = driver.state.currentLegIndex;
-      if (legIndex >= shift.legs.length) continue;
-
-      const route = this._routeManager.getRoute(shift.legs[legIndex].routeId);
-      if (route === null) continue;
-
-      driver.driveStep(
-        train,
-        virtualTime,
-        shift,
-        route,
-        this._stationManager,
-        this._trackGraph,
-        this._signalStateEngine ?? undefined,
-        this._trackAlignedPlatformManager ?? undefined,
-      );
-    }
-  }
-
-  // -----------------------------------------------------------------------
-  // Train events
-  // -----------------------------------------------------------------------
-
-  /**
-   * When a train is removed (e.g. due to coupling), suspend its assignment.
-   */
-  private _onTrainRemoved(trainId: number): void {
-    const driver = this._drivers.get(trainId);
-    if (!driver) return;
-
-    const assignment = this._assignments.get(driver.state.assignmentId);
-    if (assignment) {
-      assignment.suspended = true;
-      assignment.suspendedAtStopIndex = driver.state.currentLegIndex;
-    }
-
-    this._deactivateDriver(trainId);
-  }
-
-  /**
-   * When a train is added (e.g. placement or decoupling), check if its
-   * formation has a shift assignment and activate it.
-   */
-  private _onTrainAdded(trainId: number): void {
-    const train = this._getTrainById(trainId);
-    if (train === null) return;
-
-    const formationId = train.formation.id;
-
-    // Check direct assignment
-    for (const assignment of this._assignments.values()) {
-      if (assignment.formationId === formationId) {
-        if (assignment.suspended) {
-          assignment.suspended = false;
-          // Resume from the suspended stop index
-          this._activateDriver(trainId, assignment, assignment.suspendedAtStopIndex ?? 0);
-          assignment.suspendedAtStopIndex = null;
-        } else {
-          this._tryActivateAssignment(assignment);
+        // Check direct assignment
+        for (const assignment of this._assignments.values()) {
+            if (assignment.formationId === formationId) {
+                if (assignment.suspended) {
+                    assignment.suspended = false;
+                    // Resume from the suspended stop index
+                    this._activateDriver(
+                        trainId,
+                        assignment,
+                        assignment.suspendedAtStopIndex ?? 0
+                    );
+                    assignment.suspendedAtStopIndex = null;
+                } else {
+                    this._tryActivateAssignment(assignment);
+                }
+                return;
+            }
         }
-        return;
-      }
+
+        // Check nested formations for suspended assignments
+        this._checkNestedFormationsForAssignments(trainId, train);
     }
 
-    // Check nested formations for suspended assignments
-    this._checkNestedFormationsForAssignments(trainId, train);
-  }
-
-  /**
-   * Walk the formation tree looking for sub-formations with suspended
-   * assignments.
-   */
-  private _checkNestedFormationsForAssignments(
-    trainId: number,
-    train: Train,
-  ): void {
-    // The formation tree is walked via flatCars — but we need formation IDs.
-    // For now, only check the top-level formation.
-    // TODO: walk nested formation tree for suspended assignments after decoupling.
-  }
-
-  // -----------------------------------------------------------------------
-  // Driver lifecycle
-  // -----------------------------------------------------------------------
-
-  private _tryActivateAssignment(assignment: ShiftAssignment): void {
-    if (assignment.suspended) return;
-
-    // Find the train with this formation
-    for (const { id, train } of this._trainManager.getPlacedTrains()) {
-      if (train.formation.id === assignment.formationId) {
-        this._activateDriver(id, assignment, 0);
-        return;
-      }
-    }
-  }
-
-  private _activateDriver(
-    trainId: number,
-    assignment: ShiftAssignment,
-    startStopIndex: number,
-  ): void {
-    if (this._drivers.has(trainId)) return; // already active
-
-    const shift = this._shiftTemplateManager.getTemplate(
-      assignment.shiftTemplateId,
-    );
-    if (shift === null) return;
-
-    // Get the route for the first (or resumed) leg
-    const legIndex = startStopIndex;
-    if (legIndex >= shift.legs.length) return;
-
-    const route = this._routeManager.getRoute(shift.legs[legIndex].routeId);
-    if (route === null) return;
-
-    const train = this._getTrainById(trainId);
-    if (train === null) return;
-
-    // Create a route-aware JDM
-    const jdm = new TimetableJointDirectionManager(
-      this._trackGraph,
-      route.joints,
-      0,
-    );
-
-    // Save the original JDM so we can restore it later
-    // (We can't easily read it since it's private, so we just track that
-    // we've overridden it)
-    const defaultJdm = new DefaultJointDirectionManager(this._trackGraph);
-    this._originalJdms.set(trainId, defaultJdm);
-
-    // Swap in the timetable JDM
-    train.setJointDirectionManager(jdm);
-
-    const state: ActiveShiftState = {
-      assignmentId: assignment.id,
-      trainId,
-      currentLegIndex: startStopIndex,
-      phase: 'waiting_departure',
-      routeJointProgress: 0,
-    };
-
-    const driver = new AutoDriver(state, jdm);
-    this._drivers.set(trainId, driver);
-  }
-
-  private _deactivateDriver(trainId: number): void {
-    this._drivers.delete(trainId);
-
-    // Restore original JDM
-    const originalJdm = this._originalJdms.get(trainId);
-    if (originalJdm) {
-      const train = this._getTrainById(trainId);
-      if (train) {
-        train.setJointDirectionManager(originalJdm);
-      }
-      this._originalJdms.delete(trainId);
-    }
-  }
-
-  // -----------------------------------------------------------------------
-  // Helpers
-  // -----------------------------------------------------------------------
-
-  private _getTrainById(trainId: number): Train | null {
-    return this._trainManager.getTrainById(trainId);
-  }
-
-  // -----------------------------------------------------------------------
-  // Cleanup
-  // -----------------------------------------------------------------------
-
-  /** Unsubscribe from TrainManager events. Call when tearing down. */
-  dispose(): void {
-    if (this._unsubTrainChanges) {
-      this._unsubTrainChanges();
-      this._unsubTrainChanges = null;
-    }
-    this._drivers.clear();
-    this._originalJdms.clear();
-  }
-
-  // -----------------------------------------------------------------------
-  // Serialization
-  // -----------------------------------------------------------------------
-
-  serialize(): SerializedTimetableData {
-    return {
-      clock: this._scheduleClock.serialize(),
-      routes: this._routeManager.serialize(),
-      shiftTemplates: this._shiftTemplateManager.serialize(),
-      assignments: [...this._assignments.values()].map((a) => ({
-        id: a.id,
-        formationId: a.formationId,
-        shiftTemplateId: a.shiftTemplateId,
-        suspended: a.suspended,
-        suspendedAtStopIndex: a.suspendedAtStopIndex,
-      })),
-    };
-  }
-
-  static deserialize(
-    data: SerializedTimetableData,
-    trackGraph: TrackGraph,
-    trainManager: TrainManager,
-    stationManager: StationManager,
-    signalStateEngine?: SignalStateEngine | null,
-  ): TimetableManager {
-    const clock = ScheduleClock.deserialize(data.clock);
-    const routeManager = RouteManager.deserialize(data.routes);
-    const shiftTemplateManager = ShiftTemplateManager.deserialize(
-      data.shiftTemplates,
-    );
-
-    const manager = new TimetableManager(
-      clock,
-      trackGraph,
-      trainManager,
-      stationManager,
-      routeManager,
-      shiftTemplateManager,
-    );
-
-    // Connect the signal engine before activating drivers so that
-    // auto-drivers have signal awareness from the first frame.
-    if (signalStateEngine) {
-      manager._signalStateEngine = signalStateEngine;
+    /**
+     * Walk the formation tree looking for sub-formations with suspended
+     * assignments.
+     */
+    private _checkNestedFormationsForAssignments(
+        trainId: number,
+        train: Train
+    ): void {
+        // The formation tree is walked via flatCars — but we need formation IDs.
+        // For now, only check the top-level formation.
+        // TODO: walk nested formation tree for suspended assignments after decoupling.
     }
 
-    // Restore assignments
-    for (const sa of data.assignments) {
-      const assignment: ShiftAssignment = {
-        id: sa.id,
-        formationId: sa.formationId,
-        shiftTemplateId: sa.shiftTemplateId,
-        suspended: sa.suspended,
-        suspendedAtStopIndex: sa.suspendedAtStopIndex,
-      };
-      manager._assignments.set(sa.id, assignment);
+    // -----------------------------------------------------------------------
+    // Driver lifecycle
+    // -----------------------------------------------------------------------
 
-      // Try to activate if the formation is already placed
-      if (!assignment.suspended) {
-        manager._tryActivateAssignment(assignment);
-      }
+    private _tryActivateAssignment(assignment: ShiftAssignment): void {
+        if (assignment.suspended) return;
+
+        // Find the train with this formation
+        for (const { id, train } of this._trainManager.getPlacedTrains()) {
+            if (train.formation.id === assignment.formationId) {
+                this._activateDriver(id, assignment, 0);
+                return;
+            }
+        }
     }
 
-    return manager;
-  }
+    private _activateDriver(
+        trainId: number,
+        assignment: ShiftAssignment,
+        startStopIndex: number
+    ): void {
+        if (this._drivers.has(trainId)) return; // already active
+
+        const shift = this._shiftTemplateManager.getTemplate(
+            assignment.shiftTemplateId
+        );
+        if (shift === null) return;
+
+        // Get the route for the first (or resumed) leg
+        const legIndex = startStopIndex;
+        if (legIndex >= shift.legs.length) return;
+
+        const route = this._routeManager.getRoute(shift.legs[legIndex].routeId);
+        if (route === null) return;
+
+        const train = this._getTrainById(trainId);
+        if (train === null) return;
+
+        // Create a route-aware JDM
+        const jdm = new TimetableJointDirectionManager(
+            this._trackGraph,
+            route.joints,
+            0,
+            this._preferenceMap ?? undefined
+        );
+
+        // Save the original JDM so we can restore it later
+        // (We can't easily read it since it's private, so we just track that
+        // we've overridden it)
+        const defaultJdm = new DefaultJointDirectionManager(
+            this._trackGraph,
+            this._preferenceMap ?? undefined
+        );
+        this._originalJdms.set(trainId, defaultJdm);
+
+        // Swap in the timetable JDM
+        train.setJointDirectionManager(jdm);
+
+        const state: ActiveShiftState = {
+            assignmentId: assignment.id,
+            trainId,
+            currentLegIndex: startStopIndex,
+            phase: 'waiting_departure',
+            routeJointProgress: 0,
+        };
+
+        const driver = new AutoDriver(state, jdm);
+        this._drivers.set(trainId, driver);
+    }
+
+    private _deactivateDriver(trainId: number): void {
+        this._drivers.delete(trainId);
+
+        // Restore original JDM
+        const originalJdm = this._originalJdms.get(trainId);
+        if (originalJdm) {
+            const train = this._getTrainById(trainId);
+            if (train) {
+                train.setJointDirectionManager(originalJdm);
+            }
+            this._originalJdms.delete(trainId);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    private _getTrainById(trainId: number): Train | null {
+        return this._trainManager.getTrainById(trainId);
+    }
+
+    // -----------------------------------------------------------------------
+    // Cleanup
+    // -----------------------------------------------------------------------
+
+    /** Unsubscribe from TrainManager events. Call when tearing down. */
+    dispose(): void {
+        if (this._unsubTrainChanges) {
+            this._unsubTrainChanges();
+            this._unsubTrainChanges = null;
+        }
+        this._drivers.clear();
+        this._originalJdms.clear();
+    }
+
+    // -----------------------------------------------------------------------
+    // Serialization
+    // -----------------------------------------------------------------------
+
+    serialize(): SerializedTimetableData {
+        return {
+            clock: this._scheduleClock.serialize(),
+            routes: this._routeManager.serialize(),
+            shiftTemplates: this._shiftTemplateManager.serialize(),
+            assignments: [...this._assignments.values()].map(a => ({
+                id: a.id,
+                formationId: a.formationId,
+                shiftTemplateId: a.shiftTemplateId,
+                suspended: a.suspended,
+                suspendedAtStopIndex: a.suspendedAtStopIndex,
+            })),
+        };
+    }
+
+    static deserialize(
+        data: SerializedTimetableData,
+        trackGraph: TrackGraph,
+        trainManager: TrainManager,
+        stationManager: StationManager,
+        signalStateEngine?: SignalStateEngine | null
+    ): TimetableManager {
+        const clock = ScheduleClock.deserialize(data.clock);
+        const routeManager = RouteManager.deserialize(data.routes);
+        const shiftTemplateManager = ShiftTemplateManager.deserialize(
+            data.shiftTemplates
+        );
+
+        const manager = new TimetableManager(
+            clock,
+            trackGraph,
+            trainManager,
+            stationManager,
+            routeManager,
+            shiftTemplateManager
+        );
+
+        // Connect the signal engine before activating drivers so that
+        // auto-drivers have signal awareness from the first frame.
+        if (signalStateEngine) {
+            manager._signalStateEngine = signalStateEngine;
+        }
+
+        // Restore assignments
+        for (const sa of data.assignments) {
+            const assignment: ShiftAssignment = {
+                id: sa.id,
+                formationId: sa.formationId,
+                shiftTemplateId: sa.shiftTemplateId,
+                suspended: sa.suspended,
+                suspendedAtStopIndex: sa.suspendedAtStopIndex,
+            };
+            manager._assignments.set(sa.id, assignment);
+
+            // Try to activate if the formation is already placed
+            if (!assignment.suspended) {
+                manager._tryActivateAssignment(assignment);
+            }
+        }
+
+        return manager;
+    }
 }

--- a/apps/banana/src/trains/input-state-machine/joint-direction-state-machine.ts
+++ b/apps/banana/src/trains/input-state-machine/joint-direction-state-machine.ts
@@ -1,0 +1,355 @@
+import type {
+    BaseContext,
+    CreateStateType,
+    EventGuards,
+    EventReactions,
+    Guard,
+    StateMachine,
+} from '@ue-too/being';
+import { NO_OP, TemplateState, TemplateStateMachine } from '@ue-too/being';
+import { type Point, PointCal } from '@ue-too/math';
+
+export const JOINT_DIRECTION_STATES = ['IDLE', 'HOVERING', 'SELECTED'] as const;
+
+export type JointDirectionStates = CreateStateType<
+    typeof JOINT_DIRECTION_STATES
+>;
+
+export type JointDirectionEvents = {
+    pointerMove: {
+        x: number;
+        y: number;
+    };
+    leftPointerDown: {
+        x: number;
+        y: number;
+    };
+    leftPointerUp: {
+        x: number;
+        y: number;
+    };
+    escapeKey: {};
+    startJointDirection: {};
+    endJointDirection: {};
+};
+
+export interface JointDirectionContext extends BaseContext {
+    convert2WorldPosition(pos: Point): Point;
+    getHoveredSwitchJoint(worldPos: Point): number | null;
+    showHoverIndicator(jointNumber: number): void;
+    clearHoverIndicator(): void;
+    selectJoint(jointNumber: number): void;
+    deselectJoint(): void;
+    cycleDirection(
+        jointNumber: number,
+        direction: 'tangent' | 'reverseTangent'
+    ): void;
+    getSelectedJointTangent(): Point | null;
+    getSelectedJointPosition(): Point | null;
+}
+
+export type JointDirectionStateMachine = StateMachine<
+    JointDirectionEvents,
+    JointDirectionContext,
+    JointDirectionStates
+>;
+
+class JointDirectionIdleState extends TemplateState<
+    JointDirectionEvents,
+    JointDirectionContext,
+    JointDirectionStates
+> {
+    private _hoveringState: JointDirectionHoveringState | null = null;
+    private _lastHitJoint: number | null = null;
+
+    setHoveringState(state: JointDirectionHoveringState) {
+        this._hoveringState = state;
+    }
+
+    protected _guards: Guard<JointDirectionContext, 'foundJoint'> = {
+        foundJoint: () => {
+            return this._lastHitJoint !== null;
+        },
+    };
+
+    protected _eventGuards: Partial<
+        EventGuards<
+            JointDirectionEvents,
+            JointDirectionStates,
+            JointDirectionContext,
+            Guard<JointDirectionContext, 'foundJoint'>
+        >
+    > = {
+        pointerMove: [
+            {
+                guard: 'foundJoint',
+                target: 'HOVERING',
+            },
+        ],
+    };
+
+    protected _eventReactions: EventReactions<
+        JointDirectionEvents,
+        JointDirectionContext,
+        JointDirectionStates
+    > = {
+        pointerMove: {
+            action: (context, event) => {
+                const worldPos = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                const jointNumber = context.getHoveredSwitchJoint(worldPos);
+                this._lastHitJoint = jointNumber;
+                if (jointNumber !== null) {
+                    context.showHoverIndicator(jointNumber);
+                    this._hoveringState?.setHoveredJoint(jointNumber);
+                }
+            },
+            defaultTargetState: 'IDLE',
+        },
+        endJointDirection: {
+            action: context => {
+                context.clearHoverIndicator();
+                context.deselectJoint();
+            },
+            defaultTargetState: 'IDLE',
+        },
+    };
+}
+
+class JointDirectionHoveringState extends TemplateState<
+    JointDirectionEvents,
+    JointDirectionContext,
+    JointDirectionStates
+> {
+    private _hoveredJoint: number | null = null;
+
+    setHoveredJoint(joint: number) {
+        this._hoveredJoint = joint;
+    }
+
+    getHoveredJoint(): number | null {
+        return this._hoveredJoint;
+    }
+
+    protected _guards: Guard<JointDirectionContext, 'noJointHovered'> = {
+        noJointHovered: () => {
+            return this._hoveredJoint === null;
+        },
+    };
+
+    protected _eventGuards: Partial<
+        EventGuards<
+            JointDirectionEvents,
+            JointDirectionStates,
+            JointDirectionContext,
+            Guard<JointDirectionContext, 'noJointHovered'>
+        >
+    > = {
+        pointerMove: [
+            {
+                guard: 'noJointHovered',
+                target: 'IDLE',
+            },
+        ],
+    };
+
+    protected _eventReactions: EventReactions<
+        JointDirectionEvents,
+        JointDirectionContext,
+        JointDirectionStates
+    > = {
+        pointerMove: {
+            action: (context, event) => {
+                const worldPos = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                const jointNumber = context.getHoveredSwitchJoint(worldPos);
+                if (jointNumber !== null) {
+                    this._hoveredJoint = jointNumber;
+                    context.showHoverIndicator(jointNumber);
+                } else {
+                    this._hoveredJoint = null;
+                    context.clearHoverIndicator();
+                }
+            },
+            defaultTargetState: 'HOVERING',
+        },
+        leftPointerDown: {
+            action: context => {
+                if (this._hoveredJoint !== null) {
+                    context.clearHoverIndicator();
+                    context.selectJoint(this._hoveredJoint);
+                }
+            },
+            defaultTargetState: 'SELECTED',
+        },
+        escapeKey: {
+            action: context => {
+                this._hoveredJoint = null;
+                context.clearHoverIndicator();
+            },
+            defaultTargetState: 'IDLE',
+        },
+        endJointDirection: {
+            action: context => {
+                this._hoveredJoint = null;
+                context.clearHoverIndicator();
+            },
+            defaultTargetState: 'IDLE',
+        },
+    };
+}
+
+class JointDirectionSelectedState extends TemplateState<
+    JointDirectionEvents,
+    JointDirectionContext,
+    JointDirectionStates
+> {
+    private _selectedJoint: number | null = null;
+    private _hoveringState: JointDirectionHoveringState | null = null;
+    private _lastClickResult: 'no-joint' | 'joint' = 'joint';
+
+    setHoveringState(state: JointDirectionHoveringState) {
+        this._hoveringState = state;
+    }
+
+    protected _guards: Guard<JointDirectionContext, 'clickedNoJoint'> = {
+        clickedNoJoint: () => {
+            return this._lastClickResult === 'no-joint';
+        },
+    };
+
+    protected _eventGuards: Partial<
+        EventGuards<
+            JointDirectionEvents,
+            JointDirectionStates,
+            JointDirectionContext,
+            Guard<JointDirectionContext, 'clickedNoJoint'>
+        >
+    > = {
+        leftPointerDown: [
+            {
+                guard: 'clickedNoJoint',
+                target: 'IDLE',
+            },
+        ],
+    };
+
+    protected _eventReactions: EventReactions<
+        JointDirectionEvents,
+        JointDirectionContext,
+        JointDirectionStates
+    > = {
+        pointerMove: {
+            action: NO_OP,
+            defaultTargetState: 'SELECTED',
+        },
+        leftPointerDown: {
+            action: (context, event) => {
+                const worldPos = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                const nearJoint = context.getHoveredSwitchJoint(worldPos);
+
+                if (nearJoint === null) {
+                    // No joint near click -> deselect -> IDLE
+                    context.deselectJoint();
+                    this._selectedJoint = null;
+                    this._lastClickResult = 'no-joint';
+                    return;
+                }
+
+                this._lastClickResult = 'joint';
+
+                if (
+                    nearJoint === this._selectedJoint &&
+                    this._selectedJoint !== null
+                ) {
+                    // Same joint: determine direction via dot product
+                    const jointPos = context.getSelectedJointPosition();
+                    const jointTangent = context.getSelectedJointTangent();
+                    if (jointPos !== null && jointTangent !== null) {
+                        const clickVec = PointCal.subVector(worldPos, jointPos);
+                        const dot = PointCal.dotProduct(clickVec, jointTangent);
+                        if (dot >= 0) {
+                            context.cycleDirection(
+                                this._selectedJoint,
+                                'tangent'
+                            );
+                        } else {
+                            context.cycleDirection(
+                                this._selectedJoint,
+                                'reverseTangent'
+                            );
+                        }
+                    }
+                    return;
+                }
+
+                // Different joint: deselect old, select new
+                context.deselectJoint();
+                context.selectJoint(nearJoint);
+                this._selectedJoint = nearJoint;
+            },
+            defaultTargetState: 'SELECTED',
+        },
+        escapeKey: {
+            action: context => {
+                context.deselectJoint();
+                this._selectedJoint = null;
+            },
+            defaultTargetState: 'IDLE',
+        },
+        endJointDirection: {
+            action: context => {
+                context.deselectJoint();
+                this._selectedJoint = null;
+            },
+            defaultTargetState: 'IDLE',
+        },
+    };
+
+    uponEnter(
+        context: JointDirectionContext,
+        stateMachine: JointDirectionStateMachine,
+        from: JointDirectionStates | 'INITIAL'
+    ): void {
+        // When entering SELECTED from HOVERING, capture the hovered joint
+        if (this._hoveringState) {
+            const hovered = this._hoveringState.getHoveredJoint();
+            if (hovered !== null) {
+                this._selectedJoint = hovered;
+            }
+        }
+    }
+}
+
+export function createJointDirectionStateMachine(): JointDirectionStateMachine {
+    const hoveringState = new JointDirectionHoveringState();
+    const selectedState = new JointDirectionSelectedState();
+    const idleState = new JointDirectionIdleState();
+
+    idleState.setHoveringState(hoveringState);
+    selectedState.setHoveringState(hoveringState);
+
+    return new TemplateStateMachine<
+        JointDirectionEvents,
+        JointDirectionContext,
+        JointDirectionStates
+    >(
+        {
+            IDLE: idleState,
+            HOVERING: hoveringState,
+            SELECTED: selectedState,
+        },
+        'IDLE',
+        {
+            setup: () => {},
+            cleanup: () => {},
+        }
+    );
+}

--- a/apps/banana/src/trains/input-state-machine/kmt-state-machine-extension.ts
+++ b/apps/banana/src/trains/input-state-machine/kmt-state-machine-extension.ts
@@ -1,80 +1,168 @@
-import { DisabledState, InitialPanState, KmtIdleState, KmtInputContext, KmtInputEventMapping, KmtInputEventOutputMapping, KmtInputStateMachineWebWorkerProxy, KmtInputStates, PanState, PanViaScrollWheelState, ReadyToPanViaScrollWheelState, ReadyToPanViaSpaceBarState } from "@ue-too/board";
-import { StateMachine } from "@ue-too/being";
-import { LayoutContext, LayoutEvents, LayoutStateMachine } from "./layout-kmt-state-machine";
-import { Defer, EventReactions, Guard, State, TemplateState, TemplateStateMachine } from "@ue-too/being";
-import { createLayoutStateMachine } from "./utils";
-import { CurveCreationEngine } from "./curve-engine";
-import { createToolSwitcherStateMachine, ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStateMachine } from "./tool-switcher-state-machine";
-import { TrainPlacementStateMachine } from "./train-kmt-state-machine";
-import { CatenaryLayoutStateMachine } from "./catenary-layout-state-machine";
-import { DuplicateToSideStateMachine } from "./duplicate-to-side-state-machine";
-import { StationPlacementStateMachine } from "@/stations/station-placement-state-machine";
-import type { SingleSpinePlacementStateMachine } from '@/stations/single-spine-placement-state-machine';
-import type { DualSpinePlacementStateMachine } from '@/stations/dual-spine-placement-state-machine';
+import { StateMachine } from '@ue-too/being';
+import {
+    Defer,
+    EventReactions,
+    Guard,
+    State,
+    TemplateState,
+    TemplateStateMachine,
+} from '@ue-too/being';
+import {
+    DisabledState,
+    InitialPanState,
+    KmtIdleState,
+    KmtInputContext,
+    KmtInputEventMapping,
+    KmtInputEventOutputMapping,
+    KmtInputStateMachineWebWorkerProxy,
+    KmtInputStates,
+    PanState,
+    PanViaScrollWheelState,
+    ReadyToPanViaScrollWheelState,
+    ReadyToPanViaSpaceBarState,
+} from '@ue-too/board';
 
-type KmtStateMachineEventWithToolSwitcher = KmtInputEventMapping & ToolSwitcherEvents & {
-    startDeletion: {};
-    endDeletion: {};
-};
+import type { DualSpinePlacementStateMachine } from '@/stations/dual-spine-placement-state-machine';
+import type { SingleSpinePlacementStateMachine } from '@/stations/single-spine-placement-state-machine';
+import { StationPlacementStateMachine } from '@/stations/station-placement-state-machine';
+
+import { CatenaryLayoutStateMachine } from './catenary-layout-state-machine';
+import { CurveCreationEngine } from './curve-engine';
+import { DuplicateToSideStateMachine } from './duplicate-to-side-state-machine';
+import type { JointDirectionStateMachine } from './joint-direction-state-machine';
+import {
+    LayoutContext,
+    LayoutEvents,
+    LayoutStateMachine,
+} from './layout-kmt-state-machine';
+import {
+    ToolSwitcherContext,
+    ToolSwitcherEvents,
+    ToolSwitcherStateMachine,
+    createToolSwitcherStateMachine,
+} from './tool-switcher-state-machine';
+import { TrainPlacementStateMachine } from './train-kmt-state-machine';
+import { createLayoutStateMachine } from './utils';
+
+type KmtStateMachineEventWithToolSwitcher = KmtInputEventMapping &
+    ToolSwitcherEvents & {
+        startDeletion: {};
+        endDeletion: {};
+    };
 
 type KmtStateMachineExtensionContext = KmtInputContext & ToolSwitcherContext;
 
-class KmtStateMachineExtensionIdleState extends TemplateState<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping> {
-
-    private _originalEventReactions: EventReactions<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>;
+class KmtStateMachineExtensionIdleState extends TemplateState<
+    KmtStateMachineEventWithToolSwitcher,
+    KmtStateMachineExtensionContext,
+    KmtInputStates,
+    KmtInputEventOutputMapping
+> {
+    private _originalEventReactions: EventReactions<
+        KmtStateMachineEventWithToolSwitcher,
+        KmtStateMachineExtensionContext,
+        KmtInputStates,
+        KmtInputEventOutputMapping
+    >;
     private _toolSwitcherSubStateMachine: ToolSwitcherStateMachine;
 
-    constructor(layoutSubStateMachine: LayoutStateMachine, trainSubStateMachine: TrainPlacementStateMachine, stationSubStateMachine: StationPlacementStateMachine, duplicateSubStateMachine: DuplicateToSideStateMachine, catenarySubStateMachine: CatenaryLayoutStateMachine, singleSpineSubStateMachine: SingleSpinePlacementStateMachine, dualSpineSubStateMachine: DualSpinePlacementStateMachine) {
+    constructor(
+        layoutSubStateMachine: LayoutStateMachine,
+        trainSubStateMachine: TrainPlacementStateMachine,
+        stationSubStateMachine: StationPlacementStateMachine,
+        duplicateSubStateMachine: DuplicateToSideStateMachine,
+        catenarySubStateMachine: CatenaryLayoutStateMachine,
+        singleSpineSubStateMachine: SingleSpinePlacementStateMachine,
+        dualSpineSubStateMachine: DualSpinePlacementStateMachine,
+        jointDirectionSubStateMachine: JointDirectionStateMachine
+    ) {
         super();
         const originalIdleState = new KmtIdleState();
-        this._originalEventReactions = originalIdleState.eventReactions as unknown as EventReactions<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>;
+        this._originalEventReactions =
+            originalIdleState.eventReactions as unknown as EventReactions<
+                KmtStateMachineEventWithToolSwitcher,
+                KmtStateMachineExtensionContext,
+                KmtInputStates,
+                KmtInputEventOutputMapping
+            >;
 
         this._eventReactions = {
             ...this._originalEventReactions,
-        } as EventReactions<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>;
-
+        } as EventReactions<
+            KmtStateMachineEventWithToolSwitcher,
+            KmtStateMachineExtensionContext,
+            KmtInputStates,
+            KmtInputEventOutputMapping
+        >;
 
         this.uponEnter = originalIdleState.uponEnter as unknown as (
             context: KmtStateMachineExtensionContext,
-            stateMachine: TemplateStateMachine<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>,
+            stateMachine: TemplateStateMachine<
+                KmtStateMachineEventWithToolSwitcher,
+                KmtStateMachineExtensionContext,
+                KmtInputStates,
+                KmtInputEventOutputMapping
+            >,
             from: KmtInputStates | 'INITIAL'
         ) => void;
 
         this.beforeExit = originalIdleState.beforeExit as unknown as (
             context: KmtStateMachineExtensionContext,
-            stateMachine: TemplateStateMachine<KmtStateMachineEventWithToolSwitcher, KmtStateMachineExtensionContext, KmtInputStates, KmtInputEventOutputMapping>,
+            stateMachine: TemplateStateMachine<
+                KmtStateMachineEventWithToolSwitcher,
+                KmtStateMachineExtensionContext,
+                KmtInputStates,
+                KmtInputEventOutputMapping
+            >,
             to: KmtInputStates | 'TERMINAL'
         ) => void;
 
-        this._guards = originalIdleState.guards as unknown as Guard<KmtStateMachineExtensionContext>;
+        this._guards =
+            originalIdleState.guards as unknown as Guard<KmtStateMachineExtensionContext>;
 
-        this._toolSwitcherSubStateMachine = createToolSwitcherStateMachine(layoutSubStateMachine, trainSubStateMachine, stationSubStateMachine, duplicateSubStateMachine, catenarySubStateMachine, singleSpineSubStateMachine, dualSpineSubStateMachine);
+        this._toolSwitcherSubStateMachine = createToolSwitcherStateMachine(
+            layoutSubStateMachine,
+            trainSubStateMachine,
+            stationSubStateMachine,
+            duplicateSubStateMachine,
+            catenarySubStateMachine,
+            singleSpineSubStateMachine,
+            dualSpineSubStateMachine,
+            jointDirectionSubStateMachine
+        );
     }
 
-    protected _defer: Defer<KmtStateMachineExtensionContext, KmtStateMachineEventWithToolSwitcher, KmtInputStates, KmtInputEventOutputMapping> = {
+    protected _defer: Defer<
+        KmtStateMachineExtensionContext,
+        KmtStateMachineEventWithToolSwitcher,
+        KmtInputStates,
+        KmtInputEventOutputMapping
+    > = {
         action: (context, event, eventKey, stateMachine) => {
             // console.log('eventKey', eventKey, 'event', event);
             // console.log('current state of the tool switcher sub state machine', this._toolSwitcherSubStateMachine.currentState);
             const key = eventKey as keyof ToolSwitcherEvents;
-            const payload = event as ToolSwitcherEvents[keyof ToolSwitcherEvents];
+            const payload =
+                event as ToolSwitcherEvents[keyof ToolSwitcherEvents];
             // Assert: at runtime key and payload are correlated; TS can't infer from the union
-            const result = (this._toolSwitcherSubStateMachine.happens as (
-                k: keyof ToolSwitcherEvents,
-                p: ToolSwitcherEvents[keyof ToolSwitcherEvents]
-            ) => ReturnType<ToolSwitcherStateMachine['happens']>)(key, payload);
+            const result = (
+                this._toolSwitcherSubStateMachine.happens as (
+                    k: keyof ToolSwitcherEvents,
+                    p: ToolSwitcherEvents[keyof ToolSwitcherEvents]
+                ) => ReturnType<ToolSwitcherStateMachine['happens']>
+            )(key, payload);
             // const result = this._toolSwitcherSubStateMachine.happens(key, payload);
             // console.log('result', result);
             if (result.handled) {
                 return {
                     handled: true,
                     output: result.output,
-                }
+                };
             }
             return { handled: false };
         },
     };
 }
-
 
 export const createAdaptedStateToExpansionFunc = <
     OldState extends State<any, any, any, any>,
@@ -105,7 +193,7 @@ export type KmtExpandedStateMachine = StateMachine<
     KmtStateMachineExtensionContext,
     KmtInputStates,
     KmtInputEventOutputMapping
->
+>;
 
 export function createKmtInputStateMachineExpansion(
     layoutSubStateMachine: LayoutStateMachine,
@@ -115,10 +203,20 @@ export function createKmtInputStateMachineExpansion(
     catenarySubStateMachine: CatenaryLayoutStateMachine,
     singleSpineSubStateMachine: SingleSpinePlacementStateMachine,
     dualSpineSubStateMachine: DualSpinePlacementStateMachine,
+    jointDirectionSubStateMachine: JointDirectionStateMachine,
     context: KmtStateMachineExtensionContext
 ): KmtExpandedStateMachine {
     const states = {
-        IDLE: new KmtStateMachineExtensionIdleState(layoutSubStateMachine, trainSubStateMachine, stationSubStateMachine, duplicateSubStateMachine, catenarySubStateMachine, singleSpineSubStateMachine, dualSpineSubStateMachine),
+        IDLE: new KmtStateMachineExtensionIdleState(
+            layoutSubStateMachine,
+            trainSubStateMachine,
+            stationSubStateMachine,
+            duplicateSubStateMachine,
+            catenarySubStateMachine,
+            singleSpineSubStateMachine,
+            dualSpineSubStateMachine,
+            jointDirectionSubStateMachine
+        ),
         READY_TO_PAN_VIA_SPACEBAR: expandState(
             new ReadyToPanViaSpaceBarState()
         ),

--- a/apps/banana/src/trains/input-state-machine/tool-switcher-state-machine.ts
+++ b/apps/banana/src/trains/input-state-machine/tool-switcher-state-machine.ts
@@ -1,32 +1,61 @@
-import { BaseContext, CreateStateType, DefaultOutputMapping, Defer, EventReactions, NO_OP, StateMachine, TemplateState, TemplateStateMachine } from "@ue-too/being";
-import { LayoutStateMachine } from "./layout-kmt-state-machine";
-import { createLayoutStateMachine, CurveCreationEngine, TrainPlacementStateMachine } from ".";
-import { CatenaryLayoutStateMachine } from "./catenary-layout-state-machine";
-import { DuplicateToSideStateMachine } from "./duplicate-to-side-state-machine";
-import { StationPlacementStateMachine } from "@/stations/station-placement-state-machine";
-import type { SingleSpinePlacementStateMachine } from '@/stations/single-spine-placement-state-machine';
-import type { DualSpinePlacementStateMachine } from '@/stations/dual-spine-placement-state-machine';
+import {
+    BaseContext,
+    CreateStateType,
+    DefaultOutputMapping,
+    Defer,
+    EventReactions,
+    NO_OP,
+    StateMachine,
+    TemplateState,
+    TemplateStateMachine,
+} from '@ue-too/being';
 
-export const TOOL_SWITCHER_STATES = ['LAYOUT', 'TRAIN', 'STATION', 'DUPLICATE', 'CATENARY', 'SINGLE_SPINE_PLATFORM', 'DUAL_SPINE_PLATFORM', 'IDLE'] as const;
+import type { DualSpinePlacementStateMachine } from '@/stations/dual-spine-placement-state-machine';
+import type { SingleSpinePlacementStateMachine } from '@/stations/single-spine-placement-state-machine';
+import { StationPlacementStateMachine } from '@/stations/station-placement-state-machine';
+
+import { CatenaryLayoutStateMachine } from './catenary-layout-state-machine';
+import { DuplicateToSideStateMachine } from './duplicate-to-side-state-machine';
+import type { JointDirectionStateMachine } from './joint-direction-state-machine';
+import { LayoutStateMachine } from './layout-kmt-state-machine';
+
+import {
+    CurveCreationEngine,
+    TrainPlacementStateMachine,
+    createLayoutStateMachine,
+} from '.';
+
+export const TOOL_SWITCHER_STATES = [
+    'LAYOUT',
+    'TRAIN',
+    'STATION',
+    'DUPLICATE',
+    'CATENARY',
+    'SINGLE_SPINE_PLATFORM',
+    'DUAL_SPINE_PLATFORM',
+    'JOINT_DIRECTION',
+    'IDLE',
+] as const;
 
 export type ToolSwitcherStates = CreateStateType<typeof TOOL_SWITCHER_STATES>;
 
 export type ToolSwitcherEvents = {
-    "switchToLayout": {};
-    "switchToTrain": {};
-    "switchToStation": {};
-    "switchToDuplicate": {};
-    "switchToCatenary": {};
-    "switchToSingleSpinePlatform": { stationId: number };
-    "switchToDualSpinePlatform": { stationId: number };
-    "switchToIdle": {};
-}
+    switchToLayout: {};
+    switchToTrain: {};
+    switchToStation: {};
+    switchToDuplicate: {};
+    switchToCatenary: {};
+    switchToSingleSpinePlatform: { stationId: number };
+    switchToDualSpinePlatform: { stationId: number };
+    switchToJointDirection: {};
+    switchToIdle: {};
+};
 
 export type ToolSwitcherContext = BaseContext & {
     // switchToLayout: () => void;
     // switchToTrain: () => void;
     // switchToIdle: () => void;
-}
+};
 
 export type ToolSwitcherEventOutputMapping = {
     switchToLayout: void;
@@ -36,23 +65,40 @@ export type ToolSwitcherEventOutputMapping = {
     switchToCatenary: void;
     switchToSingleSpinePlatform: void;
     switchToDualSpinePlatform: void;
+    switchToJointDirection: void;
     switchToIdle: void;
-}
+};
 
+export type ToolSwitcherStateMachine = StateMachine<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates,
+    ToolSwitcherEventOutputMapping
+>;
 
-export type ToolSwitcherStateMachine = StateMachine<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates, ToolSwitcherEventOutputMapping>;
-
-
-class ToolSwitcherIdleState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates, ToolSwitcherEventOutputMapping> {
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+class ToolSwitcherIdleState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates,
+    ToolSwitcherEventOutputMapping
+> {
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -85,17 +131,26 @@ class ToolSwitcherIdleState extends TemplateState<ToolSwitcherEvents, ToolSwitch
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
-    }
-};
+        },
+    };
+}
 
-class ToolSwitcherLayoutState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates, ToolSwitcherEventOutputMapping> {
-
+class ToolSwitcherLayoutState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates,
+    ToolSwitcherEventOutputMapping
+> {
     private _layoutSubStateMachine: LayoutStateMachine;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(layoutSubStateMachine: LayoutStateMachine) {
@@ -103,36 +158,58 @@ class ToolSwitcherLayoutState extends TemplateState<ToolSwitcherEvents, ToolSwit
         this._layoutSubStateMachine = layoutSubStateMachine;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    public uponEnter(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, fromState: ToolSwitcherStates) {
+    public uponEnter(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        fromState: ToolSwitcherStates
+    ) {
         this._layoutSubStateMachine.happens('startLayout');
         console.log('uponEnter');
     }
 
-    public beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
+    public beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
         this._layoutSubStateMachine.happens('endLayout');
     }
 
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
             console.log('eventKey', eventKey, 'event', event);
-            console.log('current state of the layout sub state machine', this._layoutSubStateMachine.currentState);
+            console.log(
+                'current state of the layout sub state machine',
+                this._layoutSubStateMachine.currentState
+            );
             const result = this._layoutSubStateMachine.happens(eventKey, event);
             if (result.handled) {
                 return {
                     handled: true,
                     output: result.output,
-                }
+                };
             }
             return { handled: false };
         },
     };
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -165,16 +242,25 @@ class ToolSwitcherLayoutState extends TemplateState<ToolSwitcherEvents, ToolSwit
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
-    }
-};
+        },
+    };
+}
 
-class ToolSwitcherTrainState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+class ToolSwitcherTrainState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
     private _trainSubStateMachine: TrainPlacementStateMachine;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(trainSubStateMachine: TrainPlacementStateMachine) {
@@ -182,12 +268,19 @@ class ToolSwitcherTrainState extends TemplateState<ToolSwitcherEvents, ToolSwitc
         this._trainSubStateMachine = trainSubStateMachine;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -220,38 +313,68 @@ class ToolSwitcherTrainState extends TemplateState<ToolSwitcherEvents, ToolSwitc
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
+        },
+    };
+
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
+        this._trainSubStateMachine.happens('startPlacement');
     }
 
-    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
-        this._trainSubStateMachine.happens("startPlacement");
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
+        this._trainSubStateMachine.happens('endPlacement');
     }
 
-    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
-        this._trainSubStateMachine.happens("endPlacement");
-    }
-
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
             console.log('eventKey', eventKey, 'event', event);
-            console.log('current state of the train sub state machine', this._trainSubStateMachine.currentState);
+            console.log(
+                'current state of the train sub state machine',
+                this._trainSubStateMachine.currentState
+            );
             const result = this._trainSubStateMachine.happens(eventKey, event);
             if (result.handled) {
                 return {
-                    handled: true, output: result.output,
-                }
+                    handled: true,
+                    output: result.output,
+                };
             }
             return { handled: false };
         },
     };
-};
+}
 
-class ToolSwitcherStationState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+class ToolSwitcherStationState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
     private _stationSubStateMachine: StationPlacementStateMachine;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(stationSubStateMachine: StationPlacementStateMachine) {
@@ -259,12 +382,19 @@ class ToolSwitcherStationState extends TemplateState<ToolSwitcherEvents, ToolSwi
         this._stationSubStateMachine = stationSubStateMachine;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -297,34 +427,63 @@ class ToolSwitcherStationState extends TemplateState<ToolSwitcherEvents, ToolSwi
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
+        },
+    };
+
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
+        this._stationSubStateMachine.happens('startPlacement');
     }
 
-    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
-        this._stationSubStateMachine.happens("startPlacement");
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
+        this._stationSubStateMachine.happens('endPlacement');
     }
 
-    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
-        this._stationSubStateMachine.happens("endPlacement");
-    }
-
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
-            const result = this._stationSubStateMachine.happens(eventKey, event);
+            const result = this._stationSubStateMachine.happens(
+                eventKey,
+                event
+            );
             if (result.handled) {
                 return { handled: true, output: result.output };
             }
             return { handled: false };
         },
     };
-};
+}
 
-class ToolSwitcherDuplicateState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+class ToolSwitcherDuplicateState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
     private _duplicateSubStateMachine: DuplicateToSideStateMachine;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(duplicateSubStateMachine: DuplicateToSideStateMachine) {
@@ -332,12 +491,19 @@ class ToolSwitcherDuplicateState extends TemplateState<ToolSwitcherEvents, ToolS
         this._duplicateSubStateMachine = duplicateSubStateMachine;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -370,34 +536,63 @@ class ToolSwitcherDuplicateState extends TemplateState<ToolSwitcherEvents, ToolS
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
-    }
+        },
+    };
 
-    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
         this._duplicateSubStateMachine.happens('startDuplicate');
     }
 
-    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
         this._duplicateSubStateMachine.happens('endDuplicate');
     }
 
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
-            const result = this._duplicateSubStateMachine.happens(eventKey, event);
+            const result = this._duplicateSubStateMachine.happens(
+                eventKey,
+                event
+            );
             if (result.handled) {
                 return { handled: true, output: result.output };
             }
             return { handled: false };
         },
     };
-};
+}
 
-class ToolSwitcherCatenaryState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+class ToolSwitcherCatenaryState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
     private _catenarySubStateMachine: CatenaryLayoutStateMachine;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(catenarySubStateMachine: CatenaryLayoutStateMachine) {
@@ -405,12 +600,19 @@ class ToolSwitcherCatenaryState extends TemplateState<ToolSwitcherEvents, ToolSw
         this._catenarySubStateMachine = catenarySubStateMachine;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -443,35 +645,64 @@ class ToolSwitcherCatenaryState extends TemplateState<ToolSwitcherEvents, ToolSw
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
-    }
+        },
+    };
 
-    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
         this._catenarySubStateMachine.happens('startCatenary');
     }
 
-    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
         this._catenarySubStateMachine.happens('endCatenary');
     }
 
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
-            const result = this._catenarySubStateMachine.happens(eventKey, event);
+            const result = this._catenarySubStateMachine.happens(
+                eventKey,
+                event
+            );
             if (result.handled) {
                 return { handled: true, output: result.output };
             }
             return { handled: false };
         },
     };
-};
+}
 
-class ToolSwitcherSingleSpinePlatformState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+class ToolSwitcherSingleSpinePlatformState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
     private _subStateMachine: SingleSpinePlacementStateMachine;
     private _stationId: number = 0;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(subStateMachine: SingleSpinePlacementStateMachine) {
@@ -483,12 +714,19 @@ class ToolSwitcherSingleSpinePlatformState extends TemplateState<ToolSwitcherEve
         this._stationId = id;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -521,21 +759,44 @@ class ToolSwitcherSingleSpinePlatformState extends TemplateState<ToolSwitcherEve
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
+        },
+    };
+
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
+        this._subStateMachine.happens('startPlacement', {
+            stationId: this._stationId,
+        });
     }
 
-    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
-        this._subStateMachine.happens('startPlacement', { stationId: this._stationId });
-    }
-
-    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
         this._subStateMachine.happens('endPlacement');
     }
 
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
             const result = this._subStateMachine.happens(eventKey, event);
             if (result.handled) {
@@ -544,12 +805,17 @@ class ToolSwitcherSingleSpinePlatformState extends TemplateState<ToolSwitcherEve
             return { handled: false };
         },
     };
-};
+}
 
-class ToolSwitcherDualSpinePlatformState extends TemplateState<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> {
+class ToolSwitcherDualSpinePlatformState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
     private _subStateMachine: DualSpinePlacementStateMachine;
     private _stationId: number = 0;
-    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null = null;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
     private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
 
     constructor(subStateMachine: DualSpinePlacementStateMachine) {
@@ -561,12 +827,19 @@ class ToolSwitcherDualSpinePlatformState extends TemplateState<ToolSwitcherEvent
         this._stationId = id;
     }
 
-    setSubStates(singleSpineState: ToolSwitcherSingleSpinePlatformState, dualSpineState: ToolSwitcherDualSpinePlatformState) {
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
         this._singleSpineState = singleSpineState;
         this._dualSpineState = dualSpineState;
     }
 
-    protected _eventReactions: EventReactions<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates> = {
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
         switchToLayout: {
             action: NO_OP,
             defaultTargetState: 'LAYOUT',
@@ -599,21 +872,44 @@ class ToolSwitcherDualSpinePlatformState extends TemplateState<ToolSwitcherEvent
             },
             defaultTargetState: 'DUAL_SPINE_PLATFORM',
         },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
         switchToIdle: {
             action: NO_OP,
             defaultTargetState: 'IDLE',
-        }
+        },
+    };
+
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
+        this._subStateMachine.happens('startPlacement', {
+            stationId: this._stationId,
+        });
     }
 
-    uponEnter(context: BaseContext, stateMachine: StateMachine<ToolSwitcherEvents, BaseContext, ToolSwitcherStates, DefaultOutputMapping<ToolSwitcherEvents>>, from: ToolSwitcherStates | "INITIAL"): void {
-        this._subStateMachine.happens('startPlacement', { stationId: this._stationId });
-    }
-
-    beforeExit(context: ToolSwitcherContext, stateMachine: ToolSwitcherStateMachine, toState: ToolSwitcherStates) {
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
         this._subStateMachine.happens('endPlacement');
     }
 
-    protected _defer: Defer<ToolSwitcherContext, ToolSwitcherEvents, ToolSwitcherStates> = {
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
         action: (context, event, eventKey, stateMachine) => {
             const result = this._subStateMachine.happens(eventKey, event);
             if (result.handled) {
@@ -622,7 +918,113 @@ class ToolSwitcherDualSpinePlatformState extends TemplateState<ToolSwitcherEvent
             return { handled: false };
         },
     };
-};
+}
+
+class ToolSwitcherJointDirectionState extends TemplateState<
+    ToolSwitcherEvents,
+    ToolSwitcherContext,
+    ToolSwitcherStates
+> {
+    private _subStateMachine: JointDirectionStateMachine;
+    private _singleSpineState: ToolSwitcherSingleSpinePlatformState | null =
+        null;
+    private _dualSpineState: ToolSwitcherDualSpinePlatformState | null = null;
+
+    constructor(subStateMachine: JointDirectionStateMachine) {
+        super();
+        this._subStateMachine = subStateMachine;
+    }
+
+    setSubStates(
+        singleSpineState: ToolSwitcherSingleSpinePlatformState,
+        dualSpineState: ToolSwitcherDualSpinePlatformState
+    ) {
+        this._singleSpineState = singleSpineState;
+        this._dualSpineState = dualSpineState;
+    }
+
+    protected _eventReactions: EventReactions<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    > = {
+        switchToLayout: {
+            action: NO_OP,
+            defaultTargetState: 'LAYOUT',
+        },
+        switchToTrain: {
+            action: NO_OP,
+            defaultTargetState: 'TRAIN',
+        },
+        switchToStation: {
+            action: NO_OP,
+            defaultTargetState: 'STATION',
+        },
+        switchToDuplicate: {
+            action: NO_OP,
+            defaultTargetState: 'DUPLICATE',
+        },
+        switchToCatenary: {
+            action: NO_OP,
+            defaultTargetState: 'CATENARY',
+        },
+        switchToSingleSpinePlatform: {
+            action: (_context, event) => {
+                this._singleSpineState?.setStationId(event.stationId);
+            },
+            defaultTargetState: 'SINGLE_SPINE_PLATFORM',
+        },
+        switchToDualSpinePlatform: {
+            action: (_context, event) => {
+                this._dualSpineState?.setStationId(event.stationId);
+            },
+            defaultTargetState: 'DUAL_SPINE_PLATFORM',
+        },
+        switchToJointDirection: {
+            action: NO_OP,
+            defaultTargetState: 'JOINT_DIRECTION',
+        },
+        switchToIdle: {
+            action: NO_OP,
+            defaultTargetState: 'IDLE',
+        },
+    };
+
+    uponEnter(
+        context: BaseContext,
+        stateMachine: StateMachine<
+            ToolSwitcherEvents,
+            BaseContext,
+            ToolSwitcherStates,
+            DefaultOutputMapping<ToolSwitcherEvents>
+        >,
+        from: ToolSwitcherStates | 'INITIAL'
+    ): void {
+        this._subStateMachine.happens('startJointDirection');
+    }
+
+    beforeExit(
+        context: ToolSwitcherContext,
+        stateMachine: ToolSwitcherStateMachine,
+        toState: ToolSwitcherStates
+    ) {
+        this._subStateMachine.happens('endJointDirection');
+    }
+
+    protected _defer: Defer<
+        ToolSwitcherContext,
+        ToolSwitcherEvents,
+        ToolSwitcherStates
+    > = {
+        action: (context, event, eventKey, stateMachine) => {
+            const result = this._subStateMachine.happens(eventKey, event);
+            if (result.handled) {
+                return { handled: true, output: result.output };
+            }
+            return { handled: false };
+        },
+    };
+}
 
 export const createToolSwitcherStateMachine = (
     layoutSubStateMachine: LayoutStateMachine,
@@ -632,16 +1034,28 @@ export const createToolSwitcherStateMachine = (
     catenarySubStateMachine: CatenaryLayoutStateMachine,
     singleSpineSubStateMachine: SingleSpinePlacementStateMachine,
     dualSpineSubStateMachine: DualSpinePlacementStateMachine,
+    jointDirectionSubStateMachine: JointDirectionStateMachine
 ): ToolSwitcherStateMachine => {
-    const singleSpineState = new ToolSwitcherSingleSpinePlatformState(singleSpineSubStateMachine);
-    const dualSpineState = new ToolSwitcherDualSpinePlatformState(dualSpineSubStateMachine);
+    const singleSpineState = new ToolSwitcherSingleSpinePlatformState(
+        singleSpineSubStateMachine
+    );
+    const dualSpineState = new ToolSwitcherDualSpinePlatformState(
+        dualSpineSubStateMachine
+    );
 
     const idleState = new ToolSwitcherIdleState();
     const layoutState = new ToolSwitcherLayoutState(layoutSubStateMachine);
     const trainState = new ToolSwitcherTrainState(trainSubStateMachine);
     const stationState = new ToolSwitcherStationState(stationSubStateMachine);
-    const duplicateState = new ToolSwitcherDuplicateState(duplicateSubStateMachine);
-    const catenaryState = new ToolSwitcherCatenaryState(catenarySubStateMachine);
+    const duplicateState = new ToolSwitcherDuplicateState(
+        duplicateSubStateMachine
+    );
+    const catenaryState = new ToolSwitcherCatenaryState(
+        catenarySubStateMachine
+    );
+    const jointDirectionState = new ToolSwitcherJointDirectionState(
+        jointDirectionSubStateMachine
+    );
 
     idleState.setSubStates(singleSpineState, dualSpineState);
     layoutState.setSubStates(singleSpineState, dualSpineState);
@@ -651,19 +1065,28 @@ export const createToolSwitcherStateMachine = (
     catenaryState.setSubStates(singleSpineState, dualSpineState);
     singleSpineState.setSubStates(singleSpineState, dualSpineState);
     dualSpineState.setSubStates(singleSpineState, dualSpineState);
+    jointDirectionState.setSubStates(singleSpineState, dualSpineState);
 
-    return new TemplateStateMachine<ToolSwitcherEvents, ToolSwitcherContext, ToolSwitcherStates>({
-        IDLE: idleState,
-        LAYOUT: layoutState,
-        TRAIN: trainState,
-        STATION: stationState,
-        DUPLICATE: duplicateState,
-        CATENARY: catenaryState,
-        SINGLE_SPINE_PLATFORM: singleSpineState,
-        DUAL_SPINE_PLATFORM: dualSpineState,
-    }, 'IDLE', {
-        setup: () => { },
-        cleanup: () => { },
-    });
+    return new TemplateStateMachine<
+        ToolSwitcherEvents,
+        ToolSwitcherContext,
+        ToolSwitcherStates
+    >(
+        {
+            IDLE: idleState,
+            LAYOUT: layoutState,
+            TRAIN: trainState,
+            STATION: stationState,
+            DUPLICATE: duplicateState,
+            CATENARY: catenaryState,
+            SINGLE_SPINE_PLATFORM: singleSpineState,
+            DUAL_SPINE_PLATFORM: dualSpineState,
+            JOINT_DIRECTION: jointDirectionState,
+        },
+        'IDLE',
+        {
+            setup: () => {},
+            cleanup: () => {},
+        }
+    );
 };
-

--- a/apps/banana/src/trains/input-state-machine/train-kmt-state-machine.ts
+++ b/apps/banana/src/trains/input-state-machine/train-kmt-state-machine.ts
@@ -5,11 +5,22 @@ import {
     TemplateState,
     TemplateStateMachine,
 } from '@ue-too/being';
+import {
+    Canvas,
+    ObservableBoardCamera,
+    ObservableInputTracker,
+    convertFromCanvas2ViewPort,
+    convertFromCanvas2Window,
+    convertFromViewPort2Canvas,
+    convertFromViewport2World,
+    convertFromWindow2Canvas,
+    convertFromWorld2Viewport,
+} from '@ue-too/board';
 import { Point, PointCal } from '@ue-too/math';
 
-import { TrackGraph } from '../tracks/track';
 import { Formation, Train, TrainPosition } from '../formation';
-import { convertFromCanvas2ViewPort, convertFromWindow2Canvas, convertFromCanvas2Window, convertFromViewPort2Canvas, convertFromViewport2World, convertFromWorld2Viewport, ObservableBoardCamera, Canvas, ObservableInputTracker } from '@ue-too/board';
+import { JointDirectionPreferenceMap } from '../tracks/joint-direction-preference-map';
+import { TrackGraph } from '../tracks/track';
 
 export type TrainPlacementStates = 'IDLE' | 'HOVER_FOR_PLACEMENT';
 
@@ -69,9 +80,15 @@ export interface JointDirectionManager {
 
 export class DefaultJointDirectionManager implements JointDirectionManager {
     private _trackGraph: TrackGraph;
+    private _preferenceMap: JointDirectionPreferenceMap | null;
 
-    constructor(trackGraph: TrackGraph) {
+    constructor(trackGraph: TrackGraph, preferenceMap?: JointDirectionPreferenceMap) {
         this._trackGraph = trackGraph;
+        this._preferenceMap = preferenceMap ?? null;
+    }
+
+    get preferenceMap(): JointDirectionPreferenceMap | null {
+        return this._preferenceMap;
     }
 
     getNextJoint(
@@ -93,20 +110,29 @@ export class DefaultJointDirectionManager implements JointDirectionManager {
             return null;
         }
 
-        const selectedNextJointNumber = possibleNextJoints.values().next().value;
+        let selectedNextJointNumber: number | undefined;
+        if (this._preferenceMap) {
+            const preferred = this._preferenceMap.get(jointNumber, direction);
+            if (preferred !== undefined && possibleNextJoints.has(preferred)) {
+                selectedNextJointNumber = preferred;
+            }
+        }
+        if (selectedNextJointNumber === undefined) {
+            selectedNextJointNumber = possibleNextJoints.values().next().value;
+        }
         if (selectedNextJointNumber === undefined) {
             return null;
         }
-        const nextTrackSegmentNumber =
-            joint.connections.get(selectedNextJointNumber);
+        const nextTrackSegmentNumber = joint.connections.get(
+            selectedNextJointNumber
+        );
         const nextJoint = this._trackGraph.getJoint(selectedNextJointNumber);
         if (nextTrackSegmentNumber === undefined) {
             return null;
         }
-        const nextTrackSegment =
-            this._trackGraph.getTrackSegmentWithJoints(
-                nextTrackSegmentNumber
-            );
+        const nextTrackSegment = this._trackGraph.getTrackSegmentWithJoints(
+            nextTrackSegmentNumber
+        );
         if (nextJoint === null) {
             console.warn('next joint not found');
             return null;
@@ -213,12 +239,14 @@ export class WalkBackJointDirectionManager implements JointDirectionManager {
         }
         if (selectedNextJointNumber === undefined) return null;
 
-        const nextTrackSegmentNumber =
-            joint.connections.get(selectedNextJointNumber);
+        const nextTrackSegmentNumber = joint.connections.get(
+            selectedNextJointNumber
+        );
         if (nextTrackSegmentNumber === undefined) return null;
 
-        const nextTrackSegment =
-            this._trackGraph.getTrackSegmentWithJoints(nextTrackSegmentNumber);
+        const nextTrackSegment = this._trackGraph.getTrackSegmentWithJoints(
+            nextTrackSegmentNumber
+        );
         if (nextTrackSegment === null) return null;
 
         const nextDirection: 'tangent' | 'reverseTangent' =
@@ -240,7 +268,10 @@ export type TrainPlacementEngineOptions = {
     onPlaced?: (placed: Train) => Train | void;
 };
 
-export class TrainPlacementEngine extends ObservableInputTracker implements TrainPlacementContext {
+export class TrainPlacementEngine
+    extends ObservableInputTracker
+    implements TrainPlacementContext
+{
     private _trackGraph: TrackGraph;
     private _trainTangent: Point | null = null;
 
@@ -251,18 +282,19 @@ export class TrainPlacementEngine extends ObservableInputTracker implements Trai
     private _camera: ObservableBoardCamera;
     private _pendingFormation: Formation | null = null;
 
-    constructor(canvas: Canvas, trackGraph: TrackGraph, camera: ObservableBoardCamera, options?: TrainPlacementEngineOptions) {
+    constructor(
+        canvas: Canvas,
+        trackGraph: TrackGraph,
+        camera: ObservableBoardCamera,
+        options?: TrainPlacementEngineOptions
+    ) {
         super(canvas);
         this._trackGraph = trackGraph;
         this._jointDirectionManager = new DefaultJointDirectionManager(
             trackGraph
         );
         this._onPlaced = options?.onPlaced;
-        this._train = new Train(
-            null,
-            trackGraph,
-            this._jointDirectionManager
-        );
+        this._train = new Train(null, trackGraph, this._jointDirectionManager);
         this._camera = camera;
     }
 
@@ -274,7 +306,7 @@ export class TrainPlacementEngine extends ObservableInputTracker implements Trai
             null,
             this._trackGraph,
             this._jointDirectionManager,
-            formation ?? undefined,
+            formation ?? undefined
         );
     }
 
@@ -359,17 +391,33 @@ export class TrainPlacementEngine extends ObservableInputTracker implements Trai
     // position is in raw window coordinates space
     convert2WorldPosition(position: Point): Point {
         const pointInCanvas = convertFromWindow2Canvas(position, this.canvas);
-        const pointInViewPort = convertFromCanvas2ViewPort(pointInCanvas, { x: this.canvas.width / 2, y: this.canvas.height / 2 });
-        return convertFromViewport2World(pointInViewPort, this._camera.position, this._camera.zoomLevel, this._camera.rotation, false);
+        const pointInViewPort = convertFromCanvas2ViewPort(pointInCanvas, {
+            x: this.canvas.width / 2,
+            y: this.canvas.height / 2,
+        });
+        return convertFromViewport2World(
+            pointInViewPort,
+            this._camera.position,
+            this._camera.zoomLevel,
+            this._camera.rotation,
+            false
+        );
     }
 
     // position is in the world space
     convert2WindowPosition(position: Point): Point {
-        const pointInViewPort = convertFromWorld2Viewport(position, this._camera.position, this._camera.zoomLevel, this._camera.rotation);
-        const pointInCanvas = convertFromViewPort2Canvas(pointInViewPort, { x: this.canvas.width / 2, y: this.canvas.height / 2 });
+        const pointInViewPort = convertFromWorld2Viewport(
+            position,
+            this._camera.position,
+            this._camera.zoomLevel,
+            this._camera.rotation
+        );
+        const pointInCanvas = convertFromViewPort2Canvas(pointInViewPort, {
+            x: this.canvas.width / 2,
+            y: this.canvas.height / 2,
+        });
         return convertFromCanvas2Window(pointInCanvas, this.canvas);
     }
-
 }
 
 export class TrainPlacementStateMachine extends TemplateStateMachine<
@@ -399,11 +447,11 @@ export class TrainPlacementIDLEState extends TemplateState<
         TrainPlacementContext,
         TrainPlacementStates
     > = {
-            startPlacement: {
-                action: NO_OP,
-                defaultTargetState: 'HOVER_FOR_PLACEMENT',
-            },
-        };
+        startPlacement: {
+            action: NO_OP,
+            defaultTargetState: 'HOVER_FOR_PLACEMENT',
+        },
+    };
 }
 
 export class TrainPlacementHoverForPlacementState extends TemplateState<
@@ -416,37 +464,43 @@ export class TrainPlacementHoverForPlacementState extends TemplateState<
         TrainPlacementContext,
         TrainPlacementStates
     > = {
-            endPlacement: {
-                action: context => {
-                    context.cancelCurrentTrainPlacement();
-                },
-                defaultTargetState: 'IDLE',
+        endPlacement: {
+            action: context => {
+                context.cancelCurrentTrainPlacement();
             },
-            leftPointerUp: {
-                action: (context, event) => {
-                    const worldPosition = context.convert2WorldPosition({ x: event.x, y: event.y });
-                    context.placeTrain(worldPosition);
-                },
-                defaultTargetState: 'HOVER_FOR_PLACEMENT',
+            defaultTargetState: 'IDLE',
+        },
+        leftPointerUp: {
+            action: (context, event) => {
+                const worldPosition = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                context.placeTrain(worldPosition);
             },
-            pointerMove: {
-                action: (context, event) => {
-                    const worldPosition = context.convert2WorldPosition({ x: event.x, y: event.y });
-                    context.hoverForPlacement(worldPosition);
-                },
-                defaultTargetState: 'HOVER_FOR_PLACEMENT',
+            defaultTargetState: 'HOVER_FOR_PLACEMENT',
+        },
+        pointerMove: {
+            action: (context, event) => {
+                const worldPosition = context.convert2WorldPosition({
+                    x: event.x,
+                    y: event.y,
+                });
+                context.hoverForPlacement(worldPosition);
             },
-            escapeKey: {
-                action: context => {
-                    context.cancelCurrentTrainPlacement();
-                },
-                defaultTargetState: 'IDLE',
+            defaultTargetState: 'HOVER_FOR_PLACEMENT',
+        },
+        escapeKey: {
+            action: context => {
+                context.cancelCurrentTrainPlacement();
             },
-            F: {
-                action: context => {
-                    context.flipTrainDirection();
-                },
-                defaultTargetState: 'HOVER_FOR_PLACEMENT',
-            }
-        };
+            defaultTargetState: 'IDLE',
+        },
+        F: {
+            action: context => {
+                context.flipTrainDirection();
+            },
+            defaultTargetState: 'HOVER_FOR_PLACEMENT',
+        },
+    };
 }

--- a/apps/banana/src/trains/tracks/joint-direction-preference-map.ts
+++ b/apps/banana/src/trains/tracks/joint-direction-preference-map.ts
@@ -1,0 +1,190 @@
+/**
+ * Per-joint preferred-branch storage for switch junctions.
+ *
+ * Stores the user's last chosen next-joint at each switch, keyed by
+ * (jointNumber, direction).  Used by `DefaultJointDirectionManager` to
+ * remember and cycle through the available branches.
+ *
+ * @module trains/tracks/joint-direction-preference-map
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The travel direction through a joint: leaving along its tangent or its
+ * reverse-tangent set.
+ */
+export type DirectionType = 'tangent' | 'reverseTangent';
+
+/**
+ * JSON-safe serialized form of preferences for a single joint.
+ * Only the directions that have been explicitly stored are present.
+ */
+export type SerializedJointDirectionPreference = {
+    joint: number;
+    tangent?: number;
+    reverseTangent?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Internal storage shape
+// ---------------------------------------------------------------------------
+
+type JointPreference = {
+    tangent?: number;
+    reverseTangent?: number;
+};
+
+// ---------------------------------------------------------------------------
+// Class
+// ---------------------------------------------------------------------------
+
+/**
+ * Stores the user's preferred next joint at switch junctions.
+ *
+ * @example
+ * ```typescript
+ * const prefs = new JointDirectionPreferenceMap();
+ * prefs.set(1, 'tangent', 3);
+ * prefs.get(1, 'tangent'); // 3
+ * prefs.cycle(1, 'tangent', new Set([2, 3, 4])); // → 4 (next after 3)
+ * ```
+ */
+export class JointDirectionPreferenceMap {
+    private _map: Map<number, JointPreference> = new Map();
+
+    // -----------------------------------------------------------------------
+    // get / set
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns the stored preferred next-joint number, or `undefined` if none
+     * has been set for this (jointNumber, direction) pair.
+     */
+    get(jointNumber: number, direction: DirectionType): number | undefined {
+        return this._map.get(jointNumber)?.[direction];
+    }
+
+    /**
+     * Stores `nextJointNumber` as the preferred outgoing joint when leaving
+     * `jointNumber` in the given `direction`.
+     */
+    set(
+        jointNumber: number,
+        direction: DirectionType,
+        nextJointNumber: number
+    ): void {
+        let entry = this._map.get(jointNumber);
+        if (entry === undefined) {
+            entry = {};
+            this._map.set(jointNumber, entry);
+        }
+        entry[direction] = nextJointNumber;
+    }
+
+    // -----------------------------------------------------------------------
+    // clear
+    // -----------------------------------------------------------------------
+
+    /**
+     * Clears preferences.
+     *
+     * @param jointNumber - If provided, only that joint's preferences are
+     *   removed.  If omitted, all preferences are cleared.
+     */
+    clear(jointNumber?: number): void {
+        if (jointNumber === undefined) {
+            this._map.clear();
+        } else {
+            this._map.delete(jointNumber);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // cycle
+    // -----------------------------------------------------------------------
+
+    /**
+     * Advances the stored preference to the next joint in `availableJoints`
+     * (in Set iteration order), wrapping around after the last entry.
+     *
+     * - If no preference is currently stored, the first joint in the set is
+     *   chosen.
+     * - If the stored preference is no longer in `availableJoints` (stale),
+     *   the first joint is chosen.
+     *
+     * The chosen joint is persisted via {@link set} and returned.
+     *
+     * @param jointNumber - The switch joint.
+     * @param direction - The travel direction through the joint.
+     * @param availableJoints - The full set of reachable next joints.
+     * @returns The newly selected next-joint number.
+     */
+    cycle(
+        jointNumber: number,
+        direction: DirectionType,
+        availableJoints: Set<number>
+    ): number {
+        const joints = Array.from(availableJoints);
+        const current = this.get(jointNumber, direction);
+
+        let nextIndex: number;
+        if (current === undefined || !availableJoints.has(current)) {
+            nextIndex = 0;
+        } else {
+            const currentIndex = joints.indexOf(current);
+            nextIndex = (currentIndex + 1) % joints.length;
+        }
+
+        const chosen = joints[nextIndex]!;
+        this.set(jointNumber, direction, chosen);
+        return chosen;
+    }
+
+    // -----------------------------------------------------------------------
+    // serialize / deserialize
+    // -----------------------------------------------------------------------
+
+    /**
+     * Returns a JSON-safe snapshot of all stored preferences.
+     */
+    serialize(): SerializedJointDirectionPreference[] {
+        const result: SerializedJointDirectionPreference[] = [];
+        for (const [joint, prefs] of this._map) {
+            const entry: SerializedJointDirectionPreference = { joint };
+            if (prefs.tangent !== undefined) {
+                entry.tangent = prefs.tangent;
+            }
+            if (prefs.reverseTangent !== undefined) {
+                entry.reverseTangent = prefs.reverseTangent;
+            }
+            result.push(entry);
+        }
+        return result;
+    }
+
+    /**
+     * Reconstructs a {@link JointDirectionPreferenceMap} from serialized data
+     * produced by {@link serialize}.
+     */
+    static deserialize(
+        data: SerializedJointDirectionPreference[]
+    ): JointDirectionPreferenceMap {
+        const instance = new JointDirectionPreferenceMap();
+        for (const entry of data) {
+            if (entry.tangent !== undefined) {
+                instance.set(entry.joint, 'tangent', entry.tangent);
+            }
+            if (entry.reverseTangent !== undefined) {
+                instance.set(
+                    entry.joint,
+                    'reverseTangent',
+                    entry.reverseTangent
+                );
+            }
+        }
+        return instance;
+    }
+}

--- a/apps/banana/src/trains/tracks/joint-direction-render-system.ts
+++ b/apps/banana/src/trains/tracks/joint-direction-render-system.ts
@@ -1,0 +1,343 @@
+import {
+    CameraState,
+    CameraZoomEventPayload,
+    ObservableBoardCamera,
+} from '@ue-too/board';
+import { Container, Graphics } from 'pixi.js';
+
+import { WorldRenderSystem } from '@/world-render-system';
+
+import { JointDirectionPreferenceMap } from './joint-direction-preference-map';
+import type { DirectionType } from './joint-direction-preference-map';
+import type { TrackGraph } from './track';
+
+/** Base radius for the hover dot (world units); effective size = this / zoomLevel. */
+const HOVER_DOT_RADIUS = 8;
+
+/** Number of sample points for the full segment highlight polyline. */
+const HIGHLIGHT_SAMPLE_COUNT = 30;
+
+/** Number of sample points for the curved arrow polyline. */
+const ARROW_SAMPLE_COUNT = 10;
+
+/** Fraction of the curve to follow for the curved arrow. */
+const ARROW_CURVE_FRACTION = 0.2;
+
+/** Line width for highlights and arrows (world units, scaled by 1/zoom). */
+const LINE_WIDTH = 6;
+
+/** Color for the selected branch (green-500). */
+const COLOR_SELECTED = 0x22c55e;
+
+/** Color for unselected branches (gray-400). */
+const COLOR_UNSELECTED = 0x9ca3af;
+
+/** Alpha for the selected branch. */
+const ALPHA_SELECTED = 1.0;
+
+/** Alpha for unselected branches. */
+const ALPHA_UNSELECTED = 0.4;
+
+/** Color for the hover dot (blue-400). */
+const HOVER_DOT_COLOR = 0x60a5fa;
+
+/** Alpha for the hover dot. */
+const HOVER_DOT_ALPHA = 0.6;
+
+/** Arrowhead length (world units, before scaling). */
+const ARROWHEAD_LENGTH = 12;
+
+/** Arrowhead half-width (world units, before scaling). */
+const ARROWHEAD_HALF_WIDTH = 7;
+
+/**
+ * Renders direction indicator overlays on switch joints.
+ *
+ * Shows:
+ * - A hover dot when the cursor is over a joint
+ * - Segment highlight polylines and curved arrows when a joint is selected
+ *
+ * All indicators scale with 1/zoomLevel to remain constant screen size.
+ */
+export class JointDirectionRenderSystem {
+    private _worldRenderSystem: WorldRenderSystem;
+    private _trackGraph: TrackGraph;
+    private _preferenceMap: JointDirectionPreferenceMap;
+    private _camera: ObservableBoardCamera;
+
+    private _overlayContainer: Container;
+    private _highlightContainer: Container;
+    private _arrowContainer: Container;
+    private _hoverGraphic: Graphics;
+
+    private _zoomLevel: number;
+    private _selectedJointNumber: number | null = null;
+    private _abortController = new AbortController();
+
+    constructor(
+        worldRenderSystem: WorldRenderSystem,
+        trackGraph: TrackGraph,
+        preferenceMap: JointDirectionPreferenceMap,
+        camera: ObservableBoardCamera
+    ) {
+        this._worldRenderSystem = worldRenderSystem;
+        this._trackGraph = trackGraph;
+        this._preferenceMap = preferenceMap;
+        this._camera = camera;
+
+        this._overlayContainer = new Container();
+        this._highlightContainer = new Container();
+        this._arrowContainer = new Container();
+        this._hoverGraphic = new Graphics();
+
+        this._overlayContainer.addChild(this._highlightContainer);
+        this._overlayContainer.addChild(this._arrowContainer);
+        this._overlayContainer.addChild(this._hoverGraphic);
+
+        this._overlayContainer.visible = false;
+
+        this._worldRenderSystem.addOverlayContainer(this._overlayContainer);
+
+        this._zoomLevel = this._camera.zoomLevel;
+        this._camera.on('zoom', this._onZoom.bind(this), {
+            signal: this._abortController.signal,
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // Public API
+    // -------------------------------------------------------------------------
+
+    /** The currently selected joint number, or null if none. */
+    get selectedJoint(): number | null {
+        return this._selectedJointNumber;
+    }
+
+    /** Make overlay visible (tool activated). */
+    show(): void {
+        this._overlayContainer.visible = true;
+    }
+
+    /** Hide overlay and clear everything (tool deactivated). */
+    hide(): void {
+        this._overlayContainer.visible = false;
+        this._clearSelection();
+        this._hoverGraphic.clear();
+        this._selectedJointNumber = null;
+    }
+
+    /** Draw a dot on the hovered joint. */
+    showHoverIndicator(jointNumber: number): void {
+        const joint = this._trackGraph.getJoint(jointNumber);
+        if (joint === null) return;
+
+        const scale = 1 / this._zoomLevel;
+        const radius = HOVER_DOT_RADIUS * scale;
+
+        this._hoverGraphic.clear();
+        this._hoverGraphic.circle(joint.position.x, joint.position.y, radius);
+        this._hoverGraphic.fill({
+            color: HOVER_DOT_COLOR,
+            alpha: HOVER_DOT_ALPHA,
+        });
+    }
+
+    /** Remove the hover dot. */
+    clearHoverIndicator(): void {
+        this._hoverGraphic.clear();
+    }
+
+    /** Show arrows and highlights for the given joint. */
+    selectJoint(jointNumber: number): void {
+        this._selectedJointNumber = jointNumber;
+        this._drawSelection();
+    }
+
+    /** Remove arrows and highlights. */
+    deselectJoint(): void {
+        this._selectedJointNumber = null;
+        this._clearSelection();
+    }
+
+    /** Redraw after a direction cycle. */
+    refresh(): void {
+        if (this._selectedJointNumber !== null) {
+            this._drawSelection();
+        }
+    }
+
+    /** Cleanup listeners and destroy containers. */
+    dispose(): void {
+        this._abortController.abort();
+        this._overlayContainer.destroy({ children: true });
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    private _onZoom(_event: CameraZoomEventPayload, state: CameraState): void {
+        this._zoomLevel = state.zoomLevel;
+        if (this._selectedJointNumber !== null) {
+            this._drawSelection();
+        }
+        // Redraw hover if visible
+        // (hover will be redrawn by the next showHoverIndicator call from the state machine)
+    }
+
+    private _clearSelection(): void {
+        const removed1 = this._highlightContainer.removeChildren();
+        removed1.forEach(c => c.destroy({ children: true }));
+        const removed2 = this._arrowContainer.removeChildren();
+        removed2.forEach(c => c.destroy({ children: true }));
+    }
+
+    private _drawSelection(): void {
+        this._clearSelection();
+
+        const jointNumber = this._selectedJointNumber;
+        if (jointNumber === null) return;
+
+        const joint = this._trackGraph.getJoint(jointNumber);
+        if (joint === null) return;
+
+        const scale = 1 / this._zoomLevel;
+        const directions: DirectionType[] = ['tangent', 'reverseTangent'];
+
+        for (const direction of directions) {
+            const branches = joint.direction[direction];
+            if (branches.size <= 1) continue;
+
+            // Determine selected branch
+            const pref = this._preferenceMap.get(jointNumber, direction);
+            const selectedBranch =
+                pref !== undefined && branches.has(pref)
+                    ? pref
+                    : branches.values().next().value!;
+
+            for (const nextJointNumber of branches) {
+                const segmentNumber = joint.connections.get(nextJointNumber);
+                if (segmentNumber === undefined) continue;
+
+                const segment =
+                    this._trackGraph.getTrackSegmentWithJoints(segmentNumber);
+                if (segment === null) continue;
+
+                const isSelected = nextJointNumber === selectedBranch;
+                const color = isSelected ? COLOR_SELECTED : COLOR_UNSELECTED;
+                const alpha = isSelected ? ALPHA_SELECTED : ALPHA_UNSELECTED;
+                const lineWidth = LINE_WIDTH * scale;
+
+                // Determine which end of the curve is at this joint
+                const jointIsT0 = segment.t0Joint === jointNumber;
+
+                // --- Highlight: full segment polyline ---
+                const highlightGraphic = new Graphics();
+                const highlightPoints = this._sampleCurve(
+                    segment.curve,
+                    0,
+                    1,
+                    HIGHLIGHT_SAMPLE_COUNT,
+                    false
+                );
+                if (highlightPoints.length >= 2) {
+                    highlightGraphic.moveTo(
+                        highlightPoints[0]!.x,
+                        highlightPoints[0]!.y
+                    );
+                    for (let i = 1; i < highlightPoints.length; i++) {
+                        highlightGraphic.lineTo(
+                            highlightPoints[i]!.x,
+                            highlightPoints[i]!.y
+                        );
+                    }
+                    highlightGraphic.stroke({ width: lineWidth, color, alpha });
+                }
+                this._highlightContainer.addChild(highlightGraphic);
+
+                // --- Arrow: first ~20% of the curve from the joint side ---
+                const arrowStart = jointIsT0 ? 0 : 1;
+                const arrowEnd = jointIsT0
+                    ? ARROW_CURVE_FRACTION
+                    : 1 - ARROW_CURVE_FRACTION;
+                const reverse = !jointIsT0;
+
+                const arrowPoints = this._sampleCurve(
+                    segment.curve,
+                    arrowStart,
+                    arrowEnd,
+                    ARROW_SAMPLE_COUNT,
+                    reverse
+                );
+
+                if (arrowPoints.length >= 2) {
+                    const arrowGraphic = new Graphics();
+
+                    arrowGraphic.moveTo(arrowPoints[0]!.x, arrowPoints[0]!.y);
+                    for (let i = 1; i < arrowPoints.length; i++) {
+                        arrowGraphic.lineTo(
+                            arrowPoints[i]!.x,
+                            arrowPoints[i]!.y
+                        );
+                    }
+                    arrowGraphic.stroke({ width: lineWidth, color, alpha });
+
+                    // Arrowhead at the tip
+                    const tip = arrowPoints[arrowPoints.length - 1]!;
+                    const prev = arrowPoints[arrowPoints.length - 2]!;
+                    const dx = tip.x - prev.x;
+                    const dy = tip.y - prev.y;
+                    const mag = Math.sqrt(dx * dx + dy * dy);
+
+                    if (mag > 1e-6) {
+                        const ux = dx / mag;
+                        const uy = dy / mag;
+                        const perpX = -uy;
+                        const perpY = ux;
+
+                        const headLen = ARROWHEAD_LENGTH * scale;
+                        const headHalfWidth = ARROWHEAD_HALF_WIDTH * scale;
+
+                        const baseX = tip.x - headLen * ux;
+                        const baseY = tip.y - headLen * uy;
+                        const leftX = baseX + headHalfWidth * perpX;
+                        const leftY = baseY + headHalfWidth * perpY;
+                        const rightX = baseX - headHalfWidth * perpX;
+                        const rightY = baseY - headHalfWidth * perpY;
+
+                        arrowGraphic.moveTo(tip.x, tip.y);
+                        arrowGraphic.lineTo(leftX, leftY);
+                        arrowGraphic.lineTo(rightX, rightY);
+                        arrowGraphic.closePath();
+                        arrowGraphic.fill({ color, alpha });
+                    }
+
+                    this._arrowContainer.addChild(arrowGraphic);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sample `count` evenly-spaced points along the curve from parameter `tFrom` to `tTo`.
+     * If `reverse` is true, sample from `tFrom` down to `tTo` (i.e. tFrom > tTo).
+     */
+    private _sampleCurve(
+        curve: { get(t: number): { x: number; y: number } },
+        tFrom: number,
+        tTo: number,
+        count: number,
+        reverse: boolean
+    ): { x: number; y: number }[] {
+        const points: { x: number; y: number }[] = [];
+        const steps = count - 1;
+        for (let i = 0; i <= steps; i++) {
+            const frac = i / steps;
+            const t = reverse
+                ? tFrom - frac * (tFrom - tTo)
+                : tFrom + frac * (tTo - tFrom);
+            points.push(curve.get(t));
+        }
+        return points;
+    }
+}

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -8,7 +8,7 @@ import {
     InitAppOptions,
     baseInitApp,
 } from '@ue-too/board-pixi-integration';
-import { Point } from '@ue-too/math';
+import { Point, PointCal } from '@ue-too/math';
 import { toast } from 'sonner';
 import Stats from 'stats.js';
 
@@ -63,6 +63,7 @@ import {
 import { createLayoutStateMachine } from '@/trains/input-state-machine/utils';
 import { DebugOverlayRenderSystem } from '@/trains/tracks/debug-overlay-render-system';
 import { JointDirectionPreferenceMap } from '@/trains/tracks/joint-direction-preference-map';
+import { JointDirectionRenderSystem } from '@/trains/tracks/joint-direction-render-system';
 import {
     type ParallelTrackOptions,
     type ProceduralTrackOptions,
@@ -283,6 +284,7 @@ export type BananaAppComponents = BaseAppComponents & {
     formationManager: FormationManager;
     jointDirectionManager: JointDirectionManager;
     jointDirectionPreferenceMap: JointDirectionPreferenceMap;
+    jointDirectionRenderSystem: JointDirectionRenderSystem;
     layoutStateMachine: LayoutStateMachine;
     kmtStateMachineExpansion: KmtExpandedStateMachine;
     trainStateMachine: TrainPlacementStateMachine;
@@ -541,6 +543,81 @@ export const initApp = async (
 
     const jointDirectionSubStateMachine = createJointDirectionStateMachine();
 
+    const trackGraph = curveEngine.trackGraph;
+    const jointDirectionPreferenceMap = new JointDirectionPreferenceMap();
+
+    const jointDirectionRenderSystem = new JointDirectionRenderSystem(
+        worldRenderSystem,
+        trackGraph,
+        jointDirectionPreferenceMap,
+        baseComponents.camera
+    );
+
+    jointDirectionSubStateMachine.setContext({
+        setup: () => {},
+        cleanup: () => {},
+        convert2WorldPosition: pos => {
+            return curveEngine.convert2WorldPosition(pos);
+        },
+        getHoveredSwitchJoint: worldPos => {
+            const joints = trackGraph.getJoints();
+            let closestJoint: number | null = null;
+            let closestDist = 30 / baseComponents.camera.zoomLevel;
+            for (const { jointNumber, joint } of joints) {
+                if (
+                    joint.direction.tangent.size <= 1 &&
+                    joint.direction.reverseTangent.size <= 1
+                )
+                    continue;
+                const dist = PointCal.distanceBetweenPoints(
+                    worldPos,
+                    joint.position
+                );
+                if (dist < closestDist) {
+                    closestDist = dist;
+                    closestJoint = jointNumber;
+                }
+            }
+            return closestJoint;
+        },
+        showHoverIndicator: jointNumber => {
+            jointDirectionRenderSystem.showHoverIndicator(jointNumber);
+        },
+        clearHoverIndicator: () => {
+            jointDirectionRenderSystem.clearHoverIndicator();
+        },
+        selectJoint: jointNumber => {
+            jointDirectionRenderSystem.selectJoint(jointNumber);
+        },
+        deselectJoint: () => {
+            jointDirectionRenderSystem.deselectJoint();
+        },
+        cycleDirection: (jointNumber, direction) => {
+            const joint = trackGraph.getJoint(jointNumber);
+            if (!joint) return;
+            const available = joint.direction[direction];
+            if (available.size <= 1) return;
+            jointDirectionPreferenceMap.cycle(
+                jointNumber,
+                direction,
+                available
+            );
+            jointDirectionRenderSystem.refresh();
+        },
+        getSelectedJointTangent: () => {
+            const selected = jointDirectionRenderSystem.selectedJoint;
+            if (selected === null) return null;
+            const joint = trackGraph.getJoint(selected);
+            return joint?.tangent ?? null;
+        },
+        getSelectedJointPosition: () => {
+            const selected = jointDirectionRenderSystem.selectedJoint;
+            if (selected === null) return null;
+            const joint = trackGraph.getJoint(selected);
+            return joint?.position ?? null;
+        },
+    });
+
     const trackRenderSystem = new TrackRenderSystem(
         worldRenderSystem,
         curveEngine.trackGraph.trackCurveManager,
@@ -592,8 +669,6 @@ export const initApp = async (
     const trainManager = new TrainManager();
     const carStockManager = new CarStockManager();
     const formationManager = new FormationManager(carStockManager);
-    const trackGraph = curveEngine.trackGraph;
-    const jointDirectionPreferenceMap = new JointDirectionPreferenceMap();
     const jointDirectionManager = new DefaultJointDirectionManager(
         trackGraph,
         jointDirectionPreferenceMap
@@ -858,6 +933,7 @@ export const initApp = async (
         formationManager,
         jointDirectionManager,
         jointDirectionPreferenceMap,
+        jointDirectionRenderSystem,
         cameraMux,
         startFocusAnimation,
         startFollowAnimation,

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -1,51 +1,83 @@
-import { InitAppOptions, BaseAppComponents, baseInitApp } from '@ue-too/board-pixi-integration';
+import { Animation, Animator, NumberAnimationHelper } from '@ue-too/animate';
+import {
+    CameraMuxWithAnimationAndLock,
+    createCameraMuxWithAnimationAndLock,
+} from '@ue-too/board';
+import {
+    BaseAppComponents,
+    InitAppOptions,
+    baseInitApp,
+} from '@ue-too/board-pixi-integration';
+import { Point } from '@ue-too/math';
 import { toast } from 'sonner';
 import Stats from 'stats.js';
 
-import { Train, type TrainPosition } from '@/trains/formation';
-import type { JointDirectionManager } from '@/trains/input-state-machine/train-kmt-state-machine';
-import { DefaultJointDirectionManager, TrainPlacementEngine, TrainPlacementStateMachine } from '@/trains/input-state-machine/train-kmt-state-machine';
-import { LayoutStateMachine } from '@/trains/input-state-machine/layout-kmt-state-machine';
-import { CurveCreationEngine } from '@/trains/input-state-machine/curve-engine';
-import { CatenaryLayoutEngine } from '@/trains/input-state-machine/catenary-layout-engine';
-import { createCatenaryLayoutStateMachine } from '@/trains/input-state-machine/catenary-layout-state-machine';
-import { DuplicateToSideEngine } from '@/trains/input-state-machine/duplicate-to-side-engine';
-import { createDuplicateToSideStateMachine } from '@/trains/input-state-machine/duplicate-to-side-state-machine';
-import { createLayoutStateMachine } from '@/trains/input-state-machine/utils';
-import { DebugOverlayRenderSystem } from '@/trains/tracks/debug-overlay-render-system';
-import { generateProceduralTrackPath, generateParallelTracks, type ProceduralTrackOptions, type ParallelTrackOptions } from '@/trains/tracks/procedural-tracks';
-import { TrackRenderSystem } from '@/trains/tracks/render-system';
-import { TrainManager } from '@/trains/train-manager';
-import { CarStockManager } from '@/trains/car-stock-manager';
-import { FormationManager } from '@/trains/formation-manager';
-import { TrainRenderSystem } from '@/trains/train-render-system';
-import { WorldRenderSystem } from '@/world-render-system';
-import { TerrainData } from '@/terrain/terrain-data';
-import { TerrainRenderSystem } from '@/terrain/terrain-render-system';
 import { BuildingManager, BuildingRenderSystem } from '@/buildings';
-import { createKmtInputStateMachineExpansion, KmtExpandedStateMachine } from '@/trains/input-state-machine/kmt-state-machine-extension';
-import { CarImageRegistry } from '@/trains/car-image-registry';
-import { TimeManager } from '@/time';
-import { ScheduleClock, TimetableManager } from '@/timetable';
-import { BlockSignalManager, SignalStateEngine, SignalRenderSystem } from '@/signals';
+import i18n from '@/i18n';
+import {
+    BlockSignalManager,
+    SignalRenderSystem,
+    SignalStateEngine,
+} from '@/signals';
+import {
+    DualSpinePlacementEngine,
+    createDualSpinePlacementStateMachine,
+} from '@/stations/dual-spine-placement-state-machine';
+import {
+    SingleSpinePlacementEngine,
+    createSingleSpinePlacementStateMachine,
+} from '@/stations/single-spine-placement-state-machine';
 import { StationManager } from '@/stations/station-manager';
+import {
+    StationPlacementEngine,
+    StationPlacementStateMachine,
+} from '@/stations/station-placement-state-machine';
 import { StationRenderSystem } from '@/stations/station-render-system';
-import { StationPlacementEngine, StationPlacementStateMachine } from '@/stations/station-placement-state-machine';
 import { TrackAlignedPlatformManager } from '@/stations/track-aligned-platform-manager';
 import { TrackAlignedPlatformRenderSystem } from '@/stations/track-aligned-platform-render-system';
-import { SingleSpinePlacementEngine, createSingleSpinePlacementStateMachine } from '@/stations/single-spine-placement-state-machine';
-import { DualSpinePlacementEngine, createDualSpinePlacementStateMachine } from '@/stations/dual-spine-placement-state-machine';
-import { CameraMuxWithAnimationAndLock, createCameraMuxWithAnimationAndLock } from '@ue-too/board';
-import i18n from '@/i18n';
-import { Animator, NumberAnimationHelper, Animation } from '@ue-too/animate';
-import { Point } from '@ue-too/math';
-
+import { TerrainData } from '@/terrain/terrain-data';
+import { TerrainRenderSystem } from '@/terrain/terrain-render-system';
+import { TimeManager } from '@/time';
+import { ScheduleClock, TimetableManager } from '@/timetable';
+import { CarImageRegistry } from '@/trains/car-image-registry';
+import { CarStockManager } from '@/trains/car-stock-manager';
+import { Train, type TrainPosition } from '@/trains/formation';
+import { FormationManager } from '@/trains/formation-manager';
+import { CatenaryLayoutEngine } from '@/trains/input-state-machine/catenary-layout-engine';
+import { createCatenaryLayoutStateMachine } from '@/trains/input-state-machine/catenary-layout-state-machine';
+import { CurveCreationEngine } from '@/trains/input-state-machine/curve-engine';
+import { DuplicateToSideEngine } from '@/trains/input-state-machine/duplicate-to-side-engine';
+import { createDuplicateToSideStateMachine } from '@/trains/input-state-machine/duplicate-to-side-state-machine';
+import {
+    KmtExpandedStateMachine,
+    createKmtInputStateMachineExpansion,
+} from '@/trains/input-state-machine/kmt-state-machine-extension';
+import { LayoutStateMachine } from '@/trains/input-state-machine/layout-kmt-state-machine';
+import type { JointDirectionManager } from '@/trains/input-state-machine/train-kmt-state-machine';
+import {
+    DefaultJointDirectionManager,
+    TrainPlacementEngine,
+    TrainPlacementStateMachine,
+} from '@/trains/input-state-machine/train-kmt-state-machine';
+import { JointDirectionPreferenceMap } from '@/trains/tracks/joint-direction-preference-map';
+import { createLayoutStateMachine } from '@/trains/input-state-machine/utils';
+import { DebugOverlayRenderSystem } from '@/trains/tracks/debug-overlay-render-system';
+import {
+    type ParallelTrackOptions,
+    type ProceduralTrackOptions,
+    generateParallelTracks,
+    generateProceduralTrackPath,
+} from '@/trains/tracks/procedural-tracks';
+import { TrackRenderSystem } from '@/trains/tracks/render-system';
+import { TrainManager } from '@/trains/train-manager';
+import { TrainRenderSystem } from '@/trains/train-render-system';
+import { WorldRenderSystem } from '@/world-render-system';
 
 export type FocusAnimationParams = {
-  startWorldPoint: Point;
-  targetWorldPoint: Point;
-  startZoom: number;
-  targetZoom: number;
+    startWorldPoint: Point;
+    targetWorldPoint: Point;
+    startZoom: number;
+    targetZoom: number;
 };
 
 // ===========================================================================
@@ -161,12 +193,12 @@ export type FocusAnimationParams = {
 const VAN_WIJK_RHO = 1.42;
 
 type OptimalPath = {
-  /** Total arc length of the geodesic. */
-  S: number;
-  /** Pan parameter u at arc-length s. */
-  u: (s: number) => number;
-  /** Width parameter w at arc-length s. */
-  w: (s: number) => number;
+    /** Total arc length of the geodesic. */
+    S: number;
+    /** Pan parameter u at arc-length s. */
+    u: (s: number) => number;
+    /** Width parameter w at arc-length s. */
+    w: (s: number) => number;
 };
 
 /**
@@ -178,108 +210,118 @@ type OptimalPath = {
  * @param rho - zoom/pan trade-off parameter (default {@link VAN_WIJK_RHO})
  */
 function computeOptimalPath(
-  panDistance: number,
-  w0: number,
-  w1: number,
-  rho: number = VAN_WIJK_RHO,
+    panDistance: number,
+    w0: number,
+    w1: number,
+    rho: number = VAN_WIJK_RHO
 ): OptimalPath {
-  const u1 = panDistance;
+    const u1 = panDistance;
 
-  // --- Special case: pure zoom (no pan) ---
-  if (Math.abs(u1) < 1e-6) {
-    const k = w1 < w0 ? -1 : 1;
-    const S = Math.abs(Math.log(w1 / w0)) / rho;
+    // --- Special case: pure zoom (no pan) ---
+    if (Math.abs(u1) < 1e-6) {
+        const k = w1 < w0 ? -1 : 1;
+        const S = Math.abs(Math.log(w1 / w0)) / rho;
+        return {
+            S,
+            u: () => 0,
+            w: (s: number) => w0 * Math.exp(k * rho * s),
+        };
+    }
+
+    // --- General case: combined pan + zoom ---
+    const rho2 = rho * rho;
+    const rho4 = rho2 * rho2;
+
+    // b₀ = (w₁² − w₀² + ρ⁴Δu²) / (2 w₀ ρ² Δu)
+    const b0 = (w1 * w1 - w0 * w0 + rho4 * u1 * u1) / (2 * w0 * rho2 * u1);
+    // b₁ = (w₁² − w₀² − ρ⁴Δu²) / (2 w₁ ρ² Δu)
+    const b1 = (w1 * w1 - w0 * w0 - rho4 * u1 * u1) / (2 * w1 * rho2 * u1);
+
+    // rᵢ = arcsinh(−bᵢ) = ln(−bᵢ + √(bᵢ²+1))
+    const r0 = Math.log(-b0 + Math.sqrt(b0 * b0 + 1));
+    const r1 = Math.log(-b1 + Math.sqrt(b1 * b1 + 1));
+
+    const S = (r1 - r0) / rho;
+    const coshr0 = Math.cosh(r0);
+    const sinhr0 = Math.sinh(r0);
+
     return {
-      S,
-      u: () => 0,
-      w: (s: number) => w0 * Math.exp(k * rho * s),
+        S,
+        u: (s: number) => {
+            // u(s) = (w₀/ρ²) cosh(r₀) tanh(ρs + r₀) − (w₀/ρ²) sinh(r₀) + u₀
+            return (
+                (w0 / rho2) * coshr0 * Math.tanh(rho * s + r0) -
+                (w0 / rho2) * sinhr0
+            );
+        },
+        w: (s: number) => {
+            // w(s) = w₀ cosh(r₀) / cosh(ρs + r₀)
+            return (w0 * coshr0) / Math.cosh(rho * s + r0);
+        },
     };
-  }
-
-  // --- General case: combined pan + zoom ---
-  const rho2 = rho * rho;
-  const rho4 = rho2 * rho2;
-
-  // b₀ = (w₁² − w₀² + ρ⁴Δu²) / (2 w₀ ρ² Δu)
-  const b0 = (w1 * w1 - w0 * w0 + rho4 * u1 * u1) / (2 * w0 * rho2 * u1);
-  // b₁ = (w₁² − w₀² − ρ⁴Δu²) / (2 w₁ ρ² Δu)
-  const b1 = (w1 * w1 - w0 * w0 - rho4 * u1 * u1) / (2 * w1 * rho2 * u1);
-
-  // rᵢ = arcsinh(−bᵢ) = ln(−bᵢ + √(bᵢ²+1))
-  const r0 = Math.log(-b0 + Math.sqrt(b0 * b0 + 1));
-  const r1 = Math.log(-b1 + Math.sqrt(b1 * b1 + 1));
-
-  const S = (r1 - r0) / rho;
-  const coshr0 = Math.cosh(r0);
-  const sinhr0 = Math.sinh(r0);
-
-  return {
-    S,
-    u: (s: number) => {
-      // u(s) = (w₀/ρ²) cosh(r₀) tanh(ρs + r₀) − (w₀/ρ²) sinh(r₀) + u₀
-      return (w0 / rho2) * coshr0 * Math.tanh(rho * s + r0)
-           - (w0 / rho2) * sinhr0;
-    },
-    w: (s: number) => {
-      // w(s) = w₀ cosh(r₀) / cosh(ρs + r₀)
-      return w0 * coshr0 / Math.cosh(rho * s + r0);
-    },
-  };
 }
 
 export type BananaAppComponents = BaseAppComponents & {
-  scheduleClock: ScheduleClock;
-  timetableManager: TimetableManager;
-  /** Mutable ref so the TimeManager callback always uses the current timetable manager. */
-  timetableRef: { current: TimetableManager };
-  curveEngine: CurveCreationEngine;
-  duplicateToSideEngine: DuplicateToSideEngine;
-  catenaryLayoutEngine: CatenaryLayoutEngine;
-  worldRenderSystem: WorldRenderSystem;
-  terrainData: TerrainData;
-  terrainRenderSystem: TerrainRenderSystem;
-  trackRenderSystem: TrackRenderSystem;
-  trainRenderSystem: TrainRenderSystem;
-  buildingManager: BuildingManager;
-  buildingRenderSystem: BuildingRenderSystem;
-  trainPlacementEngine: TrainPlacementEngine;
-  trainManager: TrainManager;
-  carStockManager: CarStockManager;
-  formationManager: FormationManager;
-  jointDirectionManager: JointDirectionManager;
-  layoutStateMachine: LayoutStateMachine;
-  kmtStateMachineExpansion: KmtExpandedStateMachine;
-  trainStateMachine: TrainPlacementStateMachine;
-  debugOverlayRenderSystem: DebugOverlayRenderSystem;
-  carImageRegistry: CarImageRegistry;
-  timeManager: TimeManager;
-  cameraMux: CameraMuxWithAnimationAndLock;
-  startFocusAnimation: (params: FocusAnimationParams) => void;
-  startFollowAnimation: (params: FocusAnimationParams, getPosition: () => Point | null) => void;
-  stopFollowing: () => void;
-  isFollowing: () => boolean;
-  animations: Animator[];
-  stationManager: StationManager;
-  stationRenderSystem: StationRenderSystem;
-  trackAlignedPlatformManager: TrackAlignedPlatformManager;
-  trackAlignedPlatformRenderSystem: TrackAlignedPlatformRenderSystem;
-  blockSignalManager: BlockSignalManager;
-  signalStateEngine: SignalStateEngine;
-  signalRenderSystem: SignalRenderSystem;
-  /** The stats.js DOM element for toggling visibility. */
-  statsDom: HTMLDivElement;
-  /** Add a train at the given segment and t. For stress testing. */
-  addTrainAtPosition: (
-    segmentNumber: number,
-    tValue: number,
-    direction: 'tangent' | 'reverseTangent',
-  ) => boolean;
-  /** Add multiple trains on the first segment for performance testing. Returns number added. */
-  addStressTestTrains: (count: number) => number;
-  /** Generate a procedural track path for stress testing. Returns number of segments created. */
-  generateProceduralTracks: (options: ProceduralTrackOptions) => number;
-  /** Spawn N parallel straight tracks, each with one train. Returns number spawned. */
-  spawnParallelTracksWithTrains: (count: number, startX?: number, startY?: number) => number;
+    scheduleClock: ScheduleClock;
+    timetableManager: TimetableManager;
+    /** Mutable ref so the TimeManager callback always uses the current timetable manager. */
+    timetableRef: { current: TimetableManager };
+    curveEngine: CurveCreationEngine;
+    duplicateToSideEngine: DuplicateToSideEngine;
+    catenaryLayoutEngine: CatenaryLayoutEngine;
+    worldRenderSystem: WorldRenderSystem;
+    terrainData: TerrainData;
+    terrainRenderSystem: TerrainRenderSystem;
+    trackRenderSystem: TrackRenderSystem;
+    trainRenderSystem: TrainRenderSystem;
+    buildingManager: BuildingManager;
+    buildingRenderSystem: BuildingRenderSystem;
+    trainPlacementEngine: TrainPlacementEngine;
+    trainManager: TrainManager;
+    carStockManager: CarStockManager;
+    formationManager: FormationManager;
+    jointDirectionManager: JointDirectionManager;
+    jointDirectionPreferenceMap: JointDirectionPreferenceMap;
+    layoutStateMachine: LayoutStateMachine;
+    kmtStateMachineExpansion: KmtExpandedStateMachine;
+    trainStateMachine: TrainPlacementStateMachine;
+    debugOverlayRenderSystem: DebugOverlayRenderSystem;
+    carImageRegistry: CarImageRegistry;
+    timeManager: TimeManager;
+    cameraMux: CameraMuxWithAnimationAndLock;
+    startFocusAnimation: (params: FocusAnimationParams) => void;
+    startFollowAnimation: (
+        params: FocusAnimationParams,
+        getPosition: () => Point | null
+    ) => void;
+    stopFollowing: () => void;
+    isFollowing: () => boolean;
+    animations: Animator[];
+    stationManager: StationManager;
+    stationRenderSystem: StationRenderSystem;
+    trackAlignedPlatformManager: TrackAlignedPlatformManager;
+    trackAlignedPlatformRenderSystem: TrackAlignedPlatformRenderSystem;
+    blockSignalManager: BlockSignalManager;
+    signalStateEngine: SignalStateEngine;
+    signalRenderSystem: SignalRenderSystem;
+    /** The stats.js DOM element for toggling visibility. */
+    statsDom: HTMLDivElement;
+    /** Add a train at the given segment and t. For stress testing. */
+    addTrainAtPosition: (
+        segmentNumber: number,
+        tValue: number,
+        direction: 'tangent' | 'reverseTangent'
+    ) => boolean;
+    /** Add multiple trains on the first segment for performance testing. Returns number added. */
+    addStressTestTrains: (count: number) => number;
+    /** Generate a procedural track path for stress testing. Returns number of segments created. */
+    generateProceduralTracks: (options: ProceduralTrackOptions) => number;
+    /** Spawn N parallel straight tracks, each with one train. Returns number spawned. */
+    spawnParallelTracksWithTrains: (
+        count: number,
+        startX?: number,
+        startY?: number
+    ) => number;
 };
 
 /**
@@ -290,501 +332,558 @@ export type BananaAppComponents = BaseAppComponents & {
  * @returns Resolved banana app components including all render/management systems
  */
 export const initApp = async (
-  canvas: HTMLCanvasElement,
-  option: Partial<InitAppOptions> = { fullScreen: false },
+    canvas: HTMLCanvasElement,
+    option: Partial<InitAppOptions> = { fullScreen: false }
 ): Promise<BananaAppComponents> => {
-  const baseComponents = await baseInitApp(canvas, option);
+    const baseComponents = await baseInitApp(canvas, option);
 
-  // FPS / performance monitoring with stats.js
-  const stats = new Stats();
-  stats.showPanel(0); // 0: FPS, 1: MS, 2: MB
-  stats.dom.style.position = 'fixed';
-  stats.dom.style.top = '4rem';
-  stats.dom.style.right = '0';
-  stats.dom.style.left = 'auto';
-  stats.dom.style.zIndex = '10000';
-  document.body.appendChild(stats.dom);
-  const statsTick = (): void => {
-    stats.update();
-  };
-  baseComponents.app.ticker.add(statsTick);
-  // In dev mode, React's profiler accumulates PerformanceMeasure/PerformanceMark
-  // entries indefinitely, consuming ~120 MB+ in long sessions with many trains.
-  // Periodically clear them so they don't bloat the heap.
-  let perfCleanupInterval: ReturnType<typeof setInterval> | undefined;
-  if (import.meta.env.DEV) {
-    perfCleanupInterval = setInterval(() => {
-      performance.clearMeasures();
-      performance.clearMarks();
-    }, 60_000);
-  }
-
-  baseComponents.cleanups.push(() => {
-    baseComponents.app.ticker.remove(statsTick);
-    if (stats.dom.parentElement) {
-      stats.dom.parentElement.removeChild(stats.dom);
-    }
-    if (perfCleanupInterval !== undefined) clearInterval(perfCleanupInterval);
-  });
-
-  baseComponents.camera.setMaxZoomLevel(30);
-
-  const timeManager = new TimeManager(baseComponents.app);
-
-  const animations: Animator[] = [];
-
-  // Mutable state captured by the animation callback closure.
-  let focusStartWorldPoint: Point = { x: 0, y: 0 };
-  let focusTargetWorldPoint: Point = { x: 0, y: 0 };
-  let focusPanDistance = 0;
-  let currentPath: OptimalPath = { S: 1, u: () => 0, w: () => 1 };
-
-  // The Animation<number> drives a normalised progress t ∈ [0, 1].
-  // The ease function provides acceleration/deceleration on top of
-  // the paper's arc-length parameterisation.
-  // On each frame we map t → s = t × S, then sample the Van Wijk path.
-  const focusAnimation = new Animation([
-    { percentage: 0, value: 0 },
-    { percentage: 1, value: 1 },
-  ], (t: number) => {
-    const s = t * currentPath.S;
-    const u = currentPath.u(s);
-    const w = currentPath.w(s);
-
-    // Convert w back to zoom level: w = vpW / zoom  ⟹  zoom = vpW / w
-    const vpW = baseComponents.camera.viewPortWidth;
-    const zoom = vpW / w;
-
-    // Convert 1-D pan parameter u back to 2-D world position.
-    // u is the distance along the line from startPoint to targetPoint.
-    const fraction = focusPanDistance > 1e-6 ? u / focusPanDistance : 0;
-    const dx = focusTargetWorldPoint.x - focusStartWorldPoint.x;
-    const dy = focusTargetWorldPoint.y - focusStartWorldPoint.y;
-    const pos = {
-      x: focusStartWorldPoint.x + dx * fraction,
-      y: focusStartWorldPoint.y + dy * fraction,
+    // FPS / performance monitoring with stats.js
+    const stats = new Stats();
+    stats.showPanel(0); // 0: FPS, 1: MS, 2: MB
+    stats.dom.style.position = 'fixed';
+    stats.dom.style.top = '4rem';
+    stats.dom.style.right = '0';
+    stats.dom.style.left = 'auto';
+    stats.dom.style.zIndex = '10000';
+    document.body.appendChild(stats.dom);
+    const statsTick = (): void => {
+        stats.update();
     };
-
-    cameraMux.notifyZoomInputAnimation(zoom);
-    baseComponents.cameraRig.zoomTo(zoom);
-    cameraMux.notifyPanToAnimationInput(pos);
-    baseComponents.cameraRig.panToWorld(pos);
-  }, new NumberAnimationHelper(), 1000);
-
-  focusAnimation.easeFunction = (x: number): number => {
-    return -(Math.cos(Math.PI * x) - 1) / 2;
-  };
-
-  const startFocusAnimation = (params: FocusAnimationParams): void => {
-    const { startWorldPoint, targetWorldPoint, startZoom, targetZoom } = params;
-    focusStartWorldPoint = startWorldPoint;
-    focusTargetWorldPoint = targetWorldPoint;
-
-    const vpW = baseComponents.camera.viewPortWidth;
-    const w0 = vpW / startZoom;
-    const w1 = vpW / targetZoom;
-
-    const dx = targetWorldPoint.x - startWorldPoint.x;
-    const dy = targetWorldPoint.y - startWorldPoint.y;
-    focusPanDistance = Math.sqrt(dx * dx + dy * dy);
-
-    currentPath = computeOptimalPath(focusPanDistance, w0, w1);
-
-    cameraMux.initatePanTransition();
-    cameraMux.initateZoomTransition();
-    focusAnimation.start();
-  };
-
-  // --- Lock-on / follow train ---
-  // After the focus animation completes, the pan state machine transitions to
-  // LOCKED_ON_OBJECT. On each tick we feed the train's current position via
-  // lockedOnObjectPanToInput, which keeps the camera centered on the moving
-  // train while blocking normal user panning.
-  let followPositionGetter: (() => Point | null) | null = null;
-
-  const stopFollowing = (): void => {
-    followPositionGetter = null;
-    cameraMux.panStateMachine.happens('unlock');
-  };
-
-  const startFollowAnimation = (
-    _params: FocusAnimationParams,
-    getPosition: () => Point | null,
-  ): void => {
-    // If already following, stop first.
-    if (followPositionGetter) {
-      stopFollowing();
+    baseComponents.app.ticker.add(statsTick);
+    // In dev mode, React's profiler accumulates PerformanceMeasure/PerformanceMark
+    // entries indefinitely, consuming ~120 MB+ in long sessions with many trains.
+    // Periodically clear them so they don't bloat the heap.
+    let perfCleanupInterval: ReturnType<typeof setInterval> | undefined;
+    if (import.meta.env.DEV) {
+        perfCleanupInterval = setInterval(() => {
+            performance.clearMeasures();
+            performance.clearMarks();
+        }, 60_000);
     }
 
-    followPositionGetter = getPosition;
-
-    // Directly lock onto the train — no transition animation.
-    // Set camera to the train's current position and enter LOCKED_ON_OBJECT.
-    const pos = getPosition();
-    if (pos) {
-      baseComponents.cameraRig.panToWorld(pos);
-      baseComponents.cameraRig.zoomTo(_params.targetZoom);
-      cameraMux.panStateMachine.happens('lockedOnObjectPanToInput', { target: pos });
-    }
-  };
-
-  const isFollowing = (): boolean => followPositionGetter !== null;
-
-  baseComponents.app.ticker.add((time: { deltaMS: number }) => {
-    for (const animation of animations) {
-      animation.animate(time.deltaMS);
-    }
-    focusAnimation.animate(time.deltaMS);
-
-    // While locked on, continuously update camera to follow the train.
-    if (followPositionGetter) {
-      const pos = followPositionGetter();
-      if (pos) {
-        const res = cameraMux.panStateMachine.happens('lockedOnObjectPanToInput', { target: pos });
-        if (res.handled) {
-          baseComponents.cameraRig.panToWorld(pos);
+    baseComponents.cleanups.push(() => {
+        baseComponents.app.ticker.remove(statsTick);
+        if (stats.dom.parentElement) {
+            stats.dom.parentElement.removeChild(stats.dom);
         }
-      }
-    }
-  });
+        if (perfCleanupInterval !== undefined)
+            clearInterval(perfCleanupInterval);
+    });
 
-  const curveEngine = new CurveCreationEngine(baseComponents.canvasProxy, baseComponents.camera);
-  const layoutSubStateMachine = createLayoutStateMachine(curveEngine);
-  const worldRenderSystem = new WorldRenderSystem();
+    baseComponents.camera.setMaxZoomLevel(30);
 
-  // Terrain: 10000x10000m grid centered on origin, 25m cell size, flat at ground level
-  const terrainData = TerrainData.createFlat({
-    originX: -5000,
-    originY: -5000,
-    cellsX: 400,
-    cellsY: 400,
-    cellSize: 25,
-  });
-  const terrainRenderSystem = new TerrainRenderSystem(
-    worldRenderSystem,
-    terrainData,
-    { renderer: baseComponents.app.renderer },
-  );
+    const timeManager = new TimeManager(baseComponents.app);
 
-  const duplicateToSideEngine = new DuplicateToSideEngine(
-    curveEngine.trackGraph,
-    (position) => curveEngine.convert2WorldPosition(position),
-  );
-  const duplicateSubStateMachine = createDuplicateToSideStateMachine(duplicateToSideEngine);
+    const animations: Animator[] = [];
 
-  const catenaryLayoutEngine = new CatenaryLayoutEngine(
-    curveEngine.trackGraph,
-    (position) => curveEngine.convert2WorldPosition(position),
-  );
-  const catenarySubStateMachine = createCatenaryLayoutStateMachine(catenaryLayoutEngine);
+    // Mutable state captured by the animation callback closure.
+    let focusStartWorldPoint: Point = { x: 0, y: 0 };
+    let focusTargetWorldPoint: Point = { x: 0, y: 0 };
+    let focusPanDistance = 0;
+    let currentPath: OptimalPath = { S: 1, u: () => 0, w: () => 1 };
 
-  const trackRenderSystem = new TrackRenderSystem(
-    worldRenderSystem,
-    curveEngine.trackGraph.trackCurveManager,
-    curveEngine,
-    baseComponents.camera,
-    { renderer: baseComponents.app.renderer },
-    terrainData,
-    duplicateToSideEngine,
-    catenaryLayoutEngine,
-  );
-  const buildingManager = new BuildingManager();
-  const buildingRenderSystem = new BuildingRenderSystem(worldRenderSystem, buildingManager);
+    // The Animation<number> drives a normalised progress t ∈ [0, 1].
+    // The ease function provides acceleration/deceleration on top of
+    // the paper's arc-length parameterisation.
+    // On each frame we map t → s = t × S, then sample the Van Wijk path.
+    const focusAnimation = new Animation(
+        [
+            { percentage: 0, value: 0 },
+            { percentage: 1, value: 1 },
+        ],
+        (t: number) => {
+            const s = t * currentPath.S;
+            const u = currentPath.u(s);
+            const w = currentPath.w(s);
 
-  const stationManager = new StationManager();
-  const stationRenderSystem = new StationRenderSystem(
-    worldRenderSystem,
-    stationManager,
-    curveEngine.trackGraph,
-    { renderer: baseComponents.app.renderer },
-  );
+            // Convert w back to zoom level: w = vpW / zoom  ⟹  zoom = vpW / w
+            const vpW = baseComponents.camera.viewPortWidth;
+            const zoom = vpW / w;
 
-  const trackAlignedPlatformManager = new TrackAlignedPlatformManager();
-  const trackAlignedPlatformRenderSystem = new TrackAlignedPlatformRenderSystem(
-      worldRenderSystem,
-      trackAlignedPlatformManager,
-      curveEngine.trackGraph,
-      { renderer: baseComponents.app.renderer },
-  );
+            // Convert 1-D pan parameter u back to 2-D world position.
+            // u is the distance along the line from startPoint to targetPoint.
+            const fraction = focusPanDistance > 1e-6 ? u / focusPanDistance : 0;
+            const dx = focusTargetWorldPoint.x - focusStartWorldPoint.x;
+            const dy = focusTargetWorldPoint.y - focusStartWorldPoint.y;
+            const pos = {
+                x: focusStartWorldPoint.x + dx * fraction,
+                y: focusStartWorldPoint.y + dy * fraction,
+            };
 
-  curveEngine.trackGraph.setSegmentProtectionCheck((segNum) => {
-      return trackAlignedPlatformManager.getPlatformsBySegment(segNum).length > 0;
-  });
-
-  stationManager.setOnDestroyStation((stationId) => {
-      const platforms = trackAlignedPlatformManager.getPlatformsByStation(stationId);
-      for (const { id } of platforms) {
-          trackAlignedPlatformRenderSystem.removePlatform(id);
-          trackAlignedPlatformManager.destroyPlatform(id);
-      }
-  });
-
-  const trainManager = new TrainManager();
-  const carStockManager = new CarStockManager();
-  const formationManager = new FormationManager(carStockManager);
-  const trackGraph = curveEngine.trackGraph;
-  const jointDirectionManager = new DefaultJointDirectionManager(trackGraph);
-  const trainPlacementEngine = new TrainPlacementEngine(baseComponents.canvasProxy, trackGraph, baseComponents.camera, {
-    onPlaced: (placed) => {
-      // Detach the formation from the manager — it's now owned by the placed train
-      formationManager.detachFormation(placed.formation.id);
-      trainManager.addTrain(placed);
-      // Reset to default formation for next placement
-      trainPlacementEngine.setFormation(null);
-      toast.success('Train placed on the simulation map');
-      return new Train(null, trackGraph, jointDirectionManager);
-    },
-  });
-  const carImageRegistry = new CarImageRegistry();
-  const trainRenderSystem = new TrainRenderSystem(
-    worldRenderSystem,
-    () => trainManager.getPlacedTrains(),
-    () => trainPlacementEngine.train,
-    trackGraph,
-    trackRenderSystem,
-    { renderer: baseComponents.app.renderer },
-    carImageRegistry,
-  );
-  // const layoutStateMachine = createLayoutStateMachine(curveEngine);
-  const trainStateMachine = new TrainPlacementStateMachine(trainPlacementEngine);
-  const stationPlacementEngine = new StationPlacementEngine(
-    baseComponents.canvasProxy,
-    trackGraph,
-    baseComponents.camera,
-    stationManager,
-    stationRenderSystem,
-  );
-  const stationStateMachine = new StationPlacementStateMachine(stationPlacementEngine);
-
-  let platformHintToastId: string | number | undefined;
-  const showPlatformHint = (key: string) => {
-      if (platformHintToastId !== undefined) toast.dismiss(platformHintToastId);
-      const msg = i18n.t(key);
-      if (key === 'hintPlatformCreated') {
-          platformHintToastId = toast.success(msg, { duration: 2000 });
-      } else {
-          platformHintToastId = toast.info(msg, { duration: 8000 });
-      }
-  };
-
-  const singleSpineEngine = new SingleSpinePlacementEngine(
-      baseComponents.canvasProxy,
-      curveEngine.trackGraph,
-      baseComponents.camera,
-      stationManager,
-      trackAlignedPlatformManager,
-      trackAlignedPlatformRenderSystem,
-      showPlatformHint,
-  );
-  const singleSpineStateMachine = createSingleSpinePlacementStateMachine(singleSpineEngine);
-
-  const dualSpineEngine = new DualSpinePlacementEngine(
-      baseComponents.canvasProxy,
-      curveEngine.trackGraph,
-      baseComponents.camera,
-      stationManager,
-      trackAlignedPlatformManager,
-      trackAlignedPlatformRenderSystem,
-      showPlatformHint,
-  );
-  const dualSpineStateMachine = createDualSpinePlacementStateMachine(dualSpineEngine);
-
-  const debugOverlayRenderSystem = new DebugOverlayRenderSystem(
-    worldRenderSystem,
-    trackGraph,
-    baseComponents.camera,
-  );
-  debugOverlayRenderSystem.setPlacedTrainsGetter(() => trainManager.getPlacedTrains());
-  debugOverlayRenderSystem.setStationManager(stationManager);
-  debugOverlayRenderSystem.setTrackAlignedPlatformManager(trackAlignedPlatformManager);
-  debugOverlayRenderSystem.setProximityDetector(trainRenderSystem.proximityDetector);
-
-  // Share the proximity detector with the train manager for coupling queries
-  trainManager.setProximityDetector(trainRenderSystem.proximityDetector);
-
-  const scheduleClock = new ScheduleClock();
-  // Mutable ref so that the TimeManager callback always uses the current
-  // timetable manager, even after deserialization replaces it.
-  const timetableRef: { current: TimetableManager } = { current: null! };
-  let timetableManager = new TimetableManager(
-    scheduleClock,
-    trackGraph,
-    trainManager,
-    stationManager,
-  );
-  timetableRef.current = timetableManager;
-
-  // Block signal system
-  const blockSignalManager = new BlockSignalManager();
-  const signalStateEngine = new SignalStateEngine(blockSignalManager);
-  const signalRenderSystem = new SignalRenderSystem(
-    worldRenderSystem,
-    trackGraph,
-    blockSignalManager,
-    signalStateEngine,
-    { renderer: baseComponents.app.renderer },
-  );
-  timetableManager.signalStateEngine = signalStateEngine;
-  timetableManager.trackAlignedPlatformManager = trackAlignedPlatformManager;
-
-  // When a train is removed from the track, return its formation to the depot
-  trainManager.setOnBeforeRemove((train) => {
-    formationManager.addFormation(train.formation);
-  });
-
-  const kmtInputStateMachine = createKmtInputStateMachineExpansion(layoutSubStateMachine, trainStateMachine, stationStateMachine, duplicateSubStateMachine, catenarySubStateMachine, singleSpineStateMachine, dualSpineStateMachine, baseComponents.observableInputTracker);
-  baseComponents.kmtParser.stateMachine = kmtInputStateMachine;
-  baseComponents.kmtInputStateMachine = kmtInputStateMachine;
-
-  curveEngine.trackGraph.onSegmentSplit((info) => {
-    for (const { train } of trainManager.getPlacedTrains()) {
-      train.remapOnSegmentSplit(info);
-    }
-    trainPlacementEngine.train.remapOnSegmentSplit(info);
-    blockSignalManager.handleSegmentSplit(info);
-  });
-
-  curveEngine.trackGraph.onSegmentRemoved((segNum) => {
-    blockSignalManager.handleSegmentRemoved(segNum);
-  });
-
-  baseComponents.app.stage.addChild(worldRenderSystem.container);
-
-  const unsubTimeManager = timeManager.subscribe((currentTime: number, deltaTime: number) => {
-    // Timetable auto-drivers set throttle before physics update
-    timetableRef.current.update(currentTime, deltaTime);
-    trainRenderSystem.update(deltaTime);
-    // Recompute signal aspects from fresh occupancy, then update visuals
-    signalStateEngine.update(
-      trainRenderSystem.occupancyRegistry,
-      trainManager.getPlacedTrains(),
+            cameraMux.notifyZoomInputAnimation(zoom);
+            baseComponents.cameraRig.zoomTo(zoom);
+            cameraMux.notifyPanToAnimationInput(pos);
+            baseComponents.cameraRig.panToWorld(pos);
+        },
+        new NumberAnimationHelper(),
+        1000
     );
-    signalRenderSystem.update();
-    debugOverlayRenderSystem.updateFormationLabels();
-    debugOverlayRenderSystem.updateProximityLines();
-  });
 
-  const unsubTrainChanges = trainManager.subscribeToChanges(() => {
-    trainRenderSystem.forceSync();
-  });
-
-  baseComponents.cleanups.push(() => {
-    unsubTimeManager();
-    unsubTrainChanges();
-    timeManager.dispose();
-    timetableRef.current.dispose();
-    signalRenderSystem.dispose();
-  });
-
-  const cameraMux = createCameraMuxWithAnimationAndLock();
-  baseComponents.inputOrchestrator.cameraMux = cameraMux;
-
-  const addTrainAtPosition = (
-    segmentNumber: number,
-    tValue: number,
-    direction: 'tangent' | 'reverseTangent',
-  ): boolean => {
-    const segment = trackGraph.getTrackSegmentWithJoints(segmentNumber);
-    if (!segment) return false;
-    const point = segment.curve.getPointbyPercentage(tValue);
-    const position: TrainPosition = {
-      trackSegment: segmentNumber,
-      tValue,
-      direction,
-      point,
+    focusAnimation.easeFunction = (x: number): number => {
+        return -(Math.cos(Math.PI * x) - 1) / 2;
     };
-    const train = new Train(
-      position,
-      trackGraph,
-      jointDirectionManager,
+
+    const startFocusAnimation = (params: FocusAnimationParams): void => {
+        const { startWorldPoint, targetWorldPoint, startZoom, targetZoom } =
+            params;
+        focusStartWorldPoint = startWorldPoint;
+        focusTargetWorldPoint = targetWorldPoint;
+
+        const vpW = baseComponents.camera.viewPortWidth;
+        const w0 = vpW / startZoom;
+        const w1 = vpW / targetZoom;
+
+        const dx = targetWorldPoint.x - startWorldPoint.x;
+        const dy = targetWorldPoint.y - startWorldPoint.y;
+        focusPanDistance = Math.sqrt(dx * dx + dy * dy);
+
+        currentPath = computeOptimalPath(focusPanDistance, w0, w1);
+
+        cameraMux.initatePanTransition();
+        cameraMux.initateZoomTransition();
+        focusAnimation.start();
+    };
+
+    // --- Lock-on / follow train ---
+    // After the focus animation completes, the pan state machine transitions to
+    // LOCKED_ON_OBJECT. On each tick we feed the train's current position via
+    // lockedOnObjectPanToInput, which keeps the camera centered on the moving
+    // train while blocking normal user panning.
+    let followPositionGetter: (() => Point | null) | null = null;
+
+    const stopFollowing = (): void => {
+        followPositionGetter = null;
+        cameraMux.panStateMachine.happens('unlock');
+    };
+
+    const startFollowAnimation = (
+        _params: FocusAnimationParams,
+        getPosition: () => Point | null
+    ): void => {
+        // If already following, stop first.
+        if (followPositionGetter) {
+            stopFollowing();
+        }
+
+        followPositionGetter = getPosition;
+
+        // Directly lock onto the train — no transition animation.
+        // Set camera to the train's current position and enter LOCKED_ON_OBJECT.
+        const pos = getPosition();
+        if (pos) {
+            baseComponents.cameraRig.panToWorld(pos);
+            baseComponents.cameraRig.zoomTo(_params.targetZoom);
+            cameraMux.panStateMachine.happens('lockedOnObjectPanToInput', {
+                target: pos,
+            });
+        }
+    };
+
+    const isFollowing = (): boolean => followPositionGetter !== null;
+
+    baseComponents.app.ticker.add((time: { deltaMS: number }) => {
+        for (const animation of animations) {
+            animation.animate(time.deltaMS);
+        }
+        focusAnimation.animate(time.deltaMS);
+
+        // While locked on, continuously update camera to follow the train.
+        if (followPositionGetter) {
+            const pos = followPositionGetter();
+            if (pos) {
+                const res = cameraMux.panStateMachine.happens(
+                    'lockedOnObjectPanToInput',
+                    { target: pos }
+                );
+                if (res.handled) {
+                    baseComponents.cameraRig.panToWorld(pos);
+                }
+            }
+        }
+    });
+
+    const curveEngine = new CurveCreationEngine(
+        baseComponents.canvasProxy,
+        baseComponents.camera
     );
-    trainManager.addTrain(train);
-    return true;
-  };
+    const layoutSubStateMachine = createLayoutStateMachine(curveEngine);
+    const worldRenderSystem = new WorldRenderSystem();
 
-  const addStressTestTrains = (count: number): number => {
-    const segmentNumbers = trackGraph.trackCurveManager.livingEntities;
-    if (segmentNumbers.length === 0) return 0;
-    const segmentNumber = segmentNumbers[0];
-    let added = 0;
-    for (let i = 0; i < count; i++) {
-      const t = 0.3 + (i / Math.max(count, 1)) * 0.4;
-      if (addTrainAtPosition(segmentNumber, t, 'tangent')) added += 1;
+    // Terrain: 10000x10000m grid centered on origin, 25m cell size, flat at ground level
+    const terrainData = TerrainData.createFlat({
+        originX: -5000,
+        originY: -5000,
+        cellsX: 400,
+        cellsY: 400,
+        cellSize: 25,
+    });
+    const terrainRenderSystem = new TerrainRenderSystem(
+        worldRenderSystem,
+        terrainData,
+        { renderer: baseComponents.app.renderer }
+    );
+
+    const duplicateToSideEngine = new DuplicateToSideEngine(
+        curveEngine.trackGraph,
+        position => curveEngine.convert2WorldPosition(position)
+    );
+    const duplicateSubStateMachine = createDuplicateToSideStateMachine(
+        duplicateToSideEngine
+    );
+
+    const catenaryLayoutEngine = new CatenaryLayoutEngine(
+        curveEngine.trackGraph,
+        position => curveEngine.convert2WorldPosition(position)
+    );
+    const catenarySubStateMachine =
+        createCatenaryLayoutStateMachine(catenaryLayoutEngine);
+
+    const trackRenderSystem = new TrackRenderSystem(
+        worldRenderSystem,
+        curveEngine.trackGraph.trackCurveManager,
+        curveEngine,
+        baseComponents.camera,
+        { renderer: baseComponents.app.renderer },
+        terrainData,
+        duplicateToSideEngine,
+        catenaryLayoutEngine
+    );
+    const buildingManager = new BuildingManager();
+    const buildingRenderSystem = new BuildingRenderSystem(
+        worldRenderSystem,
+        buildingManager
+    );
+
+    const stationManager = new StationManager();
+    const stationRenderSystem = new StationRenderSystem(
+        worldRenderSystem,
+        stationManager,
+        curveEngine.trackGraph,
+        { renderer: baseComponents.app.renderer }
+    );
+
+    const trackAlignedPlatformManager = new TrackAlignedPlatformManager();
+    const trackAlignedPlatformRenderSystem =
+        new TrackAlignedPlatformRenderSystem(
+            worldRenderSystem,
+            trackAlignedPlatformManager,
+            curveEngine.trackGraph,
+            { renderer: baseComponents.app.renderer }
+        );
+
+    curveEngine.trackGraph.setSegmentProtectionCheck(segNum => {
+        return (
+            trackAlignedPlatformManager.getPlatformsBySegment(segNum).length > 0
+        );
+    });
+
+    stationManager.setOnDestroyStation(stationId => {
+        const platforms =
+            trackAlignedPlatformManager.getPlatformsByStation(stationId);
+        for (const { id } of platforms) {
+            trackAlignedPlatformRenderSystem.removePlatform(id);
+            trackAlignedPlatformManager.destroyPlatform(id);
+        }
+    });
+
+    const trainManager = new TrainManager();
+    const carStockManager = new CarStockManager();
+    const formationManager = new FormationManager(carStockManager);
+    const trackGraph = curveEngine.trackGraph;
+    const jointDirectionPreferenceMap = new JointDirectionPreferenceMap();
+    const jointDirectionManager = new DefaultJointDirectionManager(trackGraph, jointDirectionPreferenceMap);
+    const trainPlacementEngine = new TrainPlacementEngine(
+        baseComponents.canvasProxy,
+        trackGraph,
+        baseComponents.camera,
+        {
+            onPlaced: placed => {
+                // Detach the formation from the manager — it's now owned by the placed train
+                formationManager.detachFormation(placed.formation.id);
+                trainManager.addTrain(placed);
+                // Reset to default formation for next placement
+                trainPlacementEngine.setFormation(null);
+                toast.success('Train placed on the simulation map');
+                return new Train(null, trackGraph, jointDirectionManager);
+            },
+        }
+    );
+    const carImageRegistry = new CarImageRegistry();
+    const trainRenderSystem = new TrainRenderSystem(
+        worldRenderSystem,
+        () => trainManager.getPlacedTrains(),
+        () => trainPlacementEngine.train,
+        trackGraph,
+        trackRenderSystem,
+        { renderer: baseComponents.app.renderer },
+        carImageRegistry
+    );
+    // const layoutStateMachine = createLayoutStateMachine(curveEngine);
+    const trainStateMachine = new TrainPlacementStateMachine(
+        trainPlacementEngine
+    );
+    const stationPlacementEngine = new StationPlacementEngine(
+        baseComponents.canvasProxy,
+        trackGraph,
+        baseComponents.camera,
+        stationManager,
+        stationRenderSystem
+    );
+    const stationStateMachine = new StationPlacementStateMachine(
+        stationPlacementEngine
+    );
+
+    let platformHintToastId: string | number | undefined;
+    const showPlatformHint = (key: string) => {
+        if (platformHintToastId !== undefined)
+            toast.dismiss(platformHintToastId);
+        const msg = i18n.t(key);
+        if (key === 'hintPlatformCreated') {
+            platformHintToastId = toast.success(msg, { duration: 2000 });
+        } else {
+            platformHintToastId = toast.info(msg, { duration: 8000 });
+        }
+    };
+
+    const singleSpineEngine = new SingleSpinePlacementEngine(
+        baseComponents.canvasProxy,
+        curveEngine.trackGraph,
+        baseComponents.camera,
+        stationManager,
+        trackAlignedPlatformManager,
+        trackAlignedPlatformRenderSystem,
+        showPlatformHint
+    );
+    const singleSpineStateMachine =
+        createSingleSpinePlacementStateMachine(singleSpineEngine);
+
+    const dualSpineEngine = new DualSpinePlacementEngine(
+        baseComponents.canvasProxy,
+        curveEngine.trackGraph,
+        baseComponents.camera,
+        stationManager,
+        trackAlignedPlatformManager,
+        trackAlignedPlatformRenderSystem,
+        showPlatformHint
+    );
+    const dualSpineStateMachine =
+        createDualSpinePlacementStateMachine(dualSpineEngine);
+
+    const debugOverlayRenderSystem = new DebugOverlayRenderSystem(
+        worldRenderSystem,
+        trackGraph,
+        baseComponents.camera
+    );
+    debugOverlayRenderSystem.setPlacedTrainsGetter(() =>
+        trainManager.getPlacedTrains()
+    );
+    debugOverlayRenderSystem.setStationManager(stationManager);
+    debugOverlayRenderSystem.setTrackAlignedPlatformManager(
+        trackAlignedPlatformManager
+    );
+    debugOverlayRenderSystem.setProximityDetector(
+        trainRenderSystem.proximityDetector
+    );
+
+    // Share the proximity detector with the train manager for coupling queries
+    trainManager.setProximityDetector(trainRenderSystem.proximityDetector);
+
+    const scheduleClock = new ScheduleClock();
+    // Mutable ref so that the TimeManager callback always uses the current
+    // timetable manager, even after deserialization replaces it.
+    const timetableRef: { current: TimetableManager } = { current: null! };
+    let timetableManager = new TimetableManager(
+        scheduleClock,
+        trackGraph,
+        trainManager,
+        stationManager,
+        undefined,
+        undefined,
+        jointDirectionPreferenceMap
+    );
+    timetableRef.current = timetableManager;
+
+    // Block signal system
+    const blockSignalManager = new BlockSignalManager();
+    const signalStateEngine = new SignalStateEngine(blockSignalManager);
+    const signalRenderSystem = new SignalRenderSystem(
+        worldRenderSystem,
+        trackGraph,
+        blockSignalManager,
+        signalStateEngine,
+        { renderer: baseComponents.app.renderer }
+    );
+    timetableManager.signalStateEngine = signalStateEngine;
+    timetableManager.trackAlignedPlatformManager = trackAlignedPlatformManager;
+
+    // When a train is removed from the track, return its formation to the depot
+    trainManager.setOnBeforeRemove(train => {
+        formationManager.addFormation(train.formation);
+    });
+
+    const kmtInputStateMachine = createKmtInputStateMachineExpansion(
+        layoutSubStateMachine,
+        trainStateMachine,
+        stationStateMachine,
+        duplicateSubStateMachine,
+        catenarySubStateMachine,
+        singleSpineStateMachine,
+        dualSpineStateMachine,
+        baseComponents.observableInputTracker
+    );
+    baseComponents.kmtParser.stateMachine = kmtInputStateMachine;
+    baseComponents.kmtInputStateMachine = kmtInputStateMachine;
+
+    curveEngine.trackGraph.onSegmentSplit(info => {
+        for (const { train } of trainManager.getPlacedTrains()) {
+            train.remapOnSegmentSplit(info);
+        }
+        trainPlacementEngine.train.remapOnSegmentSplit(info);
+        blockSignalManager.handleSegmentSplit(info);
+    });
+
+    curveEngine.trackGraph.onSegmentRemoved(segNum => {
+        blockSignalManager.handleSegmentRemoved(segNum);
+    });
+
+    baseComponents.app.stage.addChild(worldRenderSystem.container);
+
+    const unsubTimeManager = timeManager.subscribe(
+        (currentTime: number, deltaTime: number) => {
+            // Timetable auto-drivers set throttle before physics update
+            timetableRef.current.update(currentTime, deltaTime);
+            trainRenderSystem.update(deltaTime);
+            // Recompute signal aspects from fresh occupancy, then update visuals
+            signalStateEngine.update(
+                trainRenderSystem.occupancyRegistry,
+                trainManager.getPlacedTrains()
+            );
+            signalRenderSystem.update();
+            debugOverlayRenderSystem.updateFormationLabels();
+            debugOverlayRenderSystem.updateProximityLines();
+        }
+    );
+
+    const unsubTrainChanges = trainManager.subscribeToChanges(() => {
+        trainRenderSystem.forceSync();
+    });
+
+    baseComponents.cleanups.push(() => {
+        unsubTimeManager();
+        unsubTrainChanges();
+        timeManager.dispose();
+        timetableRef.current.dispose();
+        signalRenderSystem.dispose();
+    });
+
+    const cameraMux = createCameraMuxWithAnimationAndLock();
+    baseComponents.inputOrchestrator.cameraMux = cameraMux;
+
+    const addTrainAtPosition = (
+        segmentNumber: number,
+        tValue: number,
+        direction: 'tangent' | 'reverseTangent'
+    ): boolean => {
+        const segment = trackGraph.getTrackSegmentWithJoints(segmentNumber);
+        if (!segment) return false;
+        const point = segment.curve.getPointbyPercentage(tValue);
+        const position: TrainPosition = {
+            trackSegment: segmentNumber,
+            tValue,
+            direction,
+            point,
+        };
+        const train = new Train(position, trackGraph, jointDirectionManager);
+        trainManager.addTrain(train);
+        return true;
+    };
+
+    const addStressTestTrains = (count: number): number => {
+        const segmentNumbers = trackGraph.trackCurveManager.livingEntities;
+        if (segmentNumbers.length === 0) return 0;
+        const segmentNumber = segmentNumbers[0];
+        let added = 0;
+        for (let i = 0; i < count; i++) {
+            const t = 0.3 + (i / Math.max(count, 1)) * 0.4;
+            if (addTrainAtPosition(segmentNumber, t, 'tangent')) added += 1;
+        }
+        return added;
+    };
+
+    const generateProceduralTracks = (
+        options: ProceduralTrackOptions
+    ): number => {
+        return generateProceduralTrackPath(trackGraph, options);
+    };
+
+    const spawnParallelTracksWithTrains = (
+        count: number,
+        startX?: number,
+        startY?: number
+    ): number => {
+        const opts: ParallelTrackOptions = { count, length: 500 };
+        if (startX !== undefined) opts.startX = startX;
+        if (startY !== undefined) opts.startY = startY;
+        const segmentIds = generateParallelTracks(trackGraph, opts);
+        let placed = 0;
+        for (const segId of segmentIds) {
+            if (addTrainAtPosition(segId, 0.5, 'tangent')) placed += 1;
+        }
+        trainRenderSystem.forceSync();
+        return placed;
+    };
+
+    return {
+        ...baseComponents,
+        curveEngine,
+        duplicateToSideEngine,
+        catenaryLayoutEngine,
+        worldRenderSystem,
+        terrainData,
+        terrainRenderSystem,
+        trackRenderSystem,
+        trainRenderSystem,
+        buildingManager,
+        buildingRenderSystem,
+        trainPlacementEngine,
+        trainManager,
+        carStockManager,
+        formationManager,
+        jointDirectionManager,
+        jointDirectionPreferenceMap,
+        cameraMux,
+        startFocusAnimation,
+        startFollowAnimation,
+        stopFollowing,
+        isFollowing,
+        layoutStateMachine: layoutSubStateMachine,
+        kmtStateMachineExpansion: kmtInputStateMachine,
+        trainStateMachine,
+        debugOverlayRenderSystem,
+        carImageRegistry,
+        timeManager,
+        scheduleClock,
+        timetableManager,
+        timetableRef,
+        stationManager,
+        stationRenderSystem,
+        trackAlignedPlatformManager,
+        trackAlignedPlatformRenderSystem,
+        blockSignalManager,
+        signalStateEngine,
+        signalRenderSystem,
+        statsDom: stats.dom,
+        addTrainAtPosition,
+        addStressTestTrains,
+        generateProceduralTracks,
+        spawnParallelTracksWithTrains,
+        animations,
+    };
+
+    // Expose app components on window for console debugging
+    if (typeof window !== 'undefined') {
+        (window as unknown as Record<string, unknown>).__banana = result;
     }
-    return added;
-  };
 
-  const generateProceduralTracks = (options: ProceduralTrackOptions): number => {
-    return generateProceduralTrackPath(trackGraph, options);
-  };
-
-  const spawnParallelTracksWithTrains = (
-    count: number,
-    startX?: number,
-    startY?: number,
-  ): number => {
-    const opts: ParallelTrackOptions = { count, length: 500 };
-    if (startX !== undefined) opts.startX = startX;
-    if (startY !== undefined) opts.startY = startY;
-    const segmentIds = generateParallelTracks(trackGraph, opts);
-    let placed = 0;
-    for (const segId of segmentIds) {
-      if (addTrainAtPosition(segId, 0.5, 'tangent')) placed += 1;
-    }
-    trainRenderSystem.forceSync();
-    return placed;
-  };
-
-  return {
-    ...baseComponents,
-    curveEngine,
-    duplicateToSideEngine,
-    catenaryLayoutEngine,
-    worldRenderSystem,
-    terrainData,
-    terrainRenderSystem,
-    trackRenderSystem,
-    trainRenderSystem,
-    buildingManager,
-    buildingRenderSystem,
-    trainPlacementEngine,
-    trainManager,
-    carStockManager,
-    formationManager,
-    jointDirectionManager,
-    cameraMux,
-    startFocusAnimation,
-    startFollowAnimation,
-    stopFollowing,
-    isFollowing,
-    layoutStateMachine: layoutSubStateMachine,
-    kmtStateMachineExpansion: kmtInputStateMachine,
-    trainStateMachine,
-    debugOverlayRenderSystem,
-    carImageRegistry,
-    timeManager,
-    scheduleClock,
-    timetableManager,
-    timetableRef,
-    stationManager,
-    stationRenderSystem,
-    trackAlignedPlatformManager,
-    trackAlignedPlatformRenderSystem,
-    blockSignalManager,
-    signalStateEngine,
-    signalRenderSystem,
-    statsDom: stats.dom,
-    addTrainAtPosition,
-    addStressTestTrains,
-    generateProceduralTracks,
-    spawnParallelTracksWithTrains,
-    animations,
-  };
-
-  // Expose app components on window for console debugging
-  if (typeof window !== 'undefined') {
-    (window as unknown as Record<string, unknown>).__banana = result;
-  }
-
-  return result;
+    return result;
 };

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -48,6 +48,7 @@ import { createCatenaryLayoutStateMachine } from '@/trains/input-state-machine/c
 import { CurveCreationEngine } from '@/trains/input-state-machine/curve-engine';
 import { DuplicateToSideEngine } from '@/trains/input-state-machine/duplicate-to-side-engine';
 import { createDuplicateToSideStateMachine } from '@/trains/input-state-machine/duplicate-to-side-state-machine';
+import { createJointDirectionStateMachine } from '@/trains/input-state-machine/joint-direction-state-machine';
 import {
     KmtExpandedStateMachine,
     createKmtInputStateMachineExpansion,
@@ -59,9 +60,9 @@ import {
     TrainPlacementEngine,
     TrainPlacementStateMachine,
 } from '@/trains/input-state-machine/train-kmt-state-machine';
-import { JointDirectionPreferenceMap } from '@/trains/tracks/joint-direction-preference-map';
 import { createLayoutStateMachine } from '@/trains/input-state-machine/utils';
 import { DebugOverlayRenderSystem } from '@/trains/tracks/debug-overlay-render-system';
+import { JointDirectionPreferenceMap } from '@/trains/tracks/joint-direction-preference-map';
 import {
     type ParallelTrackOptions,
     type ProceduralTrackOptions,
@@ -538,6 +539,8 @@ export const initApp = async (
     const catenarySubStateMachine =
         createCatenaryLayoutStateMachine(catenaryLayoutEngine);
 
+    const jointDirectionSubStateMachine = createJointDirectionStateMachine();
+
     const trackRenderSystem = new TrackRenderSystem(
         worldRenderSystem,
         curveEngine.trackGraph.trackCurveManager,
@@ -591,7 +594,10 @@ export const initApp = async (
     const formationManager = new FormationManager(carStockManager);
     const trackGraph = curveEngine.trackGraph;
     const jointDirectionPreferenceMap = new JointDirectionPreferenceMap();
-    const jointDirectionManager = new DefaultJointDirectionManager(trackGraph, jointDirectionPreferenceMap);
+    const jointDirectionManager = new DefaultJointDirectionManager(
+        trackGraph,
+        jointDirectionPreferenceMap
+    );
     const trainPlacementEngine = new TrainPlacementEngine(
         baseComponents.canvasProxy,
         trackGraph,
@@ -729,6 +735,7 @@ export const initApp = async (
         catenarySubStateMachine,
         singleSpineStateMachine,
         dualSpineStateMachine,
+        jointDirectionSubStateMachine,
         baseComponents.observableInputTracker
     );
     baseComponents.kmtParser.stateMachine = kmtInputStateMachine;

--- a/apps/banana/test/default-joint-direction-manager.test.ts
+++ b/apps/banana/test/default-joint-direction-manager.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+
+import { DefaultJointDirectionManager } from '../src/trains/input-state-machine/train-kmt-state-machine';
+import { JointDirectionPreferenceMap } from '../src/trains/tracks/joint-direction-preference-map';
+import type { TrackGraph } from '../src/trains/tracks/track';
+import type { TrackJoint } from '../src/trains/tracks/types';
+
+// ---------------------------------------------------------------------------
+// Helpers (same pattern as timetable-joint-direction-manager.test.ts)
+// ---------------------------------------------------------------------------
+
+function makeJoint(
+    tangent: number[],
+    reverseTangent: number[],
+    connections: [number, number][] = []
+): TrackJoint {
+    return {
+        position: { x: 0, y: 0 },
+        connections: new Map(connections),
+        tangent: { x: 1, y: 0 },
+        direction: {
+            tangent: new Set(tangent),
+            reverseTangent: new Set(reverseTangent),
+        },
+    };
+}
+
+/**
+ * Build a mock TrackGraph for the direction manager tests.
+ *
+ * Layout:
+ *   0 --(seg 100)--> 1 --(seg 101)--> 2
+ *                     1 --(seg 102)--> 3  (branch)
+ *
+ * Joint 0: t=[1], rt=[], connections: {1: 100}
+ * Joint 1: t=[2, 3], rt=[0], connections: {0: 100, 2: 101, 3: 102}
+ * Joint 2: t=[], rt=[1], connections: {1: 101}
+ * Joint 3: t=[], rt=[1], connections: {1: 102}
+ */
+function buildTestGraph(): TrackGraph {
+    const joints = new Map<number, TrackJoint>();
+    joints.set(0, makeJoint([1], [], [[1, 100]]));
+    joints.set(
+        1,
+        makeJoint(
+            [2, 3],
+            [0],
+            [
+                [0, 100],
+                [2, 101],
+                [3, 102],
+            ]
+        )
+    );
+    joints.set(2, makeJoint([], [1], [[1, 101]]));
+    joints.set(3, makeJoint([], [1], [[1, 102]]));
+
+    return {
+        getJoint(n: number) {
+            return joints.get(n) ?? null;
+        },
+        getTrackSegmentWithJoints(segNumber: number) {
+            const segMap: Record<number, { t0Joint: number; t1Joint: number }> =
+                {
+                    100: { t0Joint: 0, t1Joint: 1 },
+                    101: { t0Joint: 1, t1Joint: 2 },
+                    102: { t0Joint: 1, t1Joint: 3 },
+                };
+            const info = segMap[segNumber];
+            if (!info) return null;
+            return { ...info, curve: { fullLength: 10, lengthAtT: () => 5 } };
+        },
+    } as unknown as TrackGraph;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DefaultJointDirectionManager', () => {
+    let graph: TrackGraph;
+
+    beforeEach(() => {
+        graph = buildTestGraph();
+    });
+
+    describe('without preference map (backwards compatible)', () => {
+        it('constructs without preference map and falls back to first-from-set', () => {
+            const mgr = new DefaultJointDirectionManager(graph);
+            // Joint 1 tangent: Set([2, 3]) — first is 2
+            const result = mgr.getNextJoint(1, 'tangent');
+            expect(result).not.toBeNull();
+            expect(result!.jointNumber).toBe(2);
+            expect(result!.curveNumber).toBe(101);
+        });
+
+        it('returns null for unknown joint', () => {
+            const mgr = new DefaultJointDirectionManager(graph);
+            const result = mgr.getNextJoint(99, 'tangent');
+            expect(result).toBeNull();
+        });
+
+        it('returns null when no outgoing joints in direction', () => {
+            const mgr = new DefaultJointDirectionManager(graph);
+            // Joint 2 has no tangent connections
+            const result = mgr.getNextJoint(2, 'tangent');
+            expect(result).toBeNull();
+        });
+
+        it('preferenceMap getter returns null when no map provided', () => {
+            const mgr = new DefaultJointDirectionManager(graph);
+            expect(mgr.preferenceMap).toBeNull();
+        });
+    });
+
+    describe('with preference map', () => {
+        it('uses preference when set and valid', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            // Prefer joint 3 at joint 1 going tangent
+            prefs.set(1, 'tangent', 3);
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+
+            const result = mgr.getNextJoint(1, 'tangent');
+            expect(result).not.toBeNull();
+            expect(result!.jointNumber).toBe(3);
+            expect(result!.curveNumber).toBe(102);
+        });
+
+        it('falls back to first-from-set when no preference is set', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            // No preference for joint 1
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+
+            // Joint 1 tangent: Set([2, 3]) — first is 2
+            const result = mgr.getNextJoint(1, 'tangent');
+            expect(result).not.toBeNull();
+            expect(result!.jointNumber).toBe(2);
+        });
+
+        it('ignores stale preference not in direction set', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            // Store a preference for a joint that doesn't exist in the set
+            prefs.set(1, 'tangent', 99);
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+
+            // Should fall back to first-from-set (joint 2)
+            const result = mgr.getNextJoint(1, 'tangent');
+            expect(result).not.toBeNull();
+            expect(result!.jointNumber).toBe(2);
+        });
+
+        it('preferenceMap getter returns the provided map', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+            expect(mgr.preferenceMap).toBe(prefs);
+        });
+
+        it('uses preference for reverseTangent direction', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            // Joint 1 reverseTangent only has [0] — still valid to test the path
+            // Use joint 0 tangent which has [1]
+            prefs.set(0, 'tangent', 1);
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+
+            const result = mgr.getNextJoint(0, 'tangent');
+            expect(result).not.toBeNull();
+            expect(result!.jointNumber).toBe(1);
+        });
+
+        it('preference for joint 2 (branch) overrides default joint 2', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            // Default would pick joint 2 (first in Set), but we set preference to 3
+            prefs.set(1, 'tangent', 3);
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+
+            const result = mgr.getNextJoint(1, 'tangent');
+            expect(result!.jointNumber).toBe(3);
+        });
+
+        it('switching preference between branches works', () => {
+            const prefs = new JointDirectionPreferenceMap();
+            const mgr = new DefaultJointDirectionManager(graph, prefs);
+
+            // First: no preference → gets 2
+            const result1 = mgr.getNextJoint(1, 'tangent');
+            expect(result1!.jointNumber).toBe(2);
+
+            // Now set preference to 3
+            prefs.set(1, 'tangent', 3);
+            const result2 = mgr.getNextJoint(1, 'tangent');
+            expect(result2!.jointNumber).toBe(3);
+
+            // Change back to 2
+            prefs.set(1, 'tangent', 2);
+            const result3 = mgr.getNextJoint(1, 'tangent');
+            expect(result3!.jointNumber).toBe(2);
+        });
+    });
+});

--- a/apps/banana/test/joint-direction-preference-map.test.ts
+++ b/apps/banana/test/joint-direction-preference-map.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+
+import {
+    type DirectionType,
+    JointDirectionPreferenceMap,
+    type SerializedJointDirectionPreference,
+} from '../src/trains/tracks/joint-direction-preference-map';
+
+describe('JointDirectionPreferenceMap', () => {
+    let map: JointDirectionPreferenceMap;
+
+    beforeEach(() => {
+        map = new JointDirectionPreferenceMap();
+    });
+
+    // -------------------------------------------------------------------------
+    // get
+    // -------------------------------------------------------------------------
+
+    describe('get', () => {
+        it('returns undefined when no preference is set', () => {
+            expect(map.get(1, 'tangent')).toBeUndefined();
+            expect(map.get(1, 'reverseTangent')).toBeUndefined();
+        });
+
+        it('returns the stored tangent preference', () => {
+            map.set(1, 'tangent', 5);
+            expect(map.get(1, 'tangent')).toBe(5);
+        });
+
+        it('returns the stored reverseTangent preference', () => {
+            map.set(2, 'reverseTangent', 7);
+            expect(map.get(2, 'reverseTangent')).toBe(7);
+        });
+
+        it('returns undefined for a direction not yet set on a joint that has the other direction set', () => {
+            map.set(3, 'tangent', 4);
+            expect(map.get(3, 'reverseTangent')).toBeUndefined();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // set
+    // -------------------------------------------------------------------------
+
+    describe('set', () => {
+        it('stores tangent and reverseTangent independently', () => {
+            map.set(1, 'tangent', 10);
+            map.set(1, 'reverseTangent', 20);
+            expect(map.get(1, 'tangent')).toBe(10);
+            expect(map.get(1, 'reverseTangent')).toBe(20);
+        });
+
+        it('overwrites an existing preference', () => {
+            map.set(1, 'tangent', 5);
+            map.set(1, 'tangent', 99);
+            expect(map.get(1, 'tangent')).toBe(99);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // clear
+    // -------------------------------------------------------------------------
+
+    describe('clear', () => {
+        it("clear(jointNumber) removes only that joint's preferences", () => {
+            map.set(1, 'tangent', 5);
+            map.set(1, 'reverseTangent', 6);
+            map.set(2, 'tangent', 7);
+
+            map.clear(1);
+
+            expect(map.get(1, 'tangent')).toBeUndefined();
+            expect(map.get(1, 'reverseTangent')).toBeUndefined();
+            expect(map.get(2, 'tangent')).toBe(7);
+        });
+
+        it('clear() with no argument removes all preferences', () => {
+            map.set(1, 'tangent', 5);
+            map.set(2, 'reverseTangent', 6);
+
+            map.clear();
+
+            expect(map.get(1, 'tangent')).toBeUndefined();
+            expect(map.get(2, 'reverseTangent')).toBeUndefined();
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // cycle
+    // -------------------------------------------------------------------------
+
+    describe('cycle', () => {
+        it('selects the first joint when no preference exists', () => {
+            const available = new Set([2, 3, 4]);
+            const result = map.cycle(1, 'tangent', available);
+            expect(result).toBe(2);
+            expect(map.get(1, 'tangent')).toBe(2);
+        });
+
+        it('advances to the next joint in iteration order', () => {
+            const available = new Set([2, 3, 4]);
+            map.set(1, 'tangent', 2);
+            const result = map.cycle(1, 'tangent', available);
+            expect(result).toBe(3);
+            expect(map.get(1, 'tangent')).toBe(3);
+        });
+
+        it('wraps around to the first joint after the last', () => {
+            const available = new Set([2, 3, 4]);
+            map.set(1, 'tangent', 4);
+            const result = map.cycle(1, 'tangent', available);
+            expect(result).toBe(2);
+            expect(map.get(1, 'tangent')).toBe(2);
+        });
+
+        it('resets to the first joint if the current preference is stale (not in available set)', () => {
+            const available = new Set([10, 20]);
+            map.set(1, 'tangent', 99); // 99 is not in the available set
+            const result = map.cycle(1, 'tangent', available);
+            expect(result).toBe(10);
+            expect(map.get(1, 'tangent')).toBe(10);
+        });
+
+        it('returns the only option when the set has size 1', () => {
+            const available = new Set([5]);
+            const result = map.cycle(1, 'tangent', available);
+            expect(result).toBe(5);
+            expect(map.get(1, 'tangent')).toBe(5);
+        });
+
+        it('works independently for tangent and reverseTangent on the same joint', () => {
+            const available = new Set([2, 3]);
+            map.set(1, 'tangent', 2);
+            map.set(1, 'reverseTangent', 3);
+
+            const tangentResult = map.cycle(1, 'tangent', available);
+            expect(tangentResult).toBe(3);
+
+            const reverseResult = map.cycle(1, 'reverseTangent', available);
+            expect(reverseResult).toBe(2);
+        });
+    });
+
+    // -------------------------------------------------------------------------
+    // serialize / deserialize
+    // -------------------------------------------------------------------------
+
+    describe('serialize', () => {
+        it('returns an empty array for an empty map', () => {
+            expect(map.serialize()).toEqual([]);
+        });
+
+        it('serializes tangent-only preference', () => {
+            map.set(1, 'tangent', 5);
+            const data = map.serialize();
+            expect(data).toHaveLength(1);
+            expect(data[0]).toEqual({ joint: 1, tangent: 5 });
+        });
+
+        it('serializes reverseTangent-only preference', () => {
+            map.set(2, 'reverseTangent', 7);
+            const data = map.serialize();
+            expect(data).toHaveLength(1);
+            expect(data[0]).toEqual({ joint: 2, reverseTangent: 7 });
+        });
+
+        it('serializes both directions for a single joint', () => {
+            map.set(3, 'tangent', 10);
+            map.set(3, 'reverseTangent', 20);
+            const data = map.serialize();
+            expect(data).toHaveLength(1);
+            expect(data[0]).toEqual({
+                joint: 3,
+                tangent: 10,
+                reverseTangent: 20,
+            });
+        });
+
+        it('serializes multiple joints', () => {
+            map.set(1, 'tangent', 5);
+            map.set(2, 'reverseTangent', 6);
+            const data = map.serialize();
+            expect(data).toHaveLength(2);
+            const byJoint = Object.fromEntries(data.map(d => [d.joint, d]));
+            expect(byJoint[1]).toEqual({ joint: 1, tangent: 5 });
+            expect(byJoint[2]).toEqual({ joint: 2, reverseTangent: 6 });
+        });
+    });
+
+    describe('deserialize', () => {
+        it('produces an empty map from an empty array', () => {
+            const result = JointDirectionPreferenceMap.deserialize([]);
+            expect(result.serialize()).toEqual([]);
+        });
+
+        it('round-trips tangent preference', () => {
+            map.set(1, 'tangent', 5);
+            const restored = JointDirectionPreferenceMap.deserialize(
+                map.serialize()
+            );
+            expect(restored.get(1, 'tangent')).toBe(5);
+            expect(restored.get(1, 'reverseTangent')).toBeUndefined();
+        });
+
+        it('round-trips reverseTangent preference', () => {
+            map.set(2, 'reverseTangent', 7);
+            const restored = JointDirectionPreferenceMap.deserialize(
+                map.serialize()
+            );
+            expect(restored.get(2, 'reverseTangent')).toBe(7);
+            expect(restored.get(2, 'tangent')).toBeUndefined();
+        });
+
+        it('round-trips both directions on the same joint', () => {
+            map.set(3, 'tangent', 10);
+            map.set(3, 'reverseTangent', 20);
+            const restored = JointDirectionPreferenceMap.deserialize(
+                map.serialize()
+            );
+            expect(restored.get(3, 'tangent')).toBe(10);
+            expect(restored.get(3, 'reverseTangent')).toBe(20);
+        });
+
+        it('round-trips multiple joints', () => {
+            map.set(1, 'tangent', 5);
+            map.set(2, 'reverseTangent', 6);
+            map.set(3, 'tangent', 8);
+            map.set(3, 'reverseTangent', 9);
+            const restored = JointDirectionPreferenceMap.deserialize(
+                map.serialize()
+            );
+            expect(restored.get(1, 'tangent')).toBe(5);
+            expect(restored.get(2, 'reverseTangent')).toBe(6);
+            expect(restored.get(3, 'tangent')).toBe(8);
+            expect(restored.get(3, 'reverseTangent')).toBe(9);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Adds a **Joint Direction Editing Tool** that lets users manually set which branch a train takes at switch joints
- New `JointDirectionPreferenceMap` stores per-joint branch preferences globally, consulted by `DefaultJointDirectionManager` before falling back to arbitrary first-from-Set
- Dedicated tool mode with hover indicators (blue dot), curved arrows, and segment highlights showing selected/unselected branches
- Preferences persist through scene save/load
- Timetable routes still take precedence over manual preferences

## How it works

1. Activate the tool via the **GitFork** button in the Drawing toolbar category
2. Hover over a switch joint (where a direction has 2+ branches) — blue dot appears
3. Click to select — arrows and highlights show for each branch
4. Click near the tangent or reverseTangent side of the joint to cycle the preferred branch
5. Click empty space to deselect

## Test plan

- [x] Unit tests for `JointDirectionPreferenceMap` (get/set/clear/cycle/serialize/deserialize)
- [x] Unit tests for `DefaultJointDirectionManager` with preferences (valid, stale, backwards-compatible)
- [x] All 647 banana tests pass
- [ ] Manual: draw Y-junction, activate tool, hover/select/cycle directions
- [ ] Manual: place train, verify it follows selected branch
- [ ] Manual: save/load scene, verify preferences persist
- [ ] Manual: timetable route overrides manual preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)