### PR TITLE
fix(banana): gangway length on curves, coupler rendering, and car type UI

### DIFF
--- a/apps/banana/src/components/toolbar/BananaToolbar.tsx
+++ b/apps/banana/src/components/toolbar/BananaToolbar.tsx
@@ -68,6 +68,7 @@ import {
     generateTemplateId,
     validateCarDefinition,
 } from '@/trains/car-template';
+import type { CarType } from '@/trains/cars';
 import type { ThrottleSteps } from '@/trains/formation';
 import { ELEVATION } from '@/trains/tracks/types';
 import type { SerializedTrackData } from '@/trains/tracks/types';
@@ -659,6 +660,7 @@ export function BananaToolbar({
             bogieOffsets: number[];
             edgeToBogie?: number;
             bogieToEdge?: number;
+            carType?: CarType;
             image?: {
                 src: string;
                 position: { x: number; y: number };
@@ -671,6 +673,7 @@ export function BananaToolbar({
                 bogieOffsets: def.bogieOffsets,
                 edgeToBogie: def.edgeToBogie ?? 2.5,
                 bogieToEdge: def.bogieToEdge ?? 2.5,
+                type: def.carType,
                 image: def.image,
             };
             setCarTemplates(prev => [...prev, template]);

--- a/apps/banana/src/components/toolbar/DepotPanel.tsx
+++ b/apps/banana/src/components/toolbar/DepotPanel.tsx
@@ -4,11 +4,15 @@ import { useTranslation } from 'react-i18next';
 
 import { Button } from '@/components/ui/button';
 import { DraggablePanel } from '@/components/ui/draggable-panel';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import type { CarStockManager } from '@/trains/car-stock-manager';
 import type { CarStockEntry } from '@/trains/car-stock-manager';
 import type { CarImageRegistry } from '@/trains/car-image-registry';
 import type { CarTemplate } from '@/trains/car-template';
+import { CarType } from '@/trains/cars';
+
+const CAR_TYPES = Object.values(CarType);
 
 type DepotPanelProps = {
     carStockManager: CarStockManager;
@@ -35,23 +39,39 @@ export function DepotPanel({
     );
     const availableCars = useSyncExternalStore(subscribe, getSnapshot);
     const { t } = useTranslation();
+    const [newCarType, setNewCarType] = useState<CarType>(CarType.COACH);
 
     return (
         <DraggablePanel
             title={t('depot')}
             onClose={onClose}
             className="w-56"
-            headerActions={
+        >
+            <Separator className="mb-2" />
+            <div className="flex items-center gap-1 mb-2">
+                <Select
+                    value={newCarType}
+                    onValueChange={(value: string) => setNewCarType(value as CarType)}
+                >
+                    <SelectTrigger size="sm" className="h-6 flex-1 text-[10px]">
+                        <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                        {CAR_TYPES.map(ct => (
+                            <SelectItem key={ct} value={ct}>
+                                {t(`carType_${ct}`)}
+                            </SelectItem>
+                        ))}
+                    </SelectContent>
+                </Select>
                 <Button
                     variant="ghost"
                     size="icon-xs"
-                    onClick={() => carStockManager.createCar()}
+                    onClick={() => carStockManager.createCar(undefined, undefined, undefined, newCarType)}
                 >
                     <Plus className="size-3.5" />
                 </Button>
-            }
-        >
-            <Separator className="mb-2" />
+            </div>
             <div className="flex max-h-64 flex-col gap-1 overflow-y-auto">
                 {availableCars.length === 0 ? (
                     <span className="text-muted-foreground py-4 text-center text-xs">
@@ -109,7 +129,8 @@ export function DepotPanel({
                                                 carStockManager.createCar(
                                                     [...tpl.bogieOffsets],
                                                     tpl.edgeToBogie,
-                                                    tpl.bogieToEdge
+                                                    tpl.bogieToEdge,
+                                                    tpl.type
                                                 );
                                             if (tpl.image) {
                                                 carImageRegistry.set(
@@ -204,6 +225,8 @@ function DepotCarRow({
                     )}
                 </div>
                 <span className="text-muted-foreground text-[10px]">
+                    {t(`carType_${entry.car.type}`)}
+                    {' · '}
                     {t('bogieCount', { count: entry.car.bogieOffsets().length + 1 })}
                     {' · '}
                     {entry.car.edgeToBogie +

--- a/apps/banana/src/i18n/locales/en.ts
+++ b/apps/banana/src/i18n/locales/en.ts
@@ -150,6 +150,13 @@ const en = {
         noCarsInStock: 'No cars in stock',
         bogieCount: '{{count}} bogies',
         templates: 'Templates',
+        carType: 'Type',
+        carType_locomotive: 'Locomotive',
+        carType_coach: 'Coach',
+        carType_motor: 'Motor',
+        carType_trailer: 'Trailer',
+        carType_freight: 'Freight',
+        carType_cab_car: 'Cab Car',
 
         // Station List Panel
         stations: 'Stations',

--- a/apps/banana/src/i18n/locales/ja.ts
+++ b/apps/banana/src/i18n/locales/ja.ts
@@ -150,6 +150,13 @@ const ja = {
         noCarsInStock: '車庫に車両がありません',
         bogieCount: '{{count}} 台車',
         templates: 'テンプレート',
+        carType: 'タイプ',
+        carType_locomotive: '機関車',
+        carType_coach: '客車',
+        carType_motor: '電動車',
+        carType_trailer: '付随車',
+        carType_freight: '貨車',
+        carType_cab_car: '制御車',
 
         // Station List Panel
         stations: '駅',

--- a/apps/banana/src/i18n/locales/zh-TW.ts
+++ b/apps/banana/src/i18n/locales/zh-TW.ts
@@ -144,6 +144,13 @@ const zhTW = {
         noCarsInStock: '車庫中沒有車輛',
         bogieCount: '{{count}} 個轉向架',
         templates: '範本',
+        carType: '類型',
+        carType_locomotive: '機車',
+        carType_coach: '客車',
+        carType_motor: '動力車',
+        carType_trailer: '拖車',
+        carType_freight: '貨車',
+        carType_cab_car: '駕駛車',
 
         // Station List Panel
         stations: '車站',

--- a/apps/banana/src/storage/car-definition-storage.ts
+++ b/apps/banana/src/storage/car-definition-storage.ts
@@ -1,4 +1,5 @@
 import type { Point } from '@ue-too/math';
+import type { CarType } from '@/trains/cars';
 
 /**
  * Raw car-definition payload — the shape the train editor produces and consumes.
@@ -10,6 +11,8 @@ export type CarDefinitionData = {
     edgeToBogie: number;
     bogieToEdge: number;
     bogies: Point[];
+    /** Car category — determines default gangway/coupler flags. */
+    carType?: CarType;
     image?: {
         src: string;
         position: Point;

--- a/apps/banana/src/train-editor/train-editor-toolbar.tsx
+++ b/apps/banana/src/train-editor/train-editor-toolbar.tsx
@@ -15,6 +15,7 @@ import {
 import { CarDefinitionLibraryDialog } from '@/components/car-definition-library/CarDefinitionLibraryDialog';
 import { SaveCarDefinitionDialog } from '@/components/car-definition-library/SaveCarDefinitionDialog';
 import { Button } from '@/components/ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Separator } from '@/components/ui/separator';
 import {
     Tooltip,
@@ -30,8 +31,11 @@ import {
     generateCarDefinitionId,
     getCarDefinitionStorage,
 } from '@/storage';
+import { CarType } from '@/trains/cars';
 
 import { useTrainEditorApp } from './use-train-editor-app';
+
+const CAR_TYPES = Object.values(CarType);
 
 type TrainEditorMode = 'idle' | 'edit-bogie' | 'add-bogie' | 'edit-image';
 
@@ -123,6 +127,7 @@ export function TrainEditorToolbar() {
     const { t } = useTranslation();
     const app = useTrainEditorApp();
     const [mode, setMode] = useState<TrainEditorMode>('idle');
+    const [carType, setCarType] = useState<CarType>(CarType.COACH);
     const [loadedLibraryEntry, setLoadedLibraryEntry] = useState<{
         id: string;
         name: string;
@@ -195,9 +200,10 @@ export function TrainEditorToolbar() {
         return {
             ...def,
             bogies: [...app.bogieEditorEngine.getBogies()],
+            carType,
             image: image ? { ...image } : undefined,
         };
-    }, [app]);
+    }, [app, carType]);
 
     const hydrateFromCarDefinition = useCallback(
         (data: Partial<CarDefinitionData>): boolean => {
@@ -229,6 +235,7 @@ export function TrainEditorToolbar() {
                 }
                 app.imageEditorEngine.notifyChange();
             }
+            setCarType(data.carType ?? CarType.COACH);
             return true;
         },
         [app, t]
@@ -364,6 +371,30 @@ export function TrainEditorToolbar() {
                     >
                         <Plus />
                     </ToolbarButton>
+
+                    <Separator />
+
+                    {/* Car type */}
+                    <div className="w-full px-1">
+                        <span className="text-muted-foreground text-[9px] font-medium uppercase tracking-wider">
+                            {t('carType')}
+                        </span>
+                        <Select
+                            value={carType}
+                            onValueChange={(value: string) => setCarType(value as CarType)}
+                        >
+                            <SelectTrigger size="sm" className="h-6 w-full text-[10px]">
+                                <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                                {CAR_TYPES.map(ct => (
+                                    <SelectItem key={ct} value={ct}>
+                                        {t(`carType_${ct}`)}
+                                    </SelectItem>
+                                ))}
+                            </SelectContent>
+                        </Select>
+                    </div>
 
                     <Separator />
 

--- a/apps/banana/src/trains/car-stock-manager.ts
+++ b/apps/banana/src/trains/car-stock-manager.ts
@@ -1,5 +1,5 @@
 import { Observable, SynchronousObservable } from '@ue-too/board';
-import { Car, generateCarId } from './cars';
+import { Car, type CarType, generateCarId } from './cars';
 
 export type CarStockEntry = { id: string; car: Car };
 
@@ -39,10 +39,21 @@ export class CarStockManager {
     }
 
     /** Create a new car with default parameters and add it to stock. */
-    createCar(bogieOffsets: number[] = [20], edgeToBogie: number = 2.5, bogieToEdge: number = 2.5): Car {
-        const car = new Car(generateCarId(), bogieOffsets, edgeToBogie, bogieToEdge);
+    createCar(bogieOffsets: number[] = [20], edgeToBogie: number = 2.5, bogieToEdge: number = 2.5, type?: CarType): Car {
+        const car = new Car(generateCarId(), bogieOffsets, edgeToBogie, bogieToEdge, undefined, type);
         this.addCar(car);
         return car;
+    }
+
+    /** Change a car's type and notify subscribers. */
+    setCarType(carId: string, type: CarType): void {
+        const car = this._cars.get(carId);
+        if (car === undefined) {
+            throw new Error(`Car ${carId} is not in stock`);
+        }
+        car.type = type;
+        this._observable.notify(carId, { type: 'update' });
+        this._notify();
     }
 
     /**

--- a/apps/banana/src/trains/train-render-system.ts
+++ b/apps/banana/src/trains/train-render-system.ts
@@ -51,8 +51,15 @@ function gangwayKey(trainId: number, index: number): string {
   return `__train_${trainId}_gangway_${index}`;
 }
 
+function couplerKey(trainId: number, index: number): string {
+  return `__train_${trainId}_coupler_${index}`;
+}
+
 /** World-space width of the gangway rectangle (meters). */
 const GANGWAY_WIDTH = 1.2;
+
+/** World-space width of the coupler bar (meters). */
+const COUPLER_WIDTH = 0.25;
 
 type GangwayGeometry = {
   x: number;
@@ -113,10 +120,6 @@ function getGangwayGeometries(
       gapBy = gB.y;
     }
 
-    const edgeDx = gapBx - gapAx;
-    const edgeDy = gapBy - gapAy;
-    const gangwayLength = Math.sqrt(edgeDx * edgeDx + edgeDy * edgeDy);
-
     // Derive the gangway angle from the two bogies closest to the coupling
     // gap (bogie 2k+1 of car A and bogie 2k+2 of car B). On curves, the
     // car-edge endpoints can overshoot each other (each is extended along
@@ -130,6 +133,24 @@ function getGangwayGeometries(
       headBogie.x - tailBogie.x,
     );
 
+    // Compute gangway length from both the car-edge distance and the
+    // bogie-to-bogie distance to handle curves correctly. On curves the
+    // car edges splay apart (each extends along its own car's angle), so
+    // the edge-to-edge distance can grow beyond the nominal gap. At the
+    // same time on tight curves the edges can converge and shrink the gap.
+    // We take the max of both measurements plus CAR_GAP padding so the
+    // gangway always tucks under both car bodies with no visible seams.
+    const edgeDx = gapBx - gapAx;
+    const edgeDy = gapBy - gapAy;
+    const edgeDist = Math.sqrt(edgeDx * edgeDx + edgeDy * edgeDy);
+    const bogieDx = headBogie.x - tailBogie.x;
+    const bogieDy = headBogie.y - tailBogie.y;
+    const bogieDist = Math.sqrt(bogieDx * bogieDx + bogieDy * bogieDy);
+    const overhangA = (cars[k].flipped ? cars[k].edgeToBogie : cars[k].bogieToEdge) - CAR_GAP;
+    const overhangB = (cars[k + 1].flipped ? cars[k + 1].bogieToEdge : cars[k + 1].edgeToBogie) - CAR_GAP;
+    const nominalLength = bogieDist - overhangA - overhangB;
+    const gangwayLength = Math.max(edgeDist, nominalLength) + CAR_GAP;
+
     // Use the bogie closest to the gap for z-order band resolution
     const gapBogieIdx = 2 * k + 1;
 
@@ -140,6 +161,69 @@ function getGangwayGeometries(
       y: (gapAy + gapBy) / 2,
       angle,
       length: Math.max(gangwayLength, 0),
+      bogiePositionIndex: gapBogieIdx,
+    });
+  }
+  return out;
+}
+
+/**
+ * Compute coupler geometries between adjacent cars that do NOT both have
+ * gangway enabled on the touching sides. A coupler is a thin bar connecting
+ * the two car edges in the coupling gap.
+ */
+function getCouplerGeometries(
+  carGeoms: CarGeometry[],
+  cars: readonly Car[],
+  positions: TrainPosition[],
+): GangwayGeometry[] {
+  const out: GangwayGeometry[] = [];
+  for (let k = 0; k + 1 < cars.length; k++) {
+    // Only render couplers where gangway is NOT rendered
+    if (cars[k].tailHasGangway && cars[k + 1].headHasGangway) continue;
+
+    const gA = carGeoms[k];
+    const gB = carGeoms[k + 1];
+
+    let gapAx: number, gapAy: number;
+    if (cars[k].flipped) {
+      gapAx = gA.x;
+      gapAy = gA.y;
+    } else {
+      gapAx = gA.x + Math.cos(gA.angle) * gA.length;
+      gapAy = gA.y + Math.sin(gA.angle) * gA.length;
+    }
+
+    let gapBx: number, gapBy: number;
+    if (cars[k + 1].flipped) {
+      gapBx = gB.x + Math.cos(gB.angle) * gB.length;
+      gapBy = gB.y + Math.sin(gB.angle) * gB.length;
+    } else {
+      gapBx = gB.x;
+      gapBy = gB.y;
+    }
+
+    const tailBogie = positions[2 * k + 1].point;
+    const headBogie = positions[2 * (k + 1)].point;
+    const angle = Math.atan2(
+      headBogie.y - tailBogie.y,
+      headBogie.x - tailBogie.x,
+    );
+
+    const bogieDx = headBogie.x - tailBogie.x;
+    const bogieDy = headBogie.y - tailBogie.y;
+    const bogieDist = Math.sqrt(bogieDx * bogieDx + bogieDy * bogieDy);
+    const overhangA = (cars[k].flipped ? cars[k].edgeToBogie : cars[k].bogieToEdge) - CAR_GAP;
+    const overhangB = (cars[k + 1].flipped ? cars[k + 1].bogieToEdge : cars[k + 1].edgeToBogie) - CAR_GAP;
+    const couplerLength = bogieDist - overhangA - overhangB;
+
+    const gapBogieIdx = 2 * k + 1;
+
+    out.push({
+      x: (gapAx + gapBx) / 2,
+      y: (gapAy + gapBy) / 2,
+      angle,
+      length: Math.max(couplerLength, 0),
       bogiePositionIndex: gapBogieIdx,
     });
   }
@@ -272,6 +356,12 @@ export class TrainRenderSystem {
   private _activeGangwayCounts: Map<number, number> = new Map();
   /** Cached procedural gangway texture. */
   private _gangwayTexture: Texture | null = null;
+  /** Per-train-id: pool of Sprites for coupler connectors. */
+  private _couplerPools: Map<number, Sprite[]> = new Map();
+  /** Per-train-id: number of active coupler drawables. */
+  private _activeCouplerCounts: Map<number, number> = new Map();
+  /** Cached procedural coupler texture. */
+  private _couplerTexture: Texture | null = null;
   /** Train ids we had last frame (to remove drawables when a train is removed). */
   private _lastTrainIds: Set<number> = new Set();
 
@@ -335,6 +425,7 @@ export class TrainRenderSystem {
     this._updateActualBogies(placed);
     this._updateActualCars(placed);
     this._updateGangways(placed);
+    this._updateCouplers(placed);
     this._worldRenderSystem.sortChildren();
 
     this._lastTrainIds.clear();
@@ -380,6 +471,7 @@ export class TrainRenderSystem {
     this._updateActualBogies(placed);
     this._updateActualCars(placed);
     this._updateGangways(placed);
+    this._updateCouplers(placed);
     this._worldRenderSystem.sortChildren();
 
     this._lastTrainIds.clear();
@@ -419,6 +511,17 @@ export class TrainRenderSystem {
     }
     this._gangwayPools.clear();
     this._activeGangwayCounts.clear();
+
+    for (const [trainId] of this._couplerPools) {
+      const count = this._activeCouplerCounts.get(trainId) ?? 0;
+      for (let i = 0; i < count; i++) {
+        const key = couplerKey(trainId, i);
+        const removed = this._worldRenderSystem.removeFromBand(key);
+        removed?.destroy({ children: true });
+      }
+    }
+    this._couplerPools.clear();
+    this._activeCouplerCounts.clear();
     this._lastTrainIds.clear();
 
     for (const cached of this._customCarTextures.values()) {
@@ -618,6 +721,85 @@ export class TrainRenderSystem {
     }
   }
 
+  private _getOrCreateCouplerTexture(): Texture | null {
+    if (this._couplerTexture) return this._couplerTexture;
+    const renderer = this._textureRenderer?.renderer?.textureGenerator;
+    if (renderer === undefined) return null;
+    const w = 16;
+    const h = 16;
+    const g = new Graphics();
+    g.rect(0, 0, w, h);
+    g.fill({ color: 0x555555 });
+    this._couplerTexture = renderer.generateTexture({ target: g });
+    g.destroy();
+    return this._couplerTexture;
+  }
+
+  private _updateCouplers(placed: readonly PlacedTrainEntry[]): void {
+    const texture = this._getOrCreateCouplerTexture();
+    if (texture === null) return;
+
+    for (const { id, train } of placed) {
+      const positions = train.getBogiePositions();
+      if (positions === null || positions.length < 2) {
+        this._hideCouplerForTrain(id);
+        continue;
+      }
+      const cars = train.cars;
+      const carGeoms = getCarGeometries(positions, cars);
+      const geoms = getCouplerGeometries(carGeoms, cars, positions);
+      this._syncCouplerPoolForTrain(id, geoms.length, texture);
+      const pool = this._couplerPools.get(id)!;
+
+      for (let i = 0; i < geoms.length; i++) {
+        const sprite = pool[i];
+        const g = geoms[i];
+
+        sprite.position.set(g.x, g.y);
+        sprite.rotation = g.angle;
+        sprite.scale.set(g.length / texture.width, COUPLER_WIDTH / texture.height);
+        sprite.visible = true;
+
+        const bandIndex = this._resolveBandIndex(positions[g.bogiePositionIndex]);
+        if (bandIndex !== null) {
+          this._worldRenderSystem.addToBand(couplerKey(id, i), sprite, bandIndex, 'onTrack');
+          this._worldRenderSystem.setOrderInBand(couplerKey(id, i), 0);
+        }
+      }
+
+      // Hide excess sprites from previous frame and remove from band
+      const prevCount = this._activeCouplerCounts.get(id) ?? 0;
+      for (let i = geoms.length; i < prevCount; i++) {
+        pool[i].visible = false;
+        this._worldRenderSystem.removeFromBand(couplerKey(id, i));
+      }
+      this._activeCouplerCounts.set(id, geoms.length);
+    }
+  }
+
+  private _hideCouplerForTrain(trainId: number): void {
+    const pool = this._couplerPools.get(trainId);
+    const count = this._activeCouplerCounts.get(trainId) ?? 0;
+    if (pool) {
+      for (let i = 0; i < count; i++) {
+        pool[i].visible = false;
+      }
+    }
+  }
+
+  private _syncCouplerPoolForTrain(trainId: number, count: number, texture: Texture): void {
+    let pool = this._couplerPools.get(trainId);
+    if (!pool) {
+      pool = [];
+      this._couplerPools.set(trainId, pool);
+    }
+    while (pool.length < count) {
+      const sprite = new Sprite({ texture });
+      sprite.anchor.set(0.5, 0.5);
+      pool.push(sprite);
+    }
+  }
+
   private _updatePreviewCars(): void {
     const texture = this._getOrCreateCarTexture();
     const positions = this._getPreviewTrain().previewBogiePositions;
@@ -789,6 +971,18 @@ export class TrainRenderSystem {
       this._gangwayPools.delete(trainId);
     }
     this._activeGangwayCounts.delete(trainId);
+
+    const couplerPool = this._couplerPools.get(trainId);
+    const couplerCount = this._activeCouplerCounts.get(trainId) ?? 0;
+    if (couplerPool) {
+      for (let i = 0; i < couplerCount; i++) {
+        const key = couplerKey(trainId, i);
+        const removed = this._worldRenderSystem.removeFromBand(key);
+        removed?.destroy({ children: true });
+      }
+      this._couplerPools.delete(trainId);
+    }
+    this._activeCouplerCounts.delete(trainId);
   }
 
   private _resolveBandIndex(position: TrainPosition): number | null {


### PR DESCRIPTION
## Summary
- **Gangway length fix**: Uses both bogie-to-bogie and edge-to-edge distance (whichever is larger) plus `CAR_GAP` padding so the gangway connector always covers the coupling gap on curves without visible seams
- **Coupler rendering**: Non-gangway connections between cars now render a thin coupler bar (0.25m width, dark gray) with full sprite pooling and lifecycle management
- **Car type UI**: Car type (locomotive, coach, motor, trailer, freight, cab car) can be selected in the depot panel before adding a car, in the train editor toolbar, and flows through templates and library save/load. Car type determines default gangway/coupler flags

## Test plan
- [x] All 647 banana tests pass
- [ ] Place a train on a curved track and verify no seams between gangway-connected cars
- [ ] Verify coupler bars render between non-gangway cars (e.g. locomotives, freight)
- [ ] In depot panel, select different car types and add cars — verify correct gangway/coupler behavior
- [ ] In train editor, set car type, export/save, then import/load — verify type persists
- [ ] Import a car template from library into depot — verify car type carries through

🤖 Generated with [Claude Code](https://claude.com/claude-code)