### PR TITLE
fix(banana): close toolbar flyout when activating a tool or opening a panel

### DIFF
--- a/apps/banana/src/stores/toolbar-ui-store.ts
+++ b/apps/banana/src/stores/toolbar-ui-store.ts
@@ -80,12 +80,17 @@ export const useToolbarUIStore = create<ToolbarUIStore>()(
             activeCategory: null,
             ...INITIAL_PANEL_STATE,
 
-            setMode: mode => set({ mode }),
+            setMode: mode => set({ mode, activeCategory: null }),
 
             togglePanel: panel =>
                 set(state => {
                     const key = PANEL_KEY_MAP[panel];
-                    return { [key]: !state[key] };
+                    const opening = !state[key];
+                    return {
+                        [key]: opening,
+                        // Close the flyout when opening an independent panel
+                        ...(opening ? { activeCategory: null } : undefined),
+                    };
                 }),
 
             setPanel: (panel, open) => set({ [PANEL_KEY_MAP[panel]]: open }),

--- a/apps/banana/test/toolbar-ui-store.test.ts
+++ b/apps/banana/test/toolbar-ui-store.test.ts
@@ -32,6 +32,7 @@ const PANEL_STATE_KEYS: Record<PanelName, string> = {
 function resetStore() {
     useToolbarUIStore.setState({
         mode: 'idle',
+        activeCategory: null,
         showDepot: false,
         showTrainPanel: false,
         showFormationEditor: false,
@@ -64,6 +65,13 @@ describe('toolbar-ui-store', () => {
         it('changes the mode', () => {
             useToolbarUIStore.getState().setMode('layout');
             expect(useToolbarUIStore.getState().mode).toBe('layout');
+        });
+
+        it('closes the flyout when activating a tool', () => {
+            useToolbarUIStore.setState({ activeCategory: 'drawing' });
+            useToolbarUIStore.getState().setMode('layout');
+            expect(useToolbarUIStore.getState().mode).toBe('layout');
+            expect(useToolbarUIStore.getState().activeCategory).toBeNull();
         });
 
         it('supports all app modes', () => {
@@ -107,6 +115,23 @@ describe('toolbar-ui-store', () => {
             expect(state.showDepot).toBe(true);
             expect(state.showTrainPanel).toBe(false);
             expect(state.showDebugPanel).toBe(false);
+        });
+
+        it('closes the flyout when opening a panel', () => {
+            useToolbarUIStore.setState({ activeCategory: 'trains' });
+            useToolbarUIStore.getState().togglePanel('trainPanel');
+            expect(useToolbarUIStore.getState().showTrainPanel).toBe(true);
+            expect(useToolbarUIStore.getState().activeCategory).toBeNull();
+        });
+
+        it('does not reopen the flyout when closing a panel', () => {
+            useToolbarUIStore.setState({
+                showDepot: true,
+                activeCategory: null,
+            });
+            useToolbarUIStore.getState().togglePanel('depot');
+            expect(useToolbarUIStore.getState().showDepot).toBe(false);
+            expect(useToolbarUIStore.getState().activeCategory).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary
- Toolbar flyout (second-level category menu) now auto-dismisses when a tool mode is activated (`setMode`) or an independent side panel is opened (`togglePanel`)
- Inline submenus (export, auto-save) are unaffected since they use `setPanel` directly

## Test plan
- [x] Existing toolbar-ui-store tests pass (31 tests)
- [x] New tests: flyout closes on `setMode`, flyout closes on `togglePanel` open, flyout stays closed on `togglePanel` close

🤖 Generated with [Claude Code](https://claude.com/claude-code)