### PR TITLE
feat(banana): train collision prevention system

### DIFF
--- a/apps/banana/notes/train-simulation-performance.md
+++ b/apps/banana/notes/train-simulation-performance.md
@@ -21,7 +21,7 @@
 
 2. **Bezier `advanceAtTWithLength()`** — Newton-Raphson iteration (2-4 iters) per bogie per frame. 100 trains × 11 bogies = 1100 calls/frame. Numerically intensive but manageable.
 
-3. **No spatial indexing for trains** — no train-train collision exists, so not an issue yet. Would need broad-phase if signaling/blocking is added.
+3. **Train collision prevention** — `CollisionGuard` runs per-frame after occupancy rebuild. Uses `OccupancyRegistry` colocated pairs for same-track broad-phase and a reactive `CrossingMap` (built from `TrackSegmentWithCollision` data, filtered to same-elevation) for crossing detection. Two-tier response: emergency brake at braking distance, hard stop at critical distance (~5 world units). Throttle lock prevents overrides during collision events. Block signals additionally enforce train separation for auto-driven trains, and proximity detection exists for coupling (detecting nearby stationary train endpoints).
 
 4. **`Array.unshift()` in `getPosition()`** — prepends to arrays when crossing joints. Minor but adds up at junctions.
 

--- a/apps/banana/src/trains/collision-guard.ts
+++ b/apps/banana/src/trains/collision-guard.ts
@@ -304,14 +304,14 @@ export class CollisionGuard {
                         const posB = trainB.train.position;
                         if (!posA || !posB) continue;
 
-                        const distA = this._distanceToCrossing(posA, crossing.selfT, segData);
-                        const distB = this._distanceToCrossing(
-                            posB,
-                            crossing.otherT,
-                            partnerSegData,
+                        const distA = this._distanceToCrossingOrOccupying(
+                            trainA.train, posA, crossing.selfT, segData,
+                        );
+                        const distB = this._distanceToCrossingOrOccupying(
+                            trainB.train, posB, crossing.otherT, partnerSegData,
                         );
 
-                        // If either train is past the crossing, skip.
+                        // If either train is past the crossing AND not occupying it, skip.
                         if (distA === null || distB === null) continue;
 
                         // Tier 2: both within critical distance → emergencyStop.
@@ -364,10 +364,16 @@ export class CollisionGuard {
     }
 
     /**
-     * Compute the arc-length distance from a train's current position to a crossing t-value
-     * along the same segment. Returns `null` if the train has already passed the crossing.
+     * Compute the arc-length distance from a train to a crossing t-value.
+     *
+     * Returns:
+     * - Positive number if the train's head is approaching the crossing
+     * - `0` if the train's body is currently occupying the crossing
+     *   (head has passed but bogies still span the crossing point)
+     * - `null` if the train is entirely past the crossing
      */
-    private _distanceToCrossing(
+    private _distanceToCrossingOrOccupying(
+        train: PlacedTrainEntry['train'],
         pos: TrainPosition,
         crossingT: number,
         segData: { curve: { lengthAtT(t: number): number } },
@@ -376,10 +382,26 @@ export class CollisionGuard {
         const crossingLen = segData.curve.lengthAtT(crossingT);
         const diff = crossingLen - posLen;
 
-        if (pos.direction === 'tangent') {
-            return diff >= 0 ? diff : null; // null = past crossing
-        } else {
-            return diff <= 0 ? -diff : null; // null = past crossing
+        // Head is approaching the crossing
+        if (pos.direction === 'tangent' && diff >= 0) return diff;
+        if (pos.direction === 'reverseTangent' && diff <= 0) return -diff;
+
+        // Head has passed — check if the body still covers the crossing.
+        // The train's body extends behind the head. If any bogie on this
+        // segment is on the other side of the crossing, the train spans it.
+        const bogies = train.getBogiePositions();
+        if (bogies) {
+            for (const bogie of bogies) {
+                if (bogie.trackSegment !== pos.trackSegment) continue;
+                const bogieLen = segData.curve.lengthAtT(bogie.tValue);
+                const bogieDiff = crossingLen - bogieLen;
+                // Head and bogie are on opposite sides of the crossing → occupying
+                if ((diff < 0 && bogieDiff >= 0) || (diff > 0 && bogieDiff <= 0)) {
+                    return 0; // occupying the crossing
+                }
+            }
         }
+
+        return null; // entirely past
     }
 }

--- a/apps/banana/src/trains/collision-guard.ts
+++ b/apps/banana/src/trains/collision-guard.ts
@@ -1,0 +1,93 @@
+import type { OccupancyRegistry } from './occupancy-registry';
+import type { PlacedTrainEntry } from './train-manager';
+import type { TrackGraph } from './tracks/track';
+import type { TrainPosition } from './formation';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Arc-length distance threshold (world units) for an immediate emergency stop. */
+const CRITICAL_DISTANCE = 5;
+
+/** Safety margin multiplier applied to the kinematic braking distance for Tier 1 throttle reduction. */
+const BRAKING_SAFETY_MARGIN = 1.8;
+
+/**
+ * Emergency brake deceleration magnitude (world units / s²).
+ * Must match the `er` entry in DEFAULT_THROTTLE_STEPS (absolute value).
+ */
+const EMERGENCY_BRAKE_DECEL = 1.3;
+
+// ---------------------------------------------------------------------------
+// CrossingMap
+// ---------------------------------------------------------------------------
+
+export type CrossingEntry = {
+    crossingSegment: number;
+    selfT: number;
+    otherT: number;
+};
+
+/**
+ * Bidirectional registry of track-level crossings.
+ * When segment A crosses segment B at (tA, tB), both
+ * A→B and B→A entries are maintained so lookups are O(1).
+ *
+ * @group Train System
+ */
+export class CrossingMap {
+    private _map: Map<number, CrossingEntry[]> = new Map();
+
+    /**
+     * Record a crossing between two track segments.
+     * Inserts a pair of symmetric entries so both segments know about each other.
+     */
+    addCrossing(segmentA: number, tA: number, segmentB: number, tB: number): void {
+        this._getOrCreate(segmentA).push({ crossingSegment: segmentB, selfT: tA, otherT: tB });
+        this._getOrCreate(segmentB).push({ crossingSegment: segmentA, selfT: tB, otherT: tA });
+    }
+
+    /**
+     * Remove all crossing data for `segmentNumber`, and also remove the
+     * back-references in partner segments that pointed to it.
+     */
+    removeSegment(segmentNumber: number): void {
+        const entries = this._map.get(segmentNumber);
+        if (entries) {
+            for (const entry of entries) {
+                const partner = this._map.get(entry.crossingSegment);
+                if (partner) {
+                    const filtered = partner.filter(e => e.crossingSegment !== segmentNumber);
+                    if (filtered.length === 0) {
+                        this._map.delete(entry.crossingSegment);
+                    } else {
+                        this._map.set(entry.crossingSegment, filtered);
+                    }
+                }
+            }
+        }
+        this._map.delete(segmentNumber);
+    }
+
+    /**
+     * Return all crossings for a given segment, or an empty array if none exist.
+     */
+    getCrossings(segmentNumber: number): readonly CrossingEntry[] {
+        return this._map.get(segmentNumber) ?? EMPTY_CROSSINGS;
+    }
+
+    private _getOrCreate(segmentNumber: number): CrossingEntry[] {
+        let arr = this._map.get(segmentNumber);
+        if (!arr) {
+            arr = [];
+            this._map.set(segmentNumber, arr);
+        }
+        return arr;
+    }
+}
+
+const EMPTY_CROSSINGS: readonly CrossingEntry[] = [];
+
+// Avoid unused-import errors — CollisionGuard uses these (added in Task 3)
+export type { OccupancyRegistry, PlacedTrainEntry, TrackGraph, TrainPosition };

--- a/apps/banana/src/trains/collision-guard.ts
+++ b/apps/banana/src/trains/collision-guard.ts
@@ -13,6 +13,9 @@ const CRITICAL_DISTANCE = 5;
 /** Safety margin multiplier applied to the kinematic braking distance for Tier 1 throttle reduction. */
 const BRAKING_SAFETY_MARGIN = 1.8;
 
+/** Time window (seconds) within which two trains approaching a crossing are considered a conflict. */
+const CROSSING_TIME_WINDOW = 3;
+
 /**
  * Emergency brake deceleration magnitude (world units / s²).
  * Must match the `er` entry in DEFAULT_THROTTLE_STEPS (absolute value).
@@ -146,8 +149,8 @@ export class CollisionGuard {
             this._checkSameTrack(idA, entryA.train, idB, entryB.train, dangerousThisFrame);
         }
 
-        // --- Crossing detection (Task 4 placeholder) ---
-        this._checkCrossings();
+        // --- Crossing detection ---
+        this._checkCrossings(placedTrains, occupancyRegistry, trainMap, dangerousThisFrame);
 
         // --- Clear locks for trains no longer in danger ---
         for (const lockedId of this._lockedTrains) {
@@ -247,11 +250,118 @@ export class CollisionGuard {
     }
 
     // -----------------------------------------------------------------------
-    // Crossing detection (placeholder — implemented in Task 4)
+    // Crossing detection
     // -----------------------------------------------------------------------
 
-    // eslint-disable-next-line @typescript-eslint/no-empty-function
-    private _checkCrossings(): void {
-        // Implemented in Task 4
+    private _checkCrossings(
+        placedTrains: readonly PlacedTrainEntry[],
+        occupancyRegistry: OccupancyRegistry,
+        trainMap: Map<number, PlacedTrainEntry>,
+        dangerousThisFrame: Set<number>,
+    ): void {
+        // Build segment → trains lookup (keyed by head position segment).
+        const segmentToTrains = new Map<number, { id: number; train: PlacedTrainEntry['train'] }[]>();
+        for (const entry of placedTrains) {
+            const pos = entry.train.position;
+            if (!pos) continue;
+            const seg = pos.trackSegment;
+            let list = segmentToTrains.get(seg);
+            if (!list) {
+                list = [];
+                segmentToTrains.set(seg, list);
+            }
+            list.push({ id: entry.id, train: entry.train });
+        }
+
+        // Deduplicate pair checks.
+        const checkedPairs = new Set<string>();
+
+        for (const [segNum, trainsOnSeg] of segmentToTrains) {
+            const crossings = this._crossingMap.getCrossings(segNum);
+            if (crossings.length === 0) continue;
+
+            const segData = this._trackGraph.getTrackSegmentWithJoints(segNum);
+            if (!segData) continue;
+
+            for (const crossing of crossings) {
+                const partnerTrains = segmentToTrains.get(crossing.crossingSegment);
+                if (!partnerTrains || partnerTrains.length === 0) continue;
+
+                const partnerSegData = this._trackGraph.getTrackSegmentWithJoints(
+                    crossing.crossingSegment,
+                );
+                if (!partnerSegData) continue;
+
+                for (const trainA of trainsOnSeg) {
+                    for (const trainB of partnerTrains) {
+                        const smallerId = Math.min(trainA.id, trainB.id);
+                        const largerId = Math.max(trainA.id, trainB.id);
+                        const pairKey = `${smallerId}:${largerId}`;
+                        if (checkedPairs.has(pairKey)) continue;
+                        checkedPairs.add(pairKey);
+
+                        const posA = trainA.train.position;
+                        const posB = trainB.train.position;
+                        if (!posA || !posB) continue;
+
+                        const distA = this._distanceToCrossing(posA, crossing.selfT, segData);
+                        const distB = this._distanceToCrossing(
+                            posB,
+                            crossing.otherT,
+                            partnerSegData,
+                        );
+
+                        // If either train is past the crossing, skip.
+                        if (distA === null || distB === null) continue;
+
+                        // Tier 2: both within critical distance → emergencyStop.
+                        if (distA <= CRITICAL_DISTANCE && distB <= CRITICAL_DISTANCE) {
+                            trainA.train.emergencyStop();
+                            trainB.train.emergencyStop();
+                            this._lockedTrains.add(trainA.id);
+                            this._lockedTrains.add(trainB.id);
+                            dangerousThisFrame.add(trainA.id);
+                            dangerousThisFrame.add(trainB.id);
+                            continue;
+                        }
+
+                        // Tier 1: check time-to-arrival window.
+                        const speedA = trainA.train.speed;
+                        const speedB = trainB.train.speed;
+                        if (speedA === 0 || speedB === 0) continue;
+
+                        const timeA = distA / speedA;
+                        const timeB = distB / speedB;
+
+                        if (isFinite(timeA) && isFinite(timeB) && Math.abs(timeA - timeB) < CROSSING_TIME_WINDOW) {
+                            trainA.train.setThrottleStep('er');
+                            trainB.train.setThrottleStep('er');
+                            dangerousThisFrame.add(trainA.id);
+                            dangerousThisFrame.add(trainB.id);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Compute the arc-length distance from a train's current position to a crossing t-value
+     * along the same segment. Returns `null` if the train has already passed the crossing.
+     */
+    private _distanceToCrossing(
+        pos: TrainPosition,
+        crossingT: number,
+        segData: { curve: { lengthAtT(t: number): number } },
+    ): number | null {
+        const posLen = segData.curve.lengthAtT(pos.tValue);
+        const crossingLen = segData.curve.lengthAtT(crossingT);
+        const diff = crossingLen - posLen;
+
+        if (pos.direction === 'tangent') {
+            return diff >= 0 ? diff : null; // null = past crossing
+        } else {
+            return diff <= 0 ? -diff : null; // null = past crossing
+        }
     }
 }

--- a/apps/banana/src/trains/collision-guard.ts
+++ b/apps/banana/src/trains/collision-guard.ts
@@ -325,9 +325,27 @@ export class CollisionGuard {
                             continue;
                         }
 
-                        // Tier 1: check time-to-arrival window.
+                        // Tier 1a: one train is stopped at/near the crossing — the
+                        // other must brake regardless of time-to-arrival.
                         const speedA = trainA.train.speed;
                         const speedB = trainB.train.speed;
+                        const aAtCrossing = distA <= CRITICAL_DISTANCE && speedA === 0;
+                        const bAtCrossing = distB <= CRITICAL_DISTANCE && speedB === 0;
+
+                        if (aAtCrossing && speedB > 0) {
+                            trainB.train.setThrottleStep('er');
+                            dangerousThisFrame.add(trainA.id);
+                            dangerousThisFrame.add(trainB.id);
+                            continue;
+                        }
+                        if (bAtCrossing && speedA > 0) {
+                            trainA.train.setThrottleStep('er');
+                            dangerousThisFrame.add(trainA.id);
+                            dangerousThisFrame.add(trainB.id);
+                            continue;
+                        }
+
+                        // Tier 1b: both moving — check time-to-arrival window.
                         if (speedA === 0 || speedB === 0) continue;
 
                         const timeA = distA / speedA;

--- a/apps/banana/src/trains/collision-guard.ts
+++ b/apps/banana/src/trains/collision-guard.ts
@@ -89,5 +89,169 @@ export class CrossingMap {
 
 const EMPTY_CROSSINGS: readonly CrossingEntry[] = [];
 
-// Avoid unused-import errors — CollisionGuard uses these (added in Task 3)
-export type { OccupancyRegistry, PlacedTrainEntry, TrackGraph, TrainPosition };
+// ---------------------------------------------------------------------------
+// CollisionGuard
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-frame collision prevention system.
+ *
+ * Reads colocated train pairs from {@link OccupancyRegistry} and applies
+ * graduated braking interventions:
+ *
+ * - **Tier 2** (≤ {@link CRITICAL_DISTANCE} world units): `emergencyStop()` on both trains — speed zeroed, train locked.
+ * - **Tier 1** (≤ brakingDistance × {@link BRAKING_SAFETY_MARGIN}): `setThrottleStep('er')` on both trains.
+ *
+ * Trains that are no longer in danger have their collision lock cleared automatically each frame.
+ *
+ * @group Train System
+ */
+export class CollisionGuard {
+    private _trackGraph: TrackGraph;
+    private _crossingMap: CrossingMap;
+
+    /** IDs of trains currently hard-stopped by Tier 2. */
+    private _lockedTrains: Set<number> = new Set();
+
+    constructor(trackGraph: TrackGraph, crossingMap: CrossingMap) {
+        this._trackGraph = trackGraph;
+        this._crossingMap = crossingMap;
+    }
+
+    /**
+     * Run one frame of collision detection and response.
+     * Call after all trains have moved and after `OccupancyRegistry.updateFromTrains()`.
+     */
+    update(placedTrains: readonly PlacedTrainEntry[], occupancyRegistry: OccupancyRegistry): void {
+        // Build a fast ID → entry lookup for this frame.
+        const trainMap = new Map<number, PlacedTrainEntry>();
+        for (const entry of placedTrains) {
+            trainMap.set(entry.id, entry);
+        }
+
+        // Track which trains are still in danger this frame so we can clear stale locks.
+        const dangerousThisFrame = new Set<number>();
+
+        // --- Same-track detection ---
+        const colocatedPairs = occupancyRegistry.getColocatedPairs();
+        for (const pairKey of colocatedPairs) {
+            const colonIdx = pairKey.indexOf(':');
+            const idA = parseInt(pairKey.slice(0, colonIdx), 10);
+            const idB = parseInt(pairKey.slice(colonIdx + 1), 10);
+
+            const entryA = trainMap.get(idA);
+            const entryB = trainMap.get(idB);
+            if (!entryA || !entryB) continue;
+
+            this._checkSameTrack(idA, entryA.train, idB, entryB.train, dangerousThisFrame);
+        }
+
+        // --- Crossing detection (Task 4 placeholder) ---
+        this._checkCrossings();
+
+        // --- Clear locks for trains no longer in danger ---
+        for (const lockedId of this._lockedTrains) {
+            if (!dangerousThisFrame.has(lockedId)) {
+                const entry = trainMap.get(lockedId);
+                if (entry) {
+                    entry.train.clearCollisionLock();
+                }
+                this._lockedTrains.delete(lockedId);
+            }
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Same-track detection
+    // -----------------------------------------------------------------------
+
+    private _checkSameTrack(
+        idA: number,
+        trainA: PlacedTrainEntry['train'],
+        idB: number,
+        trainB: PlacedTrainEntry['train'],
+        dangerousThisFrame: Set<number>,
+    ): void {
+        const posA = trainA.position;
+        const posB = trainB.position;
+        if (!posA || !posB) return;
+
+        // Both must be on the same segment.
+        if (posA.trackSegment !== posB.trackSegment) return;
+
+        // Skip if both stopped.
+        if (trainA.speed === 0 && trainB.speed === 0) return;
+
+        const seg = this._trackGraph.getTrackSegmentWithJoints(posA.trackSegment);
+        if (!seg) return;
+
+        const arcA = seg.curve.lengthAtT(posA.tValue);
+        const arcB = seg.curve.lengthAtT(posB.tValue);
+        const distance = Math.abs(arcA - arcB);
+
+        // Check if the two trains are approaching each other.
+        if (!this._areApproaching(posA, posB, arcA, arcB)) return;
+
+        const closingSpeed = trainA.speed + trainB.speed;
+
+        if (distance <= CRITICAL_DISTANCE) {
+            // Tier 2: hard stop
+            trainA.emergencyStop();
+            trainB.emergencyStop();
+            this._lockedTrains.add(idA);
+            this._lockedTrains.add(idB);
+            dangerousThisFrame.add(idA);
+            dangerousThisFrame.add(idB);
+        } else {
+            const brakingDistance = (closingSpeed * closingSpeed) / (2 * EMERGENCY_BRAKE_DECEL);
+            if (distance <= brakingDistance * BRAKING_SAFETY_MARGIN) {
+                // Tier 1: reduce throttle to emergency brake without locking
+                trainA.setThrottleStep('er');
+                trainB.setThrottleStep('er');
+                dangerousThisFrame.add(idA);
+                dangerousThisFrame.add(idB);
+            }
+        }
+    }
+
+    /**
+     * Determine if two trains on the same segment are moving toward each other.
+     *
+     * Convention:
+     * - `'tangent'` → moving in the direction of increasing t-value (higher arc-length).
+     * - `'reverseTangent'` → moving in the direction of decreasing t-value (lower arc-length).
+     *
+     * Two trains approach when:
+     * - the train with **lower** arc-length is moving **toward** higher t (tangent), AND
+     * - the train with **higher** arc-length is moving **toward** lower t (reverseTangent).
+     */
+    private _areApproaching(
+        posA: TrainPosition,
+        posB: TrainPosition,
+        arcA: number,
+        arcB: number,
+    ): boolean {
+        let lowerDir: 'tangent' | 'reverseTangent';
+        let higherDir: 'tangent' | 'reverseTangent';
+
+        if (arcA <= arcB) {
+            lowerDir = posA.direction;
+            higherDir = posB.direction;
+        } else {
+            lowerDir = posB.direction;
+            higherDir = posA.direction;
+        }
+
+        // Approaching: lower is moving up (tangent) AND higher is moving down (reverseTangent).
+        return lowerDir === 'tangent' && higherDir === 'reverseTangent';
+    }
+
+    // -----------------------------------------------------------------------
+    // Crossing detection (placeholder — implemented in Task 4)
+    // -----------------------------------------------------------------------
+
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    private _checkCrossings(): void {
+        // Implemented in Task 4
+    }
+}

--- a/apps/banana/src/trains/formation.ts
+++ b/apps/banana/src/trains/formation.ts
@@ -599,6 +599,7 @@ export class Train {
     private _speed: number = 0;
     private _acceleration: number = 0;
     private _throttle: ThrottleSteps = 'N';
+    private _collisionLocked: boolean = false;
     private _maxSpeed: number;
     private _previewPositions: TrainPosition[] | null = null;
     private _previewPositionCache: TrainPosition | null = null;
@@ -668,6 +669,10 @@ export class Train {
         return this._speed;
     }
 
+    get collisionLocked(): boolean {
+        return this._collisionLocked;
+    }
+
     /**
      * Speed ceiling in world units per second. `Infinity` means no clamp from this property.
      */
@@ -686,7 +691,20 @@ export class Train {
     }
 
     setThrottleStep(throttleStep: ThrottleSteps) {
+        if (this._collisionLocked) {
+            return;
+        }
         this._throttle = throttleStep;
+    }
+
+    emergencyStop(): void {
+        this._speed = 0;
+        this._throttle = 'er';
+        this._collisionLocked = true;
+    }
+
+    clearCollisionLock(): void {
+        this._collisionLocked = false;
     }
 
     /** Replace the junction direction manager (e.g. to use a route-aware manager for timetable driving). */

--- a/apps/banana/src/trains/tracks/trackcurve-manager.ts
+++ b/apps/banana/src/trains/tracks/trackcurve-manager.ts
@@ -1041,6 +1041,28 @@ export class TrackCurveManager {
             aabb.max.y
         );
 
+        // Compute collisions with existing segments in the RTree (same as
+        // addTrackSegment). Without this, segments loaded from serialized data
+        // have empty collision arrays and crossing detection won't work.
+        const collisions: {
+            selfT: number;
+            anotherCurve: { curve: BCurve; tVal: number };
+        }[] = [];
+
+        const possibleCollisions = this._internalRTree.search(aabbRectangle);
+        for (const segment of possibleCollisions) {
+            const intersections = segment.curve
+                .getCurveIntersections(curve)
+                .map(intersection => ({
+                    selfT: intersection.otherT,
+                    anotherCurve: {
+                        curve: segment.curve,
+                        tVal: intersection.selfT,
+                    },
+                }));
+            collisions.push(...intersections);
+        }
+
         const splits: TrackSegmentSplit[] = [];
 
         if (splitTValues.length === 0) {
@@ -1135,7 +1157,7 @@ export class TrackCurveManager {
                 from: t0Elevation,
                 to: t1Elevation,
             },
-            collision: [],
+            collision: collisions,
             gauge,
             trackStyle: visualProps?.trackStyle,
             electrified: visualProps?.electrified,

--- a/apps/banana/src/trains/train-render-system.ts
+++ b/apps/banana/src/trains/train-render-system.ts
@@ -8,6 +8,7 @@ import type { PlacedTrainEntry } from './train-manager';
 import type { CarImageRegistry } from './car-image-registry';
 import { OccupancyRegistry } from './occupancy-registry';
 import { ProximityDetector } from './proximity-detector';
+import type { CollisionGuard } from './collision-guard';
 
 const BOGIE_RADIUS = 1.067 / 2;
 
@@ -367,6 +368,7 @@ export class TrainRenderSystem {
 
   private _occupancyRegistry: OccupancyRegistry = new OccupancyRegistry();
   private _proximityDetector: ProximityDetector = new ProximityDetector();
+  private _collisionGuard: CollisionGuard | null = null;
 
   /** Cached procedural car body texture; created lazily when texture renderer is available. */
   private _carTexture: Texture | null = null;
@@ -419,6 +421,7 @@ export class TrainRenderSystem {
 
     this._occupancyRegistry.updateFromTrains(placed);
     this._proximityDetector.update(placed, this._occupancyRegistry);
+    this._collisionGuard?.update(placed, this._occupancyRegistry);
 
     this._updatePreviewBogies();
     this._updatePreviewCars();
@@ -457,6 +460,10 @@ export class TrainRenderSystem {
   /** The proximity detector, updated each frame. */
   get proximityDetector(): ProximityDetector {
     return this._proximityDetector;
+  }
+
+  set collisionGuard(guard: CollisionGuard) {
+    this._collisionGuard = guard;
   }
 
   /**

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -808,13 +808,7 @@ export const initApp = async (
     const trackCurveManager = trackGraph.trackCurveManager;
 
     function addSegmentCrossings(curveNumber: number, segment: TrackSegmentWithCollision) {
-        // Use checkForCollisions to find intersections dynamically rather than
-        // relying on segment.collision, which is empty during deserialization
-        // (loadSegmentWithId sets collision: []).
-        const exclude = new Set([curveNumber]);
-        const collisions = trackCurveManager.checkForCollisions(segment.curve, exclude);
-
-        for (const col of collisions) {
+        for (const col of segment.collision) {
             // Resolve the other segment's number by matching the BCurve reference
             for (const otherNum of trackCurveManager.livingEntities) {
                 if (otherNum === curveNumber) continue;

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -808,8 +808,14 @@ export const initApp = async (
     const trackCurveManager = trackGraph.trackCurveManager;
 
     function addSegmentCrossings(curveNumber: number, segment: TrackSegmentWithCollision) {
-        for (const col of segment.collision) {
-            // Find which segment the other curve belongs to
+        // Use checkForCollisions to find intersections dynamically rather than
+        // relying on segment.collision, which is empty during deserialization
+        // (loadSegmentWithId sets collision: []).
+        const exclude = new Set([curveNumber]);
+        const collisions = trackCurveManager.checkForCollisions(segment.curve, exclude);
+
+        for (const col of collisions) {
+            // Resolve the other segment's number by matching the BCurve reference
             for (const otherNum of trackCurveManager.livingEntities) {
                 if (otherNum === curveNumber) continue;
                 const otherSeg = trackCurveManager.getTrackSegmentWithJoints(otherNum);

--- a/apps/banana/src/utils/init-app.ts
+++ b/apps/banana/src/utils/init-app.ts
@@ -39,6 +39,7 @@ import { TerrainData } from '@/terrain/terrain-data';
 import { TerrainRenderSystem } from '@/terrain/terrain-render-system';
 import { TimeManager } from '@/time';
 import { ScheduleClock, TimetableManager } from '@/timetable';
+import { CollisionGuard, CrossingMap } from '@/trains/collision-guard';
 import { CarImageRegistry } from '@/trains/car-image-registry';
 import { CarStockManager } from '@/trains/car-stock-manager';
 import { Train, type TrainPosition } from '@/trains/formation';
@@ -71,6 +72,8 @@ import {
     generateProceduralTrackPath,
 } from '@/trains/tracks/procedural-tracks';
 import { TrackRenderSystem } from '@/trains/tracks/render-system';
+import type { TrackSegmentWithCollision } from '@/trains/tracks/types';
+import { intersectionSatisfiesVerticalClearance } from '@/trains/tracks/utils';
 import { TrainManager } from '@/trains/train-manager';
 import { TrainRenderSystem } from '@/trains/train-render-system';
 import { WorldRenderSystem } from '@/world-render-system';
@@ -796,6 +799,50 @@ export const initApp = async (
     );
     timetableManager.signalStateEngine = signalStateEngine;
     timetableManager.trackAlignedPlatformManager = trackAlignedPlatformManager;
+
+    // Collision prevention system
+    const crossingMap = new CrossingMap();
+    const collisionGuard = new CollisionGuard(trackGraph, crossingMap);
+    trainRenderSystem.collisionGuard = collisionGuard;
+
+    const trackCurveManager = trackGraph.trackCurveManager;
+
+    function addSegmentCrossings(curveNumber: number, segment: TrackSegmentWithCollision) {
+        for (const col of segment.collision) {
+            // Find which segment the other curve belongs to
+            for (const otherNum of trackCurveManager.livingEntities) {
+                if (otherNum === curveNumber) continue;
+                const otherSeg = trackCurveManager.getTrackSegmentWithJoints(otherNum);
+                if (!otherSeg || otherSeg.curve !== col.anotherCurve.curve) continue;
+
+                // Skip crossings with vertical clearance (different elevations)
+                if (intersectionSatisfiesVerticalClearance(
+                    col.selfT,
+                    segment,
+                    col.anotherCurve.tVal,
+                    otherSeg,
+                )) continue;
+
+                crossingMap.addCrossing(curveNumber, col.selfT, otherNum, col.anotherCurve.tVal);
+                break;
+            }
+        }
+    }
+
+    // Populate from existing segments
+    for (const segNum of trackCurveManager.livingEntities) {
+        const seg = trackCurveManager.getTrackSegmentWithJoints(segNum);
+        if (seg) addSegmentCrossings(segNum, seg);
+    }
+
+    // Subscribe to track mutations
+    trackCurveManager.onAddTrackSegment((curveNumber, segment) => {
+        addSegmentCrossings(curveNumber, segment);
+    });
+
+    trackCurveManager.onRemoveTrackSegment((curveNumber) => {
+        crossingMap.removeSegment(curveNumber);
+    });
 
     // When a train is removed from the track, return its formation to the depot
     trainManager.setOnBeforeRemove(train => {

--- a/apps/banana/test/collision-guard.test.ts
+++ b/apps/banana/test/collision-guard.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { CrossingMap } from '../src/trains/collision-guard';
+
+// ---------------------------------------------------------------------------
+// CrossingMap tests
+// ---------------------------------------------------------------------------
+
+describe('CrossingMap', () => {
+
+    let map: CrossingMap;
+
+    beforeEach(() => {
+        map = new CrossingMap();
+    });
+
+    describe('addCrossing — bidirectional entries', () => {
+
+        it('creates an entry for A referencing B', () => {
+            map.addCrossing(1, 0.3, 2, 0.7);
+            const crossings = map.getCrossings(1);
+            expect(crossings).toHaveLength(1);
+            expect(crossings[0]).toMatchObject({ crossingSegment: 2, selfT: 0.3, otherT: 0.7 });
+        });
+
+        it('creates a mirrored entry for B referencing A', () => {
+            map.addCrossing(1, 0.3, 2, 0.7);
+            const crossings = map.getCrossings(2);
+            expect(crossings).toHaveLength(1);
+            expect(crossings[0]).toMatchObject({ crossingSegment: 1, selfT: 0.7, otherT: 0.3 });
+        });
+
+        it('accumulates multiple crossings for the same segment', () => {
+            map.addCrossing(1, 0.2, 2, 0.5);
+            map.addCrossing(1, 0.8, 3, 0.4);
+            expect(map.getCrossings(1)).toHaveLength(2);
+            expect(map.getCrossings(2)).toHaveLength(1);
+            expect(map.getCrossings(3)).toHaveLength(1);
+        });
+    });
+
+    describe('getCrossings — unknown segment returns empty array', () => {
+
+        it('returns empty array for a segment with no crossings', () => {
+            expect(map.getCrossings(99)).toHaveLength(0);
+        });
+
+        it('returns empty readonly array (not undefined)', () => {
+            const result = map.getCrossings(42);
+            expect(Array.isArray(result)).toBe(true);
+            expect(result).toHaveLength(0);
+        });
+    });
+
+    describe('removeSegment — cleans up both sides', () => {
+
+        it('removes the segment itself', () => {
+            map.addCrossing(1, 0.3, 2, 0.7);
+            map.removeSegment(1);
+            expect(map.getCrossings(1)).toHaveLength(0);
+        });
+
+        it('removes back-references from partner segments', () => {
+            map.addCrossing(1, 0.3, 2, 0.7);
+            map.removeSegment(1);
+            // Segment 2's crossing that referenced segment 1 should be gone
+            expect(map.getCrossings(2)).toHaveLength(0);
+        });
+
+        it('removing one segment does not affect unrelated crossings', () => {
+            map.addCrossing(10, 0.1, 20, 0.9);
+            map.addCrossing(30, 0.5, 40, 0.5);
+            map.removeSegment(10);
+            // 30 ↔ 40 should be untouched
+            expect(map.getCrossings(30)).toHaveLength(1);
+            expect(map.getCrossings(40)).toHaveLength(1);
+        });
+
+        it('removing a segment with multiple crossings cleans all partners', () => {
+            map.addCrossing(1, 0.2, 2, 0.5);
+            map.addCrossing(1, 0.8, 3, 0.4);
+            map.removeSegment(1);
+            expect(map.getCrossings(1)).toHaveLength(0);
+            expect(map.getCrossings(2)).toHaveLength(0);
+            expect(map.getCrossings(3)).toHaveLength(0);
+        });
+
+        it('removeSegment on unknown segment is a no-op', () => {
+            expect(() => map.removeSegment(999)).not.toThrow();
+        });
+    });
+});

--- a/apps/banana/test/collision-guard.test.ts
+++ b/apps/banana/test/collision-guard.test.ts
@@ -546,4 +546,38 @@ describe('CollisionGuard — crossing detection', () => {
         // Train 2 should be braking, train 1 is already stopped
         expect(t2.throttleStep).toBe('er');
     });
+
+    it('should detect when train body spans the crossing even if head has passed', () => {
+        // Crossing at t=0.5 on both segments.
+        // Train 1 head at t=0.6 (past crossing) but last bogie at t=0.3 (before crossing)
+        // → body spans the crossing point → occupying it (dist = 0)
+        // Train 2 approaching on the other segment
+        crossingMap.addCrossing(1, 0.5, 2, 0.5);
+        const trackGraph = mockTrackGraph(100);
+        const guard = new CollisionGuard(trackGraph, crossingMap);
+
+        const t1 = mockTrain({
+            headPosition: makePosition(1, 0.6, 'tangent'),
+            bogiePositions: [
+                makePosition(1, 0.55, 'tangent'), // first bogie, past crossing
+                makePosition(1, 0.3, 'tangent'),  // last bogie, before crossing
+            ],
+            speed: 5,
+            occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+        });
+        const t2 = mockTrain({
+            headPosition: makePosition(2, 0.3, 'tangent'),
+            bogiePositions: [makePosition(2, 0.3, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'tangent' }],
+        });
+
+        const entries = [entry(1, t1), entry(2, t2)];
+        registry.updateFromTrains(entries);
+        guard.update(entries, registry);
+
+        // Train 1 body spans crossing (dist=0 ≤ 5) and train 2 approaching (dist=20)
+        // → Tier 1b time-based check: t1 time=0 (at crossing), t2 time=2s → |0-2|<3 → brake
+        expect(t2.throttleStep).toBe('er');
+    });
 });

--- a/apps/banana/test/collision-guard.test.ts
+++ b/apps/banana/test/collision-guard.test.ts
@@ -381,3 +381,140 @@ describe('CollisionGuard', () => {
         });
     });
 });
+
+// ---------------------------------------------------------------------------
+// CollisionGuard — crossing detection tests
+// ---------------------------------------------------------------------------
+
+describe('CollisionGuard — crossing detection', () => {
+
+    let registry: OccupancyRegistry;
+    let crossingMap: CrossingMap;
+
+    beforeEach(() => {
+        registry = new OccupancyRegistry();
+        crossingMap = new CrossingMap();
+    });
+
+    it('Tier 1: both trains approach crossing simultaneously within time window → er', () => {
+        // Segment 100 units long. Crossing at t=0.5 (arc=50) on both segments.
+        // t1 on seg 1 at t=0.3 (arc=30), tangent → dist to crossing = 50-30 = 20, speed=10 → time=2s
+        // t2 on seg 2 at t=0.3 (arc=30), tangent → dist to crossing = 50-30 = 20, speed=10 → time=2s
+        // |2 - 2| = 0 < 3s window → Tier 1 trigger
+        crossingMap.addCrossing(1, 0.5, 2, 0.5);
+        const trackGraph = mockTrackGraph(100);
+        const guard = new CollisionGuard(trackGraph, crossingMap);
+
+        const t1 = mockTrain({
+            headPosition: makePosition(1, 0.3, 'tangent'),
+            bogiePositions: [makePosition(1, 0.3, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+        });
+        const t2 = mockTrain({
+            headPosition: makePosition(2, 0.3, 'tangent'),
+            bogiePositions: [makePosition(2, 0.3, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'tangent' }],
+        });
+
+        const entries = [entry(1, t1), entry(2, t2)];
+        registry.updateFromTrains(entries);
+        guard.update(entries, registry);
+
+        expect(t1.throttleStep).toBe('er');
+        expect(t2.throttleStep).toBe('er');
+        // Tier 1 does NOT collision-lock
+        expect(t1.collisionLocked).toBe(false);
+        expect(t2.collisionLocked).toBe(false);
+    });
+
+    it('No trigger: trains approach crossing at very different times (> 3s window)', () => {
+        // t1 on seg 1 at t=0.45 (arc=45), tangent → dist = 50-45 = 5, speed=10 → time=0.5s
+        // t2 on seg 2 at t=0.05 (arc=5), tangent → dist = 50-5 = 45, speed=10 → time=4.5s
+        // |0.5 - 4.5| = 4 > 3s → no trigger
+        crossingMap.addCrossing(1, 0.5, 2, 0.5);
+        const trackGraph = mockTrackGraph(100);
+        const guard = new CollisionGuard(trackGraph, crossingMap);
+
+        const t1 = mockTrain({
+            headPosition: makePosition(1, 0.45, 'tangent'),
+            bogiePositions: [makePosition(1, 0.45, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+        });
+        const t2 = mockTrain({
+            headPosition: makePosition(2, 0.05, 'tangent'),
+            bogiePositions: [makePosition(2, 0.05, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'tangent' }],
+        });
+
+        const entries = [entry(1, t1), entry(2, t2)];
+        registry.updateFromTrains(entries);
+        guard.update(entries, registry);
+
+        expect(t1.throttleStep).toBe('N');
+        expect(t2.throttleStep).toBe('N');
+    });
+
+    it('No trigger: one train moving away from crossing (past it)', () => {
+        // t1 on seg 1 at t=0.6, tangent → crossing at 0.5, diff = 50-60 = -10 → null (past crossing)
+        // t2 on seg 2 at t=0.3, tangent → approaching, but t1 skips → no trigger
+        crossingMap.addCrossing(1, 0.5, 2, 0.5);
+        const trackGraph = mockTrackGraph(100);
+        const guard = new CollisionGuard(trackGraph, crossingMap);
+
+        const t1 = mockTrain({
+            headPosition: makePosition(1, 0.6, 'tangent'),
+            bogiePositions: [makePosition(1, 0.6, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+        });
+        const t2 = mockTrain({
+            headPosition: makePosition(2, 0.3, 'tangent'),
+            bogiePositions: [makePosition(2, 0.3, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'tangent' }],
+        });
+
+        const entries = [entry(1, t1), entry(2, t2)];
+        registry.updateFromTrains(entries);
+        guard.update(entries, registry);
+
+        expect(t1.throttleStep).toBe('N');
+        expect(t2.throttleStep).toBe('N');
+    });
+
+    it('Tier 2: both trains very close to crossing → emergencyStop', () => {
+        // Crossing at t=0.5 (arc=50).
+        // t1 on seg 1 at t=0.5 (arc=50), tangent → dist = 50-50 = 0 < 5 → critical
+        // t2 on seg 2 at t=0.48 (arc=48), tangent → dist = 50-48 = 2 < 5 → critical
+        // Both within CRITICAL_DISTANCE → emergencyStop
+        crossingMap.addCrossing(1, 0.5, 2, 0.5);
+        const trackGraph = mockTrackGraph(100);
+        const guard = new CollisionGuard(trackGraph, crossingMap);
+
+        const t1 = mockTrain({
+            headPosition: makePosition(1, 0.5, 'tangent'),
+            bogiePositions: [makePosition(1, 0.5, 'tangent')],
+            speed: 2,
+            occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+        });
+        const t2 = mockTrain({
+            headPosition: makePosition(2, 0.48, 'tangent'),
+            bogiePositions: [makePosition(2, 0.48, 'tangent')],
+            speed: 2,
+            occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'tangent' }],
+        });
+
+        const entries = [entry(1, t1), entry(2, t2)];
+        registry.updateFromTrains(entries);
+        guard.update(entries, registry);
+
+        expect(t1.collisionLocked).toBe(true);
+        expect(t1.speed).toBe(0);
+        expect(t2.collisionLocked).toBe(true);
+        expect(t2.speed).toBe(0);
+    });
+});

--- a/apps/banana/test/collision-guard.test.ts
+++ b/apps/banana/test/collision-guard.test.ts
@@ -1,5 +1,88 @@
 import { describe, it, expect, beforeEach } from 'bun:test';
-import { CrossingMap } from '../src/trains/collision-guard';
+import { CrossingMap, CollisionGuard } from '../src/trains/collision-guard';
+import { OccupancyRegistry } from '../src/trains/occupancy-registry';
+import type { PlacedTrainEntry } from '../src/trains/train-manager';
+import type { Train, TrainPosition, ThrottleSteps } from '../src/trains/formation';
+import type { TrackGraph } from '../src/trains/tracks/track';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makePosition(
+    segment: number,
+    tValue: number,
+    direction: 'tangent' | 'reverseTangent' = 'tangent',
+): TrainPosition {
+    return { trackSegment: segment, tValue, direction, point: { x: 0, y: 0 } };
+}
+
+function mockTrain(opts: {
+    headPosition: TrainPosition | null;
+    bogiePositions: TrainPosition[] | null;
+    speed?: number;
+    occupiedSegments?: { trackNumber: number; inTrackDirection: 'tangent' | 'reverseTangent' }[];
+    occupiedJoints?: { jointNumber: number; direction: 'tangent' | 'reverseTangent' }[];
+}): Train {
+    let speed = opts.speed ?? 0;
+    let throttle: ThrottleSteps = 'N';
+    let collisionLocked = false;
+
+    return {
+        position: opts.headPosition,
+        getBogiePositions: () => opts.bogiePositions,
+        get speed() {
+            return speed;
+        },
+        get throttleStep() {
+            return throttle;
+        },
+        get collisionLocked() {
+            return collisionLocked;
+        },
+        occupiedTrackSegments: opts.occupiedSegments ?? [],
+        occupiedJointNumbers: opts.occupiedJoints ?? [],
+        formation: {
+            headCouplerLength: 0,
+            tailCouplerLength: 0,
+        },
+        setThrottleStep(step: ThrottleSteps) {
+            if (collisionLocked) return;
+            throttle = step;
+        },
+        emergencyStop() {
+            speed = 0;
+            throttle = 'er';
+            collisionLocked = true;
+        },
+        clearCollisionLock() {
+            collisionLocked = false;
+        },
+    } as unknown as Train;
+}
+
+function entry(id: number, train: Train): PlacedTrainEntry {
+    return { id, train };
+}
+
+/**
+ * Build a mock TrackGraph whose getTrackSegmentWithJoints returns a segment
+ * with a curve that maps tValue linearly to arc-length via fullLength.
+ *
+ * lengthAtT(t) = t * fullLength
+ */
+function mockTrackGraph(segmentFullLength: number = 100): TrackGraph {
+    return {
+        getTrackSegmentWithJoints(_segNum: number) {
+            return {
+                curve: {
+                    lengthAtT: (t: number) => t * segmentFullLength,
+                    fullLength: segmentFullLength,
+                },
+            };
+        },
+    } as unknown as TrackGraph;
+}
 
 // ---------------------------------------------------------------------------
 // CrossingMap tests
@@ -62,7 +145,6 @@ describe('CrossingMap', () => {
         it('removes back-references from partner segments', () => {
             map.addCrossing(1, 0.3, 2, 0.7);
             map.removeSegment(1);
-            // Segment 2's crossing that referenced segment 1 should be gone
             expect(map.getCrossings(2)).toHaveLength(0);
         });
 
@@ -70,7 +152,6 @@ describe('CrossingMap', () => {
             map.addCrossing(10, 0.1, 20, 0.9);
             map.addCrossing(30, 0.5, 40, 0.5);
             map.removeSegment(10);
-            // 30 ↔ 40 should be untouched
             expect(map.getCrossings(30)).toHaveLength(1);
             expect(map.getCrossings(40)).toHaveLength(1);
         });
@@ -86,6 +167,217 @@ describe('CrossingMap', () => {
 
         it('removeSegment on unknown segment is a no-op', () => {
             expect(() => map.removeSegment(999)).not.toThrow();
+        });
+    });
+});
+
+// ---------------------------------------------------------------------------
+// CollisionGuard — same-track detection tests
+// ---------------------------------------------------------------------------
+
+describe('CollisionGuard', () => {
+
+    let registry: OccupancyRegistry;
+    let crossingMap: CrossingMap;
+
+    beforeEach(() => {
+        registry = new OccupancyRegistry();
+        crossingMap = new CrossingMap();
+    });
+
+    describe('Tier 2 hard stop (distance <= 5)', () => {
+
+        it('calls emergencyStop on both trains when approaching within critical distance', () => {
+            // Segment 100 units long. trainA at t=0.04 (arc=4), trainB at t=0.07 (arc=7).
+            // Distance = |4-7| = 3 <= 5. trainA tangent (moving up), trainB reverseTangent (moving down) → approaching.
+            const trackGraph = mockTrackGraph(100);
+            const guard = new CollisionGuard(trackGraph, crossingMap);
+
+            const trainA = mockTrain({
+                headPosition: makePosition(1, 0.04, 'tangent'),
+                bogiePositions: [makePosition(1, 0.04, 'tangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+            });
+            const trainB = mockTrain({
+                headPosition: makePosition(1, 0.07, 'reverseTangent'),
+                bogiePositions: [makePosition(1, 0.07, 'reverseTangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'reverseTangent' }],
+            });
+
+            const entries = [entry(1, trainA), entry(2, trainB)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            expect(trainA.collisionLocked).toBe(true);
+            expect(trainA.speed).toBe(0);
+            expect(trainA.throttleStep).toBe('er');
+            expect(trainB.collisionLocked).toBe(true);
+            expect(trainB.speed).toBe(0);
+            expect(trainB.throttleStep).toBe('er');
+        });
+    });
+
+    describe('Tier 1 emergency brake (distance <= brakingDistance * 1.8)', () => {
+
+        it('sets throttle to er on both trains within braking distance', () => {
+            // Segment 1000 units long. speed=10. brakingDistance = 10² / (2*1.3) ≈ 38.46.
+            // threshold = 38.46 * 1.8 ≈ 69.23 units.
+            // trainA at t=0.10 (arc=100), trainB at t=0.15 (arc=150). Distance=50.
+            // 50 <= 69.23 but > 5 → Tier 1.
+            const trackGraph = mockTrackGraph(1000);
+            const guard = new CollisionGuard(trackGraph, crossingMap);
+
+            const trainA = mockTrain({
+                headPosition: makePosition(1, 0.10, 'tangent'),
+                bogiePositions: [makePosition(1, 0.10, 'tangent')],
+                speed: 10,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+            });
+            const trainB = mockTrain({
+                headPosition: makePosition(1, 0.15, 'reverseTangent'),
+                bogiePositions: [makePosition(1, 0.15, 'reverseTangent')],
+                speed: 10,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'reverseTangent' }],
+            });
+
+            const entries = [entry(1, trainA), entry(2, trainB)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            // Not collision-locked (Tier 1 does NOT call emergencyStop)
+            expect(trainA.collisionLocked).toBe(false);
+            expect(trainB.collisionLocked).toBe(false);
+            // But throttle should be set to 'er'
+            expect(trainA.throttleStep).toBe('er');
+            expect(trainB.throttleStep).toBe('er');
+        });
+    });
+
+    describe('No trigger — trains moving apart', () => {
+
+        it('does not intervene when trains are moving away from each other', () => {
+            // trainA at t=0.04 moving reverseTangent (away from trainB above it)
+            // trainB at t=0.07 moving tangent (away from trainA below it)
+            // Distance = 3 <= 5 but NOT approaching → no trigger
+            const trackGraph = mockTrackGraph(100);
+            const guard = new CollisionGuard(trackGraph, crossingMap);
+
+            const trainA = mockTrain({
+                headPosition: makePosition(1, 0.04, 'reverseTangent'),
+                bogiePositions: [makePosition(1, 0.04, 'reverseTangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'reverseTangent' }],
+            });
+            const trainB = mockTrain({
+                headPosition: makePosition(1, 0.07, 'tangent'),
+                bogiePositions: [makePosition(1, 0.07, 'tangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+            });
+
+            const entries = [entry(1, trainA), entry(2, trainB)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            expect(trainA.collisionLocked).toBe(false);
+            expect(trainB.collisionLocked).toBe(false);
+            expect(trainA.throttleStep).toBe('N');
+            expect(trainB.throttleStep).toBe('N');
+        });
+    });
+
+    describe('No trigger — both trains stopped', () => {
+
+        it('skips collision check when both trains have speed === 0', () => {
+            const trackGraph = mockTrackGraph(100);
+            const guard = new CollisionGuard(trackGraph, crossingMap);
+
+            const trainA = mockTrain({
+                headPosition: makePosition(1, 0.04, 'tangent'),
+                bogiePositions: [makePosition(1, 0.04, 'tangent')],
+                speed: 0,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+            });
+            const trainB = mockTrain({
+                headPosition: makePosition(1, 0.07, 'reverseTangent'),
+                bogiePositions: [makePosition(1, 0.07, 'reverseTangent')],
+                speed: 0,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'reverseTangent' }],
+            });
+
+            const entries = [entry(1, trainA), entry(2, trainB)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            expect(trainA.collisionLocked).toBe(false);
+            expect(trainB.collisionLocked).toBe(false);
+        });
+    });
+
+    describe('No trigger — trains on different segments', () => {
+
+        it('does not intervene when trains are on different segments (not colocated)', () => {
+            const trackGraph = mockTrackGraph(100);
+            const guard = new CollisionGuard(trackGraph, crossingMap);
+
+            const trainA = mockTrain({
+                headPosition: makePosition(1, 0.04, 'tangent'),
+                bogiePositions: [makePosition(1, 0.04, 'tangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+            });
+            const trainB = mockTrain({
+                headPosition: makePosition(2, 0.07, 'reverseTangent'),
+                bogiePositions: [makePosition(2, 0.07, 'reverseTangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'reverseTangent' }],
+            });
+
+            const entries = [entry(1, trainA), entry(2, trainB)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            expect(trainA.collisionLocked).toBe(false);
+            expect(trainB.collisionLocked).toBe(false);
+        });
+    });
+
+    describe('Lock clearing', () => {
+
+        it('clears lock for a train that is no longer in danger', () => {
+            const trackGraph = mockTrackGraph(100);
+            const guard = new CollisionGuard(trackGraph, crossingMap);
+
+            const trainA = mockTrain({
+                headPosition: makePosition(1, 0.04, 'tangent'),
+                bogiePositions: [makePosition(1, 0.04, 'tangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+            });
+            const trainB = mockTrain({
+                headPosition: makePosition(1, 0.07, 'reverseTangent'),
+                bogiePositions: [makePosition(1, 0.07, 'reverseTangent')],
+                speed: 5,
+                occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'reverseTangent' }],
+            });
+
+            let entries = [entry(1, trainA), entry(2, trainB)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            // Both should be locked after Tier 2 trigger
+            expect(trainA.collisionLocked).toBe(true);
+            expect(trainB.collisionLocked).toBe(true);
+
+            // Next frame: remove trainB, only trainA remains
+            entries = [entry(1, trainA)];
+            registry.updateFromTrains(entries);
+            guard.update(entries, registry);
+
+            // TrainA's lock should be cleared since it's no longer in danger
+            expect(trainA.collisionLocked).toBe(false);
         });
     });
 });

--- a/apps/banana/test/collision-guard.test.ts
+++ b/apps/banana/test/collision-guard.test.ts
@@ -517,4 +517,33 @@ describe('CollisionGuard — crossing detection', () => {
         expect(t2.collisionLocked).toBe(true);
         expect(t2.speed).toBe(0);
     });
+
+    it('should brake approaching train when another is stopped at the crossing', () => {
+        // Train 1 is stopped at the crossing (speed=0, dist=0)
+        // Train 2 is approaching on the other segment (speed=10)
+        // Train 2 should get emergency brake even though train 1 is stationary
+        crossingMap.addCrossing(1, 0.5, 2, 0.5);
+        const trackGraph = mockTrackGraph(100);
+        const guard = new CollisionGuard(trackGraph, crossingMap);
+
+        const t1 = mockTrain({
+            headPosition: makePosition(1, 0.5, 'tangent'),
+            bogiePositions: [makePosition(1, 0.5, 'tangent')],
+            speed: 0,
+            occupiedSegments: [{ trackNumber: 1, inTrackDirection: 'tangent' }],
+        });
+        const t2 = mockTrain({
+            headPosition: makePosition(2, 0.2, 'tangent'),
+            bogiePositions: [makePosition(2, 0.2, 'tangent')],
+            speed: 10,
+            occupiedSegments: [{ trackNumber: 2, inTrackDirection: 'tangent' }],
+        });
+
+        const entries = [entry(1, t1), entry(2, t2)];
+        registry.updateFromTrains(entries);
+        guard.update(entries, registry);
+
+        // Train 2 should be braking, train 1 is already stopped
+        expect(t2.throttleStep).toBe('er');
+    });
 });

--- a/apps/banana/test/collision-lock.test.ts
+++ b/apps/banana/test/collision-lock.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'bun:test';
+import { Car } from '../src/trains/cars';
+import { Formation, Train } from '../src/trains/formation';
+import type { TrackGraph } from '../src/trains/tracks/track';
+import type { JointDirectionManager } from '../src/trains/input-state-machine/train-kmt-state-machine';
+
+const mockTrackGraph = {} as unknown as TrackGraph;
+const mockJointDirectionManager = {} as unknown as JointDirectionManager;
+
+function makeTrain(): Train {
+    const car = new Car('A', [20], 2.5, 2.5);
+    const formation = new Formation('f', [car]);
+    return new Train(null, mockTrackGraph, mockJointDirectionManager, formation);
+}
+
+describe('Train collision lock', () => {
+
+    describe('setThrottleStep (no lock)', () => {
+
+        it('should set throttle normally when not locked', () => {
+            const train = makeTrain();
+            train.setThrottleStep('p3');
+            expect(train.throttleStep).toBe('p3');
+        });
+
+        it('should change throttle multiple times when not locked', () => {
+            const train = makeTrain();
+            train.setThrottleStep('p1');
+            expect(train.throttleStep).toBe('p1');
+            train.setThrottleStep('b2');
+            expect(train.throttleStep).toBe('b2');
+        });
+
+    });
+
+    describe('emergencyStop()', () => {
+
+        it('should set speed to 0', () => {
+            const train = makeTrain();
+            // Manually set speed via private field access
+            (train as unknown as { _speed: number })._speed = 50;
+            train.emergencyStop();
+            expect(train.speed).toBe(0);
+        });
+
+        it('should set throttle to "er"', () => {
+            const train = makeTrain();
+            train.setThrottleStep('p5');
+            train.emergencyStop();
+            expect(train.throttleStep).toBe('er');
+        });
+
+        it('should set collisionLocked to true', () => {
+            const train = makeTrain();
+            expect(train.collisionLocked).toBe(false);
+            train.emergencyStop();
+            expect(train.collisionLocked).toBe(true);
+        });
+
+        it('should set all three: speed=0, throttle=er, collisionLocked=true', () => {
+            const train = makeTrain();
+            (train as unknown as { _speed: number })._speed = 100;
+            train.setThrottleStep('p4');
+            train.emergencyStop();
+            expect(train.speed).toBe(0);
+            expect(train.throttleStep).toBe('er');
+            expect(train.collisionLocked).toBe(true);
+        });
+
+    });
+
+    describe('setThrottleStep blocked when collisionLocked', () => {
+
+        it('should be a no-op when collisionLocked is true', () => {
+            const train = makeTrain();
+            train.emergencyStop();
+            // Attempt to change throttle — should be ignored
+            train.setThrottleStep('p3');
+            expect(train.throttleStep).toBe('er');
+        });
+
+        it('should not change throttle from any value while locked', () => {
+            const train = makeTrain();
+            train.emergencyStop();
+            train.setThrottleStep('N');
+            train.setThrottleStep('b1');
+            train.setThrottleStep('p5');
+            // All changes should have been ignored
+            expect(train.throttleStep).toBe('er');
+        });
+
+    });
+
+    describe('clearCollisionLock()', () => {
+
+        it('should set collisionLocked to false', () => {
+            const train = makeTrain();
+            train.emergencyStop();
+            expect(train.collisionLocked).toBe(true);
+            train.clearCollisionLock();
+            expect(train.collisionLocked).toBe(false);
+        });
+
+        it('should allow setThrottleStep again after clearing the lock', () => {
+            const train = makeTrain();
+            train.emergencyStop();
+            train.clearCollisionLock();
+            train.setThrottleStep('p2');
+            expect(train.throttleStep).toBe('p2');
+        });
+
+        it('should be a no-op when called on an unlocked train', () => {
+            const train = makeTrain();
+            expect(train.collisionLocked).toBe(false);
+            train.clearCollisionLock();
+            expect(train.collisionLocked).toBe(false);
+        });
+
+        it('should allow multiple throttle changes after unlock', () => {
+            const train = makeTrain();
+            train.emergencyStop();
+            train.clearCollisionLock();
+            train.setThrottleStep('b3');
+            expect(train.throttleStep).toBe('b3');
+            train.setThrottleStep('p1');
+            expect(train.throttleStep).toBe('p1');
+        });
+
+    });
+
+    describe('collisionLocked getter', () => {
+
+        it('should be false by default', () => {
+            const train = makeTrain();
+            expect(train.collisionLocked).toBe(false);
+        });
+
+    });
+
+});


### PR DESCRIPTION
## Summary

- Adds a `CollisionGuard` system that prevents train-train collisions for all trains (manual and auto-driven)
- **Same-track detection**: uses `OccupancyRegistry` colocated pairs as broad-phase, computes arc-length distance between trains on shared segments, two-tier response (emergency brake at braking distance, hard stop within 5 world units)
- **Crossing detection**: reactive `CrossingMap` tracks same-elevation track intersections, time-to-arrival overlap check prevents simultaneous crossing, body-span detection catches trains whose body covers a crossing even when the head has passed
- Adds `collisionLocked` flag and `emergencyStop()` to `Train` to prevent throttle overrides during collision events
- Fixes `loadSegmentWithId` to compute collision arrays during deserialization (was `[]`)

## Test plan

- [x] Unit tests for `CrossingMap` (bidirectional entries, segment removal cleanup)
- [x] Unit tests for same-track collision (Tier 1 brake, Tier 2 hard stop, moving apart, lock clearing)
- [x] Unit tests for crossing collision (simultaneous arrival, staggered arrival, stopped at crossing, body spanning crossing)
- [x] Unit tests for `Train` collision lock (`emergencyStop`, `clearCollisionLock`, throttle guard)
- [x] 685 tests passing, 0 failures
- [ ] Manual testing: place two trains on collision course, verify they stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)