### PR TITLE
fix(dynamics): gate static-friction velocity clamp on frictionEnabled

### DIFF
--- a/.changeset/fix-static-friction-reset.md
+++ b/.changeset/fix-static-friction-reset.md
@@ -1,0 +1,7 @@
+---
+'@ue-too/dynamics': patch
+---
+
+fix(dynamics): only apply static-friction-like velocity clamp when friction is enabled
+
+The check `|v| < |F*dt/m|` that zeroes velocity in `BaseRigidBody.step` previously ran unconditionally. When `frictionEnabled=false` (the default) and a body has a ramping force applied (e.g. through a first-order lag on a controller input), this creates a stable fixed point at `|v| = |F*dt/m|` where the body gets pinned instead of accelerating. The clamp now lives inside the `frictionEnabled` branch alongside the other friction logic.

--- a/packages/dynamics/src/rigidbody.ts
+++ b/packages/dynamics/src/rigidbody.ts
@@ -233,17 +233,23 @@ export abstract class BaseRigidBody implements RigidBody {
             this._angularVelocity += angularDamping;
         }
         this._orientationAngle += this._angularVelocity * deltaTime;
+        // Static-friction-like clamp: if the pending impulse would overshoot
+        // the current velocity (i.e. the body would "reverse" in one step),
+        // zero the velocity so it doesn't. Only meaningful when friction is
+        // enabled — without friction this creates a stable fixed point at
+        // |v| = |F*dt/m| where the body gets pinned each step.
         if (
+            this.frictionEnabled &&
             PointCal.magnitude({
                 x: this._linearVelocity.x,
                 y: this._linearVelocity.y,
             }) <
-            PointCal.magnitude(
-                PointCal.divideVectorByScalar(
-                    PointCal.multiplyVectorByScalar(this.force, deltaTime),
-                    this.mass
+                PointCal.magnitude(
+                    PointCal.divideVectorByScalar(
+                        PointCal.multiplyVectorByScalar(this.force, deltaTime),
+                        this.mass
+                    )
                 )
-            )
         ) {
             if (this._linearVelocity.z != undefined) {
                 this._linearVelocity = {

--- a/packages/dynamics/test/rigidbody.test.ts
+++ b/packages/dynamics/test/rigidbody.test.ts
@@ -128,6 +128,48 @@ describe('Polygon Rigidbody', () => {
         expect(polygon.center.y).toBeGreaterThan(0);
     });
 
+    test('Polygon accelerates past |F*dt/m| when friction is disabled', () => {
+        // Regression: prior to the fix, the static-friction-like clamp ran
+        // even with frictionEnabled=false. If force ramps up (e.g. through
+        // a first-order lag on a controller input), the check |v| < |F*dt/m|
+        // fires every step and pins velocity at ~|F_target*dt/m| indefinitely
+        // — the body "stalls" instead of accelerating.
+        const vertices = [
+            { x: 1, y: 1 },
+            { x: -1, y: 1 },
+            { x: -1, y: -1 },
+            { x: 1, y: -1 },
+        ];
+        const polygon = new Polygon(
+            { x: 0, y: 0 },
+            vertices,
+            0,
+            500,
+            false,
+            false
+        );
+        const dt = 1 / 240;
+        const tau = 0.15;
+        const Fx_target = 14480;
+        const Fy_target = -486;
+        let Fx = 0;
+        let Fy = 0;
+
+        for (let i = 0; i < 500; i++) {
+            Fx += ((Fx_target - Fx) * dt) / tau;
+            Fy += ((Fy_target - Fy) * dt) / tau;
+            polygon.applyForce({ x: Fx, y: Fy });
+            polygon.step(dt);
+        }
+
+        const vPinned = Math.hypot(Fx_target, Fy_target) * (dt / 500); // ~0.121 m/s
+        const vmag = Math.hypot(
+            polygon.linearVelocity.x,
+            polygon.linearVelocity.y
+        );
+        expect(vmag).toBeGreaterThan(vPinned * 5);
+    });
+
     test('Polygon getMinMaxProjection', () => {
         const vertices = [
             { x: 10, y: 0 },


### PR DESCRIPTION
## Summary

- `BaseRigidBody.step` had a static-friction-like velocity clamp (`|v| < |F*dt/m|` → zero velocity) that ran **unconditionally**, even with `frictionEnabled=false`.
- With a ramping force (e.g. first-order lag on a controller input), this creates a stable fixed point at `|v| = |F*dt/m|` where the body gets pinned and cannot accelerate.
- Surfaced in the horse-racing sim as certain BT archetypes "stalling" for 10+ seconds at ~0.12 m/s during the initial input ramp-up.
- Fix: move the clamp inside the `frictionEnabled` branch alongside the existing static/kinetic friction logic.

## Test plan

- [x] `bunx nx test dynamics` — 120/120 passing
- [x] New regression test `Polygon accelerates past |F*dt/m| when friction is disabled` — verified to fail on `main` and pass with the fix
- [x] Changeset added (`@ue-too/dynamics`: patch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)