### PR TITLE
chore(0.17.0): backport static-friction fix and KMTEventParser refactor

### DIFF
--- a/.changeset/fix-static-friction-reset.md
+++ b/.changeset/fix-static-friction-reset.md
@@ -1,0 +1,7 @@
+---
+'@ue-too/dynamics': patch
+---
+
+fix(dynamics): only apply static-friction-like velocity clamp when friction is enabled
+
+The check `|v| < |F*dt/m|` that zeroes velocity in `BaseRigidBody.step` previously ran unconditionally. When `frictionEnabled=false` (the default) and a body has a ramping force applied (e.g. through a first-order lag on a controller input), this creates a stable fixed point at `|v| = |F*dt/m|` where the body gets pinned instead of accelerating. The clamp now lives inside the `frictionEnabled` branch alongside the other friction logic.

--- a/packages/board/src/input-interpretation/raw-input-parser/vanilla-kmt-event-parser.ts
+++ b/packages/board/src/input-interpretation/raw-input-parser/vanilla-kmt-event-parser.ts
@@ -2,7 +2,6 @@ import type { EventArgs, EventResult } from '@ue-too/being';
 
 import type {
     KmtInputEventMapping,
-    KmtInputStateMachine,
 } from '../../input-interpretation/input-state-machine';
 import type { InputOrchestrator } from '../input-orchestrator';
 
@@ -170,7 +169,7 @@ export class VanillaKMTEventParser implements KMTEventParser {
     private _orchestrator: InputOrchestrator;
     private _keyfirstPressed: Map<string, boolean>;
     private _abortController: AbortController;
-    private _canvas?: HTMLCanvasElement | SVGSVGElement;
+    protected _canvas?: HTMLCanvasElement | SVGSVGElement;
 
     constructor(
         kmtInputStateMachine: StateMachine,
@@ -247,7 +246,7 @@ export class VanillaKMTEventParser implements KMTEventParser {
         this.keyupHandler = this.keyupHandler.bind(this);
     }
 
-    private processEvent<K extends keyof KmtInputEventMapping>(
+    protected processEvent<K extends keyof KmtInputEventMapping>(
         ...args: EventArgs<KmtInputEventMapping, K>
     ): void {
         const result = this._stateMachine.happens(...args);

--- a/packages/dynamics/src/rigidbody.ts
+++ b/packages/dynamics/src/rigidbody.ts
@@ -233,17 +233,23 @@ export abstract class BaseRigidBody implements RigidBody {
             this._angularVelocity += angularDamping;
         }
         this._orientationAngle += this._angularVelocity * deltaTime;
+        // Static-friction-like clamp: if the pending impulse would overshoot
+        // the current velocity (i.e. the body would "reverse" in one step),
+        // zero the velocity so it doesn't. Only meaningful when friction is
+        // enabled — without friction this creates a stable fixed point at
+        // |v| = |F*dt/m| where the body gets pinned each step.
         if (
+            this.frictionEnabled &&
             PointCal.magnitude({
                 x: this._linearVelocity.x,
                 y: this._linearVelocity.y,
             }) <
-            PointCal.magnitude(
-                PointCal.divideVectorByScalar(
-                    PointCal.multiplyVectorByScalar(this.force, deltaTime),
-                    this.mass
+                PointCal.magnitude(
+                    PointCal.divideVectorByScalar(
+                        PointCal.multiplyVectorByScalar(this.force, deltaTime),
+                        this.mass
+                    )
                 )
-            )
         ) {
             if (this._linearVelocity.z != undefined) {
                 this._linearVelocity = {

--- a/packages/dynamics/test/rigidbody.test.ts
+++ b/packages/dynamics/test/rigidbody.test.ts
@@ -128,6 +128,48 @@ describe('Polygon Rigidbody', () => {
         expect(polygon.center.y).toBeGreaterThan(0);
     });
 
+    test('Polygon accelerates past |F*dt/m| when friction is disabled', () => {
+        // Regression: prior to the fix, the static-friction-like clamp ran
+        // even with frictionEnabled=false. If force ramps up (e.g. through
+        // a first-order lag on a controller input), the check |v| < |F*dt/m|
+        // fires every step and pins velocity at ~|F_target*dt/m| indefinitely
+        // — the body "stalls" instead of accelerating.
+        const vertices = [
+            { x: 1, y: 1 },
+            { x: -1, y: 1 },
+            { x: -1, y: -1 },
+            { x: 1, y: -1 },
+        ];
+        const polygon = new Polygon(
+            { x: 0, y: 0 },
+            vertices,
+            0,
+            500,
+            false,
+            false
+        );
+        const dt = 1 / 240;
+        const tau = 0.15;
+        const Fx_target = 14480;
+        const Fy_target = -486;
+        let Fx = 0;
+        let Fy = 0;
+
+        for (let i = 0; i < 500; i++) {
+            Fx += ((Fx_target - Fx) * dt) / tau;
+            Fy += ((Fy_target - Fy) * dt) / tau;
+            polygon.applyForce({ x: Fx, y: Fy });
+            polygon.step(dt);
+        }
+
+        const vPinned = Math.hypot(Fx_target, Fy_target) * (dt / 500); // ~0.121 m/s
+        const vmag = Math.hypot(
+            polygon.linearVelocity.x,
+            polygon.linearVelocity.y
+        );
+        expect(vmag).toBeGreaterThan(vPinned * 5);
+    });
+
     test('Polygon getMinMaxProjection', () => {
         const vertices = [
             { x: 10, y: 0 },


### PR DESCRIPTION
## Summary
Backports two patches from `main` onto `version/0.17.0` for a 0.17.x patch release.

- bb67911f — fix(dynamics): gate static-friction velocity clamp on `frictionEnabled` (#413)
- c2fa452f — refactor(board): allow extending `VanillaKMTEventParser` (#414)

## Test plan
- [ ] CI green on the branch
- [ ] Verify changeset for static-friction fix is picked up by the release workflow