### PR TITLE
feat(board): add input-mode toggle API to Board (backport to v0.17.0)

### DIFF
--- a/docs/superpowers/specs/2026-06-01-input-mode-toggle-design.md
+++ b/docs/superpowers/specs/2026-06-01-input-mode-toggle-design.md
@@ -1,0 +1,72 @@
+# Input-Mode Toggle API on `Board`
+
+**Date:** 2026-06-01
+**Package:** `board`
+**Branch:** `feat/switch-between-kmt-trackpad`
+
+## Problem
+
+The `Board` class can lock its input modality via `setInputMode('kmt' | 'trackpad')`
+(`packages/board/src/boardify/index.ts:932`), but there is no convenient way to:
+
+- read the current mode (no getter), so UI cannot reflect or drive a toggle button;
+- flip between keyboard-mouse and trackpad without the caller tracking current state;
+- return to auto-detection after a manual lock (the tracker supports it via the
+  unexposed `enableInputModeDetection()`).
+
+The mode is tri-state: `'kmt'` (keyboard-mouse), `'trackpad'`, and `'TBD'`
+(auto-detecting, not yet committed).
+
+## Goal
+
+Add a small, convenient public API on `Board` for toggling and inspecting input
+mode, plus a path back to auto-detection. Binary toggle with a separate auto
+method — not a 3-way cycle.
+
+## Design
+
+All changes are confined to the `Board` class in
+`packages/board/src/boardify/index.ts`. No state-machine or interface changes:
+`_observableInputTracker` is typed as the concrete `ObservableInputTracker`
+(`index.ts:213`), which already exposes `mode`, `setMode`, and
+`enableInputModeDetection`.
+
+### 1. `get inputMode(): 'kmt' | 'trackpad' | 'TBD'`
+
+Returns `this._observableInputTracker.mode`. Lets UI reflect current state.
+`'TBD'` means auto-detection is active and has not committed to a mode.
+
+### 2. `toggleInputMode(): void`
+
+Flips between the two concrete modes and locks it (via the existing `setMode`,
+which sets `_deciding = false`, disabling auto-detection):
+
+- current `'kmt'` → `setMode('trackpad')`
+- current `'trackpad'` or `'TBD'` → `setMode('kmt')`
+
+The `'TBD' → 'kmt'` choice is deliberate: in the scroll handler, `'TBD'` already
+behaves like trackpad (`mode === 'kmt' ? scrollZoom : scrollPan`), so the natural
+"other" state to toggle into is `'kmt'`.
+
+### 3. `enableAutoInputMode(): void`
+
+Calls `this._observableInputTracker.enableInputModeDetection()` (already
+implemented at `kmt-input-context.ts:717`: resets `_deciding = true` and score to
+0). Returns the board to auto-detection after a manual lock.
+
+## Out of scope
+
+- Wiring up the commented-out auto-detect threshold
+  (`kmt-input-context.ts:733,744`). Auto mode stays as-is: it tracks score but
+  never commits on its own. That is separate detection behavior and not requested.
+- Any change to `VanillaKMTEventParser` / `VanillaTouchEventParser`.
+
+## Testing
+
+Unit tests on `Board`:
+
+- `inputMode` reflects `setInputMode('kmt')` and `setInputMode('trackpad')`.
+- `toggleInputMode` from `'kmt'` → `'trackpad'`.
+- `toggleInputMode` from `'trackpad'` → `'kmt'`.
+- `toggleInputMode` from `'TBD'` (initial state) → `'kmt'`.
+- `enableAutoInputMode` returns `inputMode` to `'TBD'` after a manual lock.

--- a/packages/board/src/boardify/index.ts
+++ b/packages/board/src/boardify/index.ts
@@ -933,6 +933,41 @@ export default class Board {
         this._observableInputTracker.setMode(mode);
     }
 
+    /**
+     * The current input modality.
+     *
+     * @returns `'kmt'` (keyboard-mouse), `'trackpad'`, or `'TBD'` when
+     * auto-detection is active and has not yet committed to a mode.
+     */
+    get inputMode(): 'kmt' | 'trackpad' | 'TBD' {
+        return this._observableInputTracker.mode;
+    }
+
+    /**
+     * Flips the input mode between keyboard-mouse and trackpad and locks it,
+     * disabling auto-detection.
+     *
+     * From `'kmt'` this switches to `'trackpad'`; from `'trackpad'` or `'TBD'`
+     * it switches to `'kmt'`. (`'TBD'` already behaves like trackpad, so the
+     * natural "other" mode to toggle into is `'kmt'`.)
+     *
+     * @see {@link setInputMode} to set a specific mode, and
+     * {@link enableAutoInputMode} to return to auto-detection.
+     */
+    toggleInputMode(): void {
+        this.setInputMode(this.inputMode === 'kmt' ? 'trackpad' : 'kmt');
+    }
+
+    /**
+     * Returns the board to auto-detection of input modality after a manual lock
+     * set via {@link setInputMode} or {@link toggleInputMode}.
+     *
+     * The mode reverts to `'TBD'` until auto-detection commits to a mode.
+     */
+    enableAutoInputMode(): void {
+        this._observableInputTracker.enableInputModeDetection();
+    }
+
     onCanvasDimensionChange(callback: (dimensions: CanvasDimensions) => void) {
         return this._canvasProxy.subscribe(callback);
     }

--- a/packages/board/src/input-interpretation/input-state-machine/kmt-input-context.ts
+++ b/packages/board/src/input-interpretation/input-state-machine/kmt-input-context.ts
@@ -331,7 +331,6 @@ export class CanvasProxy implements Canvas, Observable<[CanvasDimensions]> {
         this._canvas = canvas;
         this._canvasPositionDimensionPublisher.attach(canvas);
     }
-
 }
 
 export class SvgProxy implements Canvas, Observable<[CanvasDimensions]> {
@@ -471,7 +470,6 @@ export class SvgProxy implements Canvas, Observable<[CanvasDimensions]> {
             position: this._position,
         });
     }
-
 }
 
 /**
@@ -717,6 +715,7 @@ export class ObservableInputTracker implements KmtInputContext {
     enableInputModeDetection(): void {
         this._deciding = true;
         this._kmtTrackpadTrackScore = 0;
+        this._mode = 'TBD';
     }
 
     get kmtTrackpadTrackScore(): number {

--- a/packages/board/test/boardify/input-mode.test.ts
+++ b/packages/board/test/boardify/input-mode.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import Board from '../../src/boardify';
+
+// Board's CanvasProxy constructs ResizeObserver/IntersectionObserver/MutationObserver
+// eagerly. With no canvas they never observe anything, so no-op stubs suffice to let
+// Board instantiate in a DOM-free test runner. The input-mode logic under test is real.
+class NoopObserver {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+    takeRecords(): unknown[] {
+        return [];
+    }
+}
+globalThis.ResizeObserver ??= NoopObserver as unknown as typeof ResizeObserver;
+globalThis.IntersectionObserver ??=
+    NoopObserver as unknown as typeof IntersectionObserver;
+globalThis.MutationObserver ??=
+    NoopObserver as unknown as typeof MutationObserver;
+
+describe('Board input mode', () => {
+    it('defaults to TBD (auto-detection)', () => {
+        const board = new Board();
+        expect(board.inputMode).toBe('TBD');
+    });
+
+    it('inputMode reflects setInputMode("kmt")', () => {
+        const board = new Board();
+        board.setInputMode('kmt');
+        expect(board.inputMode).toBe('kmt');
+    });
+
+    it('inputMode reflects setInputMode("trackpad")', () => {
+        const board = new Board();
+        board.setInputMode('trackpad');
+        expect(board.inputMode).toBe('trackpad');
+    });
+
+    it('toggleInputMode flips kmt -> trackpad', () => {
+        const board = new Board();
+        board.setInputMode('kmt');
+        board.toggleInputMode();
+        expect(board.inputMode).toBe('trackpad');
+    });
+
+    it('toggleInputMode flips trackpad -> kmt', () => {
+        const board = new Board();
+        board.setInputMode('trackpad');
+        board.toggleInputMode();
+        expect(board.inputMode).toBe('kmt');
+    });
+
+    it('toggleInputMode from TBD lands on kmt', () => {
+        const board = new Board();
+        expect(board.inputMode).toBe('TBD');
+        board.toggleInputMode();
+        expect(board.inputMode).toBe('kmt');
+    });
+
+    it('enableAutoInputMode returns to TBD after a manual lock', () => {
+        const board = new Board();
+        board.setInputMode('kmt');
+        expect(board.inputMode).toBe('kmt');
+        board.enableAutoInputMode();
+        expect(board.inputMode).toBe('TBD');
+    });
+});


### PR DESCRIPTION
Backport of #419 (merged to `main`) to `version/0.17.0`.

Cherry-picked the squash-merge commit `a11bb780` cleanly (no conflicts).

## Summary

Adds a small public API on `Board` for inspecting and switching input modality, building on the existing `setInputMode('kmt' | 'trackpad')`:

- `get inputMode(): 'kmt' | 'trackpad' | 'TBD'` — read the current modality (`'TBD'` = auto-detecting, uncommitted)
- `toggleInputMode(): void` — flips kmt↔trackpad and locks it; from `'TBD'` it lands on `'kmt'`
- `enableAutoInputMode(): void` — returns to auto-detection after a manual lock

Supporting change: `enableInputModeDetection()` now also resets `_mode` to `'TBD'`.

## Testing

- 7 new tests in `packages/board/test/boardify/input-mode.test.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)