### PR TITLE
chore: update GitHub org references from ue-too to kinnet-studio

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,7 +191,7 @@ jobs:
               uses: ./.github/actions/open-doc-pr
               with:
                   doc-version: ${{ steps.get-version.outputs.version }}
-                  target-repo: 'ue-too/documentation'
+                  target-repo: 'kinnet-studio/documentation'
                   target-branch: 'main'
                   pr-branch: 'update-docs-v${{ steps.get-version.outputs.version }}'
                   pr-title: 'Update documentation for v${{ steps.get-version.outputs.version }}'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### 🩹 Fixes
 
-- **board:** explicit package exports and root imports for bundlers ([#379](https://github.com/ue-too/ue-too/pull/379))
+- **board:** explicit package exports and root imports for bundlers ([#379](https://github.com/kinnet-studio/ue-too/pull/379))
 
 ### ❤️ Thank You
 
@@ -12,7 +12,7 @@
 
 ### 🩹 Fixes
 
-- support nested subpath exports in package.json ([#377](https://github.com/ue-too/ue-too/pull/377))
+- support nested subpath exports in package.json ([#377](https://github.com/kinnet-studio/ue-too/pull/377))
 
 ### ❤️ Thank You
 
@@ -27,7 +27,7 @@ This was a version bump only, there were no code changes.
 
 ### 🩹 Fixes
 
-- add temp file to gitignore ([11f19d8](https://github.com/ue-too/ue-too/commit/11f19d8))
+- add temp file to gitignore ([11f19d8](https://github.com/kinnet-studio/ue-too/commit/11f19d8))
 
 ### ❤️ Thank You
 
@@ -37,7 +37,7 @@ This was a version bump only, there were no code changes.
 
 ### 🩹 Fixes
 
-- no longer release individual package's bundled javascript ([#318](https://github.com/ue-too/ue-too/pull/318))
+- no longer release individual package's bundled javascript ([#318](https://github.com/kinnet-studio/ue-too/pull/318))
 
 ### ❤️ Thank You
 
@@ -47,23 +47,23 @@ This was a version bump only, there were no code changes.
 
 ### 🚀 Features
 
-- add vue integration ([#303](https://github.com/ue-too/ue-too/pull/303))
-- auto detect input mode ([#306](https://github.com/ue-too/ue-too/pull/306))
-- third party framework integration ([#310](https://github.com/ue-too/ue-too/pull/310))
-- board component swappable ([#311](https://github.com/ue-too/ue-too/pull/311))
-- add hierarchical state machine poc ([#312](https://github.com/ue-too/ue-too/pull/312))
-- ecs serializable ([#314](https://github.com/ue-too/ue-too/pull/314))
-- board game engine ([#315](https://github.com/ue-too/ue-too/pull/315))
+- add vue integration ([#303](https://github.com/kinnet-studio/ue-too/pull/303))
+- auto detect input mode ([#306](https://github.com/kinnet-studio/ue-too/pull/306))
+- third party framework integration ([#310](https://github.com/kinnet-studio/ue-too/pull/310))
+- board component swappable ([#311](https://github.com/kinnet-studio/ue-too/pull/311))
+- add hierarchical state machine poc ([#312](https://github.com/kinnet-studio/ue-too/pull/312))
+- ecs serializable ([#314](https://github.com/kinnet-studio/ue-too/pull/314))
+- board game engine ([#315](https://github.com/kinnet-studio/ue-too/pull/315))
 
 ### 🩹 Fixes
 
-- documentation ([2414e43](https://github.com/ue-too/ue-too/commit/2414e43))
-- update when attribute changes ([#304](https://github.com/ue-too/ue-too/pull/304))
-- vue library bundle ([#309](https://github.com/ue-too/ue-too/pull/309))
-- board-vue dependency update ([3ed998a](https://github.com/ue-too/ue-too/commit/3ed998a))
-- state machine ([#313](https://github.com/ue-too/ue-too/pull/313))
-- update gitignore ([9c8d424](https://github.com/ue-too/ue-too/commit/9c8d424))
-- build workflow ([#316](https://github.com/ue-too/ue-too/pull/316))
+- documentation ([2414e43](https://github.com/kinnet-studio/ue-too/commit/2414e43))
+- update when attribute changes ([#304](https://github.com/kinnet-studio/ue-too/pull/304))
+- vue library bundle ([#309](https://github.com/kinnet-studio/ue-too/pull/309))
+- board-vue dependency update ([3ed998a](https://github.com/kinnet-studio/ue-too/commit/3ed998a))
+- state machine ([#313](https://github.com/kinnet-studio/ue-too/pull/313))
+- update gitignore ([9c8d424](https://github.com/kinnet-studio/ue-too/commit/9c8d424))
+- build workflow ([#316](https://github.com/kinnet-studio/ue-too/pull/316))
 
 ### ❤️ Thank You
 
@@ -81,27 +81,27 @@ This was a version bump only, there were no code changes.
 
 ### 🚀 Features
 
-- copy doc media to deploy to github pages ([#289](https://github.com/ue-too/ue-too/pull/289))
-- typedoc flow ([#292](https://github.com/ue-too/ue-too/pull/292))
-- documentation deployment upon new release ([#293](https://github.com/ue-too/ue-too/pull/293))
-- subdirectory import ([#294](https://github.com/ue-too/ue-too/pull/294))
-- add a new package for board react adapter ([#297](https://github.com/ue-too/ue-too/pull/297))
-- svg support ([#299](https://github.com/ue-too/ue-too/pull/299))
+- copy doc media to deploy to github pages ([#289](https://github.com/kinnet-studio/ue-too/pull/289))
+- typedoc flow ([#292](https://github.com/kinnet-studio/ue-too/pull/292))
+- documentation deployment upon new release ([#293](https://github.com/kinnet-studio/ue-too/pull/293))
+- subdirectory import ([#294](https://github.com/kinnet-studio/ue-too/pull/294))
+- add a new package for board react adapter ([#297](https://github.com/kinnet-studio/ue-too/pull/297))
+- svg support ([#299](https://github.com/kinnet-studio/ue-too/pull/299))
 
 ### 🩹 Fixes
 
-- add npmignore in move package step ([#286](https://github.com/ue-too/ue-too/pull/286))
-- npmignore path ([#287](https://github.com/ue-too/ue-too/pull/287))
-- add tsbuildinfo to git ignore ([f96472c](https://github.com/ue-too/ue-too/commit/f96472c))
-- update output directory for built documentation media ([1e82780](https://github.com/ue-too/ue-too/commit/1e82780))
-- branch name format in deploy workflow ([2ad0149](https://github.com/ue-too/ue-too/commit/2ad0149))
-- deploy static images ([#290](https://github.com/ue-too/ue-too/pull/290))
-- package without subdirectory import ([#295](https://github.com/ue-too/ue-too/pull/295))
-- deploy documentation branch rule ([229e93c](https://github.com/ue-too/ue-too/commit/229e93c))
-- do not differentiate version on documentation ([5b62d18](https://github.com/ue-too/ue-too/commit/5b62d18))
-- framework integration examples ([#298](https://github.com/ue-too/ue-too/pull/298))
-- package badge link ([9cfe140](https://github.com/ue-too/ue-too/commit/9cfe140))
-- package badge link ([3373960](https://github.com/ue-too/ue-too/commit/3373960))
+- add npmignore in move package step ([#286](https://github.com/kinnet-studio/ue-too/pull/286))
+- npmignore path ([#287](https://github.com/kinnet-studio/ue-too/pull/287))
+- add tsbuildinfo to git ignore ([f96472c](https://github.com/kinnet-studio/ue-too/commit/f96472c))
+- update output directory for built documentation media ([1e82780](https://github.com/kinnet-studio/ue-too/commit/1e82780))
+- branch name format in deploy workflow ([2ad0149](https://github.com/kinnet-studio/ue-too/commit/2ad0149))
+- deploy static images ([#290](https://github.com/kinnet-studio/ue-too/pull/290))
+- package without subdirectory import ([#295](https://github.com/kinnet-studio/ue-too/pull/295))
+- deploy documentation branch rule ([229e93c](https://github.com/kinnet-studio/ue-too/commit/229e93c))
+- do not differentiate version on documentation ([5b62d18](https://github.com/kinnet-studio/ue-too/commit/5b62d18))
+- framework integration examples ([#298](https://github.com/kinnet-studio/ue-too/pull/298))
+- package badge link ([9cfe140](https://github.com/kinnet-studio/ue-too/commit/9cfe140))
+- package badge link ([3373960](https://github.com/kinnet-studio/ue-too/commit/3373960))
 
 ### ❤️ Thank You
 
@@ -111,7 +111,7 @@ This was a version bump only, there were no code changes.
 
 ### 🩹 Fixes
 
-- start with 0.8.1 ([45b9c95](https://github.com/ue-too/ue-too/commit/45b9c95))
+- start with 0.8.1 ([45b9c95](https://github.com/kinnet-studio/ue-too/commit/45b9c95))
 
 ### ❤️ Thank You
 
@@ -121,7 +121,7 @@ This was a version bump only, there were no code changes.
 
 ### 🩹 Fixes
 
-- manually bump version ([a33588e](https://github.com/ue-too/ue-too/commit/a33588e))
+- manually bump version ([a33588e](https://github.com/kinnet-studio/ue-too/commit/a33588e))
 
 ### ❤️ Thank You
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,13 +56,13 @@ packages/
     board-game-engine/
 
 apps/
-    examples/       — Interactive demos (https://ue-too.github.io/ue-too/)
+    examples/       — Interactive demos (https://kinnet-studio.github.io/ue-too/)
     blast/          — Tabletop game prototype maker (WIP)
     board-react/    — React example app
     board-vue/      — Vue example app
 ```
 
-Graduated apps (now in their own repos): banana (https://github.com/ue-too/banana), knit, horse-racing.
+Graduated apps (now in their own repos): banana (https://github.com/kinnet-studio/banana), knit, horse-racing.
 
 ## Standards
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 <p align="center">
   <a href="#overview">Overview</a> •
-  <a href="https://ue-too.github.io/documentation/">Documentation</a> •
+  <a href="https://kinnet-studio.github.io/documentation/">Documentation</a> •
   <a href="#packages">Packages</a> •
   <a href="#examples">Examples</a> •
   <a href="#development">Development</a>
@@ -42,29 +42,29 @@ npm install @ue-too/board @ue-too/math @ue-too/animate
 
 ## Examples
 
-A live website containing the examples is available [here](https://ue-too.github.io/ue-too/).
+A live website containing the examples is available [here](https://kinnet-studio.github.io/ue-too/).
 
 This monorepo includes comprehensive examples demonstrating various packages and integrations:
 
 ### Core Examples
 
-- [**Base Example**](https://ue-too.github.io/ue-too/base/) - Basic canvas viewport with pan, zoom, and rotate
-- [**Attach / Detach Example**](https://ue-too.github.io/ue-too/attach-detach/) - Dynamically attach and detach a canvas from the board
-- [**Navigation Example**](https://ue-too.github.io/ue-too/navigation/) - Keyboard-driven camera panning via `panByViewPort()`
-- [**Ruler Example**](https://ue-too.github.io/ue-too/ruler/) - Measurement ruler overlay that updates with pan and zoom
-- [**Camera Animation**](https://ue-too.github.io/ue-too/camera-animation/) - Smooth animated camera transitions on click
-- [**Image Example**](https://ue-too.github.io/ue-too/image-example/) - Upload and display an image on the pannable canvas
-- [**SVG Example**](https://ue-too.github.io/ue-too/svg/) - Board camera system applied to SVG elements
+- [**Base Example**](https://kinnet-studio.github.io/ue-too/base/) - Basic canvas viewport with pan, zoom, and rotate
+- [**Attach / Detach Example**](https://kinnet-studio.github.io/ue-too/attach-detach/) - Dynamically attach and detach a canvas from the board
+- [**Navigation Example**](https://kinnet-studio.github.io/ue-too/navigation/) - Keyboard-driven camera panning via `panByViewPort()`
+- [**Ruler Example**](https://kinnet-studio.github.io/ue-too/ruler/) - Measurement ruler overlay that updates with pan and zoom
+- [**Camera Animation**](https://kinnet-studio.github.io/ue-too/camera-animation/) - Smooth animated camera transitions on click
+- [**Image Example**](https://kinnet-studio.github.io/ue-too/image-example/) - Upload and display an image on the pannable canvas
+- [**SVG Example**](https://kinnet-studio.github.io/ue-too/svg/) - Board camera system applied to SVG elements
 
 ### Framework Integrations
 
-- [**PixiJS Integration**](https://ue-too.github.io/ue-too/pixi-integration/) - Full-screen PixiJS canvas with board camera controls
-- [**Konva Integration**](https://ue-too.github.io/ue-too/konva-integration/) - Konva.js stage synchronized with board camera transforms
-- [**Fabric Integration**](https://ue-too.github.io/ue-too/fabric-integration/) - Fabric.js with toggleable movement/selection modes
+- [**PixiJS Integration**](https://kinnet-studio.github.io/ue-too/pixi-integration/) - Full-screen PixiJS canvas with board camera controls
+- [**Konva Integration**](https://kinnet-studio.github.io/ue-too/konva-integration/) - Konva.js stage synchronized with board camera transforms
+- [**Fabric Integration**](https://kinnet-studio.github.io/ue-too/fabric-integration/) - Fabric.js with toggleable movement/selection modes
 
 ### Advanced Features
 
-- [**Physics Example**](https://ue-too.github.io/ue-too/physics/) - Four-bar linkage with rigid body physics and constraints
+- [**Physics Example**](https://kinnet-studio.github.io/ue-too/physics/) - Four-bar linkage with rigid body physics and constraints
 
 ### Running Examples
 
@@ -72,7 +72,7 @@ To run the examples locally:
 
 ```bash
 # Clone the repository
-git clone https://github.com/ue-too/ue-too.git
+git clone https://github.com/kinnet-studio/ue-too.git
 cd ue-too
 
 # Install dependencies
@@ -94,7 +94,7 @@ Then, visit `http://localhost:5173` to explore all examples.
 
 ```bash
 # Clone and install
-git clone https://github.com/ue-too/ue-too.git
+git clone https://github.com/kinnet-studio/ue-too.git
 cd ue-too
 bun install
 
@@ -139,7 +139,7 @@ ue-too/
 
 Some apps that started in this monorepo have moved to their own repositories once they stabilized:
 
-- **banana** (railway simulator) → [github.com/ue-too/banana](https://github.com/ue-too/banana)
+- **banana** (railway simulator) → [github.com/kinnet-studio/banana](https://github.com/kinnet-studio/banana)
 - **knit** (knitting pattern editor) → moved to a private repository
 - **horse-racing** (RL environment) → moved to a private repository
 
@@ -149,6 +149,6 @@ MIT License - see [LICENSE.txt](LICENSE.txt) for details.
 
 ## Support
 
-- [GitHub Issues](https://github.com/ue-too/ue-too/issues) - Bug reports and feature requests
+- [GitHub Issues](https://github.com/kinnet-studio/ue-too/issues) - Bug reports and feature requests
 
 > Currently not accepting contributions yet. If there's any features you want to see, please let me know by creating an issue.

--- a/apps/blast/src/board-game-engine/schema/json-schema/game-definition.schema.json
+++ b/apps/blast/src/board-game-engine/schema/json-schema/game-definition.schema.json
@@ -479,7 +479,7 @@
             "type": "string"
         }
     },
-    "$id": "https://ue-too.github.io/board-game-engine/game-definition.schema.json",
+    "$id": "https://kinnet-studio.github.io/board-game-engine/game-definition.schema.json",
     "$schema": "https://json-schema.org/draft/2020-12/schema",
     "description": "Schema for defining board games declaratively in JSON format",
     "properties": {

--- a/package.json
+++ b/package.json
@@ -28,14 +28,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ue-too/ue-too.git"
+    "url": "git+https://github.com/kinnet-studio/ue-too.git"
   },
   "author": "niuee",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ue-too/ue-too/issues"
+    "url": "https://github.com/kinnet-studio/ue-too/issues"
   },
-  "homepage": "https://github.com/ue-too/ue-too#readme",
+  "homepage": "https://github.com/kinnet-studio/ue-too#readme",
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "@nx/devkit": "22.2.0",

--- a/packages/animate/README.md
+++ b/packages/animate/README.md
@@ -3,7 +3,7 @@
 Keyframe-based animation library for TypeScript canvas applications.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/animate.svg)](https://www.npmjs.com/package/@ue-too/animate)
-[![license](https://img.shields.io/npm/l/@ue-too/animate.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/animate.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -546,4 +546,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/animate/package.json
+++ b/packages/animate/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/being/README.md
+++ b/packages/being/README.md
@@ -1,7 +1,7 @@
 # being
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/being.svg)](https://www.npmjs.com/package/@ue-too/being)
-[![license](https://img.shields.io/npm/l/@ue-too/being.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/being.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 This is a library that helps with building finite state machines.
 

--- a/packages/being/package.json
+++ b/packages/being/package.json
@@ -4,9 +4,9 @@
     "version": "0.17.1",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-fabric-integration/README.md
+++ b/packages/board-fabric-integration/README.md
@@ -3,7 +3,7 @@
 Description of the board-fabric-integration package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-fabric-integration.svg)](https://www.npmjs.com/package/@ue-too/board-fabric-integration)
-[![license](https://img.shields.io/npm/l/@ue-too/board-fabric-integration.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-fabric-integration.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -37,4 +37,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-fabric-integration/package.json
+++ b/packages/board-fabric-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-game-engine/README.md
+++ b/packages/board-game-engine/README.md
@@ -3,7 +3,7 @@
 Description of the board-game-engine package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-game-engine.svg)](https://www.npmjs.com/package/@ue-too/board-game-engine)
-[![license](https://img.shields.io/npm/l/@ue-too/board-game-engine.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-game-engine.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -37,4 +37,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-game-engine/package.json
+++ b/packages/board-game-engine/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-konva-integration/README.md
+++ b/packages/board-konva-integration/README.md
@@ -3,7 +3,7 @@
 Description of the board-konva-integration package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-konva-integration.svg)](https://www.npmjs.com/package/@ue-too/board-konva-integration)
-[![license](https://img.shields.io/npm/l/@ue-too/board-konva-integration.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-konva-integration.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -37,4 +37,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-konva-integration/package.json
+++ b/packages/board-konva-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-pixi-integration/README.md
+++ b/packages/board-pixi-integration/README.md
@@ -3,7 +3,7 @@
 Description of the board-integration package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-integration.svg)](https://www.npmjs.com/package/@ue-too/board-integration)
-[![license](https://img.shields.io/npm/l/@ue-too/board-integration.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-integration.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -37,4 +37,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-pixi-integration/package.json
+++ b/packages/board-pixi-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest"
     },

--- a/packages/board-pixi-react-integration/README.md
+++ b/packages/board-pixi-react-integration/README.md
@@ -3,7 +3,7 @@
 Description of the board-pixi-react-integration package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-pixi-react-integration.svg)](https://www.npmjs.com/package/@ue-too/board-pixi-react-integration)
-[![license](https://img.shields.io/npm/l/@ue-too/board-pixi-react-integration.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-pixi-react-integration.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -37,4 +37,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-pixi-react-integration/package.json
+++ b/packages/board-pixi-react-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest"
     },

--- a/packages/board-react-adapter/README.md
+++ b/packages/board-react-adapter/README.md
@@ -3,7 +3,7 @@
 React adapter for the @ue-too/board infinite canvas library.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-react-adapter.svg)](https://www.npmjs.com/package/@ue-too/board-react-adapter)
-[![license](https://img.shields.io/npm/l/@ue-too/board-react-adapter.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-react-adapter.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -525,4 +525,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-react-adapter/package.json
+++ b/packages/board-react-adapter/package.json
@@ -4,9 +4,9 @@
     "version": "0.17.1",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-vue-adapter/README.md
+++ b/packages/board-vue-adapter/README.md
@@ -3,7 +3,7 @@
 Description of the board-vue-adapter package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board-vue-adapter.svg)](https://www.npmjs.com/package/@ue-too/board-vue-adapter)
-[![license](https://img.shields.io/npm/l/@ue-too/board-vue-adapter.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/board-vue-adapter.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -37,4 +37,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/board-vue-adapter/package.json
+++ b/packages/board-vue-adapter/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build": "vite build",

--- a/packages/board/README.md
+++ b/packages/board/README.md
@@ -8,8 +8,8 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/board.svg?style=for-the-badge)](https://www.npmjs.com/package/@ue-too/board)
-[![ci tests](https://img.shields.io/github/actions/workflow/status/ue-too/ue-too/ci-test.yml?label=test&style=for-the-badge)](https://github.com/ue-too/ue-too/actions/workflows/ci-test.yml)
-[![License](https://img.shields.io/github/license/ue-too/ue-too?style=for-the-badge)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![ci tests](https://img.shields.io/github/actions/workflow/status/ue-too/ue-too/ci-test.yml?label=test&style=for-the-badge)](https://github.com/kinnet-studio/ue-too/actions/workflows/ci-test.yml)
+[![License](https://img.shields.io/github/license/ue-too/ue-too?style=for-the-badge)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 [![bundle size](https://img.shields.io/bundlephobia/minzip/@ue-too/board?color=success&label=gzipped%20bundle%20size&style=for-the-badge)](https://bundlephobia.com/package/@ue-too/board)
 
 </div>
@@ -17,7 +17,7 @@
 <p align="center">
   <a href="#examples">Examples</a> •
   <a href="#quick-coding-demo">Quick Coding Demo</a> •
-  <a href="https://ue-too.github.io/documentation/board/">Documentation</a> •
+  <a href="https://kinnet-studio.github.io/documentation/board/">Documentation</a> •
   <a href="#installation-and-usage">Install</a> •
   <a href="#key-features">Key Features</a> •
   <a href="#quick-start-html-canvas">Quick Start</a> •
@@ -25,7 +25,7 @@
   <a href="#under-the-hood">Basic API Overview</a>
 </p>
 
-![small-demo](https://ue-too.github.io/ue-too/assets/doc-media/small-demo-with-cursor.gif)
+![small-demo](https://kinnet-studio.github.io/ue-too/assets/doc-media/small-demo-with-cursor.gif)
 
 <p align="center">
     A demonstration of uē-tôo's core functionality.
@@ -50,30 +50,30 @@
 
 ## Examples
 
-A live website containing the examples is available [here](https://ue-too.github.io/ue-too/).
+A live website containing the examples is available [here](https://kinnet-studio.github.io/ue-too/).
 
 This monorepo includes comprehensive examples demonstrating various packages and integrations:
 
 ### Core Examples
 
-- [**Base Example**](https://ue-too.github.io/ue-too/base/) - Basic canvas viewport with pan, zoom, and rotate
-- [**Attach / Detach Example**](https://ue-too.github.io/ue-too/attach-detach/) - Dynamically attach and detach a canvas from the board
-- [**Navigation Example**](https://ue-too.github.io/ue-too/navigation/) - Keyboard-driven camera panning via `panByViewPort()`
-- [**Ruler Example**](https://ue-too.github.io/ue-too/ruler/) - Measurement ruler overlay that updates with pan and zoom
-- [**Camera Animation**](https://ue-too.github.io/ue-too/camera-animation/) - Smooth animated camera transitions on click
-- [**Image Example**](https://ue-too.github.io/ue-too/image-example/) - Upload and display an image on the pannable canvas
-- [**SVG Example**](https://ue-too.github.io/ue-too/svg/) - Board camera system applied to SVG elements
+- [**Base Example**](https://kinnet-studio.github.io/ue-too/base/) - Basic canvas viewport with pan, zoom, and rotate
+- [**Attach / Detach Example**](https://kinnet-studio.github.io/ue-too/attach-detach/) - Dynamically attach and detach a canvas from the board
+- [**Navigation Example**](https://kinnet-studio.github.io/ue-too/navigation/) - Keyboard-driven camera panning via `panByViewPort()`
+- [**Ruler Example**](https://kinnet-studio.github.io/ue-too/ruler/) - Measurement ruler overlay that updates with pan and zoom
+- [**Camera Animation**](https://kinnet-studio.github.io/ue-too/camera-animation/) - Smooth animated camera transitions on click
+- [**Image Example**](https://kinnet-studio.github.io/ue-too/image-example/) - Upload and display an image on the pannable canvas
+- [**SVG Example**](https://kinnet-studio.github.io/ue-too/svg/) - Board camera system applied to SVG elements
 
 ### Framework Integrations
 
-- [**PixiJS Integration**](https://ue-too.github.io/ue-too/pixi-integration/) - Full-screen PixiJS canvas with board camera controls
-- [**Konva Integration**](https://ue-too.github.io/ue-too/konva-integration/) - Konva.js stage synchronized with board camera transforms
-- [**Fabric Integration**](https://ue-too.github.io/ue-too/fabric-integration/) - Fabric.js with toggleable movement/selection modes
+- [**PixiJS Integration**](https://kinnet-studio.github.io/ue-too/pixi-integration/) - Full-screen PixiJS canvas with board camera controls
+- [**Konva Integration**](https://kinnet-studio.github.io/ue-too/konva-integration/) - Konva.js stage synchronized with board camera transforms
+- [**Fabric Integration**](https://kinnet-studio.github.io/ue-too/fabric-integration/) - Fabric.js with toggleable movement/selection modes
 
 
 ## Documentation
 
-The documentation is available [here](https://ue-too.github.io/documentation/board/).
+The documentation is available [here](https://kinnet-studio.github.io/documentation/board/).
 
 ## Installation and Usage
 
@@ -158,7 +158,7 @@ The `Board` class handles:
 
 All components and utility functions are accessible, allowing you to create your own board implementation without using the `requestAnimationFrame` callback method.
 
-For detailed camera control information, refer to the [Board Camera](https://github.com/ue-too/ue-too/tree/main/packages/board/src/camera) section.
+For detailed camera control information, refer to the [Board Camera](https://github.com/kinnet-studio/ue-too/tree/main/packages/board/src/camera) section.
 
 ## Development
 
@@ -166,7 +166,7 @@ For detailed camera control information, refer to the [Board Camera](https://git
 
 > Currently not ready for contribution. If you have any suggestions or ideas, please let me know by creating an issue.
 
-Please refer to the [README](https://github.com/ue-too/ue-too/) in the root directory for the overall development setup.
+Please refer to the [README](https://github.com/kinnet-studio/ue-too/) in the root directory for the overall development setup.
 
 1. This package is within a monorepo, and is managed by nx and bun. I am not super familiar with nx or monorepo; this is kind of an experiment and a learning experience for me as well. (if you have any suggestions on how to improve the setup, please let me know!)
 2. Bundling the package is done through rollup and testing through bun test.
@@ -181,11 +181,11 @@ ue-too consists of 3 core components:
 
 To see detail of each component navigate to the respective readme in the subdirectories.
 
-- [Board Camera](https://github.com/ue-too/ue-too/tree/main/packages/board/src/camera)
-- [Camera Mux](https://github.com/ue-too/ue-too/tree/main/packages/board/src/camera/camera-mux)
-- [User Input Interpreter](https://github.com/ue-too/ue-too/tree/main/packages/board/src/input-interpretation)
+- [Board Camera](https://github.com/kinnet-studio/ue-too/tree/main/packages/board/src/camera)
+- [Camera Mux](https://github.com/kinnet-studio/ue-too/tree/main/packages/board/src/camera/camera-mux)
+- [User Input Interpreter](https://github.com/kinnet-studio/ue-too/tree/main/packages/board/src/input-interpretation)
 
-It's recommended to start with the [Board Camera](https://github.com/ue-too/ue-too/tree/main/packages/board/src/camera) since the other parts are built on top of it.
+It's recommended to start with the [Board Camera](https://github.com/kinnet-studio/ue-too/tree/main/packages/board/src/camera) since the other parts are built on top of it.
 
 Below is a diagram showing the data flow from user input to camera updates.
 

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -44,14 +44,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/ue-too/ue-too.git"
+        "url": "git+https://github.com/kinnet-studio/ue-too.git"
     },
     "author": "niuee",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/ue-too/ue-too/issues"
+        "url": "https://github.com/kinnet-studio/ue-too/issues"
     },
-    "homepage": "https://github.com/ue-too/ue-too#readme",
+    "homepage": "https://github.com/kinnet-studio/ue-too#readme",
     "keywords": [
         "canvas",
         "infinite-canvas",

--- a/packages/board/src/input-interpretation/README.md
+++ b/packages/board/src/input-interpretation/README.md
@@ -5,7 +5,7 @@ This module demonstrates how to interpret user input using the state machine pat
 You can implement your own input interpretation logic. After processing the input, you can either:
 
 1. Set the camera state directly using the `setPosition`, `setZoomLevel`, and `setRotation` methods
-2. Use the camera rig as described in the [board camera README](https://github.com/ue-too/ue-too/tree/main/packages/board/src/camera)
+2. Use the camera rig as described in the [board camera README](https://github.com/kinnet-studio/ue-too/tree/main/packages/board/src/camera)
 
 The module consists of two main components:
 
@@ -22,10 +22,10 @@ The state machine manages different input states and transitions. Below are the 
 
 #### Keyboard, Mouse, and Trackpad Input
 
-![kmt-input-state-machine](https://ue-too.github.io/ue-too/assets/doc-media/kmt-input-state-machine.png)
+![kmt-input-state-machine](https://kinnet-studio.github.io/ue-too/assets/doc-media/kmt-input-state-machine.png)
 
 #### Touch Input
 
-![touch-input-state-machine](https://ue-too.github.io/ue-too/assets/doc-media/touch-input-state-machine.png)
+![touch-input-state-machine](https://kinnet-studio.github.io/ue-too/assets/doc-media/touch-input-state-machine.png)
 
-You can customize the state machine's behavior by defining relationships between states. The `@ue-too/being` library is used to implement the state machine. Please refer to the [being README](https://github.com/ue-too/ue-too/tree/main/packages/being) for more details.
+You can customize the state machine's behavior by defining relationships between states. The `@ue-too/being` library is used to implement the state machine. Please refer to the [being README](https://github.com/kinnet-studio/ue-too/tree/main/packages/being) for more details.

--- a/packages/border/README.md
+++ b/packages/border/README.md
@@ -3,7 +3,7 @@
 Geodesy and map projection library for TypeScript.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/border.svg)](https://www.npmjs.com/package/@ue-too/border)
-[![license](https://img.shields.io/npm/l/@ue-too/border.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/border.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -472,4 +472,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/border/package.json
+++ b/packages/border/package.json
@@ -4,9 +4,9 @@
     "version": "0.17.1",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "license": "MIT",
     "scripts": {
         "test": "jest",

--- a/packages/curve/README.md
+++ b/packages/curve/README.md
@@ -5,7 +5,7 @@ This is a library that basically follows the algorithms in Pomax's superb [Prime
 Bezier curve and geometric path library for TypeScript canvas applications.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/curve.svg)](https://www.npmjs.com/package/@ue-too/curve)
-[![license](https://img.shields.io/npm/l/@ue-too/curve.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/curve.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -491,4 +491,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/curve/package.json
+++ b/packages/curve/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/dynamics/README.md
+++ b/packages/dynamics/README.md
@@ -3,7 +3,7 @@
 2D physics engine with rigid body dynamics and collision detection.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/dynamics.svg)](https://www.npmjs.com/package/@ue-too/dynamics)
-[![license](https://img.shields.io/npm/l/@ue-too/dynamics.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/dynamics.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 > **Experimental**: This package is an experimental implementation. Please **DO NOT** use this in production.
 
@@ -573,4 +573,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/ecs/README.md
+++ b/packages/ecs/README.md
@@ -3,7 +3,7 @@
 High-performance Entity Component System (ECS) architecture for TypeScript.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/ecs.svg)](https://www.npmjs.com/package/@ue-too/ecs)
-[![license](https://img.shields.io/npm/l/@ue-too/ecs.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/ecs.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 > **Experimental**: This package is an experimental implementation based on [Austin Morlan's ECS tutorial](https://austinmorlan.com/posts/entity_component_system/). Please **DO NOT** use this in production.
 
@@ -368,4 +368,4 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -7,9 +7,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "exports": {
         ".": {
             "types": "./src/index.ts",

--- a/packages/math/README.md
+++ b/packages/math/README.md
@@ -8,7 +8,7 @@
 <div align="center">
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/math.svg?style=for-the-badge)](https://www.npmjs.com/package/@ue-too/math)
-[![License](https://img.shields.io/github/license/ue-too/ue-too?style=for-the-badge)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![License](https://img.shields.io/github/license/ue-too/ue-too?style=for-the-badge)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 </div>
 
@@ -210,7 +210,7 @@ const currentPos = PointCal.linearInterpolation(start, end, progress);
 For complete API documentation with detailed examples, see:
 
 - [Full TypeDoc Documentation](/math/) (generated from source)
-- [Source Code](https://github.com/ue-too/ue-too/blob/main/packages/math/src/index.ts) with inline JSDoc comments
+- [Source Code](https://github.com/kinnet-studio/ue-too/blob/main/packages/math/src/index.ts) with inline JSDoc comments
 
 ## TypeScript Support
 
@@ -252,8 +252,8 @@ const unit = PointCal.divideVectorByScalar(vector, mag);
 
 ## License
 
-MIT License - see [LICENSE.txt](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt) for details.
+MIT License - see [LICENSE.txt](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt) for details.
 
 ## Contributing
 
-> Currently not accepting contributions. If you have feature requests or bug reports, please [create an issue](https://github.com/ue-too/ue-too/issues).
+> Currently not accepting contributions. If you have feature requests or bug reports, please [create an issue](https://github.com/kinnet-studio/ue-too/issues).

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -7,9 +7,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "exports": {
         ".": {
             "types": "./src/index.ts",

--- a/scripts/scaffold-package.mjs
+++ b/scripts/scaffold-package.mjs
@@ -55,9 +55,9 @@ try {
         license: 'MIT',
         repository: {
             type: 'git',
-            url: 'https://github.com/ue-too/ue-too.git',
+            url: 'https://github.com/kinnet-studio/ue-too.git',
         },
-        homepage: 'https://github.com/ue-too/ue-too',
+        homepage: 'https://github.com/kinnet-studio/ue-too',
         scripts: {
             test: 'jest',
             'build:legacy': 'rm -rf dist && rollup -c rollup.config.js',
@@ -280,7 +280,7 @@ export {};
 Description of the ${packageName} package.
 
 [![npm version](https://img.shields.io/npm/v/@ue-too/${packageName}.svg)](https://www.npmjs.com/package/@ue-too/${packageName})
-[![license](https://img.shields.io/npm/l/@ue-too/${packageName}.svg)](https://github.com/ue-too/ue-too/blob/main/LICENSE.txt)
+[![license](https://img.shields.io/npm/l/@ue-too/${packageName}.svg)](https://github.com/kinnet-studio/ue-too/blob/main/LICENSE.txt)
 
 ## Overview
 
@@ -312,7 +312,7 @@ MIT
 
 ## Repository
 
-[https://github.com/ue-too/ue-too](https://github.com/ue-too/ue-too)
+[https://github.com/kinnet-studio/ue-too](https://github.com/kinnet-studio/ue-too)
 `;
     fs.writeFileSync(path.join(packageDir, 'README.md'), readme);
     console.log('✅ Created README.md');


### PR DESCRIPTION
## Summary

The organization was renamed from **ue-too** to **kinnet-studio**. This updates organization-level references across the monorepo (38 files).

- `github.com/ue-too` → `github.com/kinnet-studio` — all GitHub URLs (repo links, issues, PRs, commits, blob/tree, graduated `banana` repo). Repo slug preserved, e.g. `github.com/kinnet-studio/ue-too`. Includes CHANGELOG files.
- `ue-too.github.io` → `kinnet-studio.github.io` — the org's GitHub Pages domain (examples, docs, assets).
- `.github/workflows/release.yml`: docs `target-repo` → `kinnet-studio/documentation`.

## Intentionally unchanged

The `@ue-too/*` npm scope (804 occurrences) and the `ue-too` project/repo identity stay as-is (root package name, repo-structure mentions, `vite.config.js` Pages base path = repo slug).

Three borderline items were left alone pending confirmation:
- `component-schema.schema.json` `$id` domain `ue-too.dev`
- `"author": "ue-too"` in sample game JSONs under `apps/blast/src/games/`
- `STORAGE_KEY = 'ue-too-examples-lang'` localStorage key

🤖 Generated with [Claude Code](https://claude.com/claude-code)