### PR TITLE
fix(board-pixi-react-integration): prevent Pixi re-init and lost-context reuse (cherry-pick #422)

### DIFF
--- a/.changeset/fix-pixi-react-init-context-leak.md
+++ b/.changeset/fix-pixi-react-init-context-leak.md
@@ -1,0 +1,9 @@
+---
+'@ue-too/board-pixi-react-integration': patch
+---
+
+fix(board-pixi-react-integration): stop re-initializing Pixi on every render and reuse of lost GL contexts
+
+`useInitializePixiApp` keyed its init effect on the `option` object and `initFunction` — both routinely passed as inline literals — so any re-render (including a React Fast Refresh from unrelated HMR) tore down and recreated the Pixi `Application` on the same reused `<canvas>`. Because Pixi calls `WEBGL_lose_context` on destroy, the new renderer would come up on a lost context that collided with the in-flight one, hard-freezing the GPU process on some drivers (notably Linux/Mesa).
+
+The hook now: (1) initializes once per mount, reading the latest `option`/`initFunction` from refs rather than effect deps; (2) serializes init/teardown through a promise chain so two initializations never overlap (StrictMode mount→unmount→mount, fast remounts); and (3) creates a fresh `<canvas>` for each init and detaches it on teardown (`removeView`) so a lost context is never reused. `useInitializePixiApp` now returns `{ containerRef }` (attach to a wrapping element) instead of `{ canvasRef }`; the public `Wrapper`/`PixiCanvasApp` API is unchanged.

--- a/packages/board-pixi-react-integration/src/components/PixiCanvas.tsx
+++ b/packages/board-pixi-react-integration/src/components/PixiCanvas.tsx
@@ -26,9 +26,16 @@ export const PixiCanvas = ({
     ) => Promise<BaseAppComponents>;
     className?: string;
 }): React.ReactNode => {
-    const { canvasRef } = useInitializePixiApp(option, initFunction);
+    const { containerRef } = useInitializePixiApp(
+        option,
+        initFunction,
+        className
+    );
 
-    return <canvas ref={canvasRef} className={className} />;
+    // The hook owns canvas creation (a fresh <canvas> per init); we only
+    // provide the mount point. `display: contents` keeps this wrapper out of
+    // layout so the canvas lays out exactly as a direct child would.
+    return <div ref={containerRef} style={{ display: 'contents' }} />;
 };
 
 export const OverlayContainer = ({
@@ -48,7 +55,9 @@ export const OverlayContainer = ({
                 position: 'absolute',
                 top: 0,
                 left: 0,
-                ...(isReady ? { width, height } : { width: '100%', height: '100%' }),
+                ...(isReady
+                    ? { width, height }
+                    : { width: '100%', height: '100%' }),
                 pointerEvents: 'none',
             }}
         >

--- a/packages/board-pixi-react-integration/src/hooks/pixi/initialization.ts
+++ b/packages/board-pixi-react-integration/src/hooks/pixi/initialization.ts
@@ -1,91 +1,128 @@
-import { BaseAppComponents, InitAppOptions } from '@ue-too/board-pixi-integration';
+import {
+    BaseAppComponents,
+    InitAppOptions,
+} from '@ue-too/board-pixi-integration';
 import { useEffect, useRef } from 'react';
 
 import { usePixiCanvas } from '../../contexts/pixi';
 
+/**
+ * Initializes a Pixi application into a container element and tears it down on
+ * unmount. Attach the returned `containerRef` to a wrapping element; a fresh
+ * `<canvas>` is created inside it for each initialization.
+ *
+ * The design below prevents a class of WebGL-context bugs that hard-freeze the
+ * GPU process on some drivers (notably Linux/Mesa):
+ *
+ * 1. **Init runs once per mount.** Callers routinely pass an inline `option`
+ *    object and `initFunction` closure, so keying the effect on them would
+ *    re-initialize Pixi on every render — destroying and recreating the GL
+ *    context on the same canvas, which collides with the in-flight renderer
+ *    and wedges the GPU. The latest values are read from refs instead, so the
+ *    effect depends only on the stable `setResult`.
+ * 2. **Init/teardown are serialized** through a promise chain, so two
+ *    initializations never overlap (e.g. React StrictMode's mount→unmount→
+ *    mount in dev, or a fast remount). The previous context is fully destroyed
+ *    before the next one is created.
+ * 3. **A fresh `<canvas>` per init.** Pixi calls `WEBGL_lose_context` when the
+ *    renderer is destroyed; a canvas whose context was lost cannot be
+ *    reinitialized, so each init gets a brand-new element and the old one is
+ *    detached on teardown (`removeView`).
+ */
 export const useInitializePixiApp = <T extends InitAppOptions = InitAppOptions>(
     option: Partial<T>,
     initFunction: (
         canvas: HTMLCanvasElement,
         option: Partial<T>
-    ) => Promise<BaseAppComponents>
+    ) => Promise<BaseAppComponents>,
+    className?: string
 ) => {
     const { setResult } = usePixiCanvas<BaseAppComponents>();
-    const canvasRef = useRef<HTMLCanvasElement | null>(null);
+    const containerRef = useRef<HTMLDivElement | null>(null);
     const appComponentsRef = useRef<BaseAppComponents | null>(null);
-    const isInitializingRef = useRef(false);
+
+    // Latest values, read at init time without being effect dependencies (1).
+    const optionRef = useRef(option);
+    const initFunctionRef = useRef(initFunction);
+    const classNameRef = useRef(className);
+    optionRef.current = option;
+    initFunctionRef.current = initFunction;
+    classNameRef.current = className;
+
+    // Serializes init/teardown so two runs never overlap (2).
+    const chainRef = useRef<Promise<void>>(Promise.resolve());
 
     useEffect(() => {
-        const canvas = canvasRef.current;
-        if (!canvas || isInitializingRef.current) return;
+        const container = containerRef.current;
+        if (!container) return;
 
-        let isMounted = true;
-        isInitializingRef.current = true;
+        let cancelled = false;
 
-        const initializePixi = async () => {
-            try {
-                // Clean up any existing app first
+        const teardown = (components: BaseAppComponents | null) => {
+            if (!components) return;
+            components.cleanup();
+            components.cleanups.forEach(cleanup => cleanup());
+            // `removeView` detaches the <canvas>, so the element (and its
+            // now-lost GL context) is discarded rather than reused (3).
+            components.app.destroy({ removeView: true }, { children: true });
+        };
+
+        const run = chainRef.current
+            .then(async () => {
+                if (cancelled) return;
+
+                // Tear down a leftover app from a previous run before starting.
                 if (appComponentsRef.current) {
                     setResult({ initialized: false });
-                    appComponentsRef.current.cleanup();
-                    appComponentsRef.current.cleanups.forEach(cleanup =>
-                        cleanup()
-                    );
-                    appComponentsRef.current.app.destroy(false);
+                    teardown(appComponentsRef.current);
                     appComponentsRef.current = null;
                 }
 
-                // Small delay to ensure canvas is fully ready
-                await new Promise(resolve => setTimeout(resolve, 0));
+                const canvas = document.createElement('canvas');
+                if (classNameRef.current) {
+                    canvas.className = classNameRef.current;
+                }
+                container.appendChild(canvas);
 
-                if (!isMounted) return;
+                const components = await initFunctionRef.current(
+                    canvas,
+                    optionRef.current
+                );
 
-                // console.log('initialize pixi');
-
-                const appComponents = await initFunction(canvas, option);
-
-                if (!isMounted) {
-                    setResult({ initialized: true, success: false });
-                    appComponents.cleanup();
-                    appComponents.cleanups.forEach(cleanup => cleanup());
-                    appComponents.app.destroy(false);
-                    appComponentsRef.current = null;
+                if (cancelled) {
+                    // Unmounted while initializing — discard immediately.
+                    teardown(components);
                     return;
                 }
 
-                appComponentsRef.current = appComponents;
+                appComponentsRef.current = components;
                 setResult({
                     initialized: true,
                     success: true,
-                    components: appComponents,
+                    components,
                 });
-            } catch (error) {
-                setResult({ initialized: true, success: false });
+            })
+            .catch(error => {
                 console.error('Failed to initialize PixiJS:', error);
-                appComponentsRef.current?.cleanups.forEach(cleanup =>
-                    cleanup()
-                );
-                appComponentsRef.current?.cleanup();
-            } finally {
-                isInitializingRef.current = false;
-            }
-        };
+                setResult({ initialized: true, success: false });
+            });
 
-        initializePixi();
+        chainRef.current = run;
 
         // Cleanup function
         return () => {
-            isMounted = false;
-            isInitializingRef.current = false;
-            if (appComponentsRef.current) {
-                setResult({ initialized: false });
-                appComponentsRef.current.cleanup();
-                appComponentsRef.current.cleanups.forEach(cleanup => cleanup());
-                appComponentsRef.current.app.destroy(false);
-                appComponentsRef.current = null;
-            }
+            cancelled = true;
+            // Chain teardown after this run so we never destroy an app that is
+            // still initializing.
+            chainRef.current = run.then(() => {
+                if (appComponentsRef.current) {
+                    setResult({ initialized: false });
+                    teardown(appComponentsRef.current);
+                    appComponentsRef.current = null;
+                }
+            });
         };
-    }, [setResult, option]);
+    }, [setResult]);
 
-    return { canvasRef };
+    return { containerRef };
 };


### PR DESCRIPTION
Cherry-picks the latest merged PR commit on `main` (`9dc8ecfc`, #422) onto a branch created from the `v0.17.0` tag.

## Original commit
- `fix(board-pixi-react-integration): prevent Pixi re-init and lost-context reuse (#422)`

This brings the Pixi re-init / lost-context fix onto a `v0.17.0` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)