### PR TITLE
chore(release): fix repository URLs to kinnet-studio org for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,14 +33,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/ue-too/ue-too.git"
+    "url": "git+https://github.com/kinnet-studio/ue-too.git"
   },
   "author": "niuee",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ue-too/ue-too/issues"
+    "url": "https://github.com/kinnet-studio/ue-too/issues"
   },
-  "homepage": "https://github.com/ue-too/ue-too#readme",
+  "homepage": "https://github.com/kinnet-studio/ue-too#readme",
   "devDependencies": {
     "@changesets/cli": "^2.29.7",
     "@nx/devkit": "22.2.0",

--- a/packages/animate/package.json
+++ b/packages/animate/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/being/package.json
+++ b/packages/being/package.json
@@ -4,9 +4,9 @@
     "version": "0.17.6",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-fabric-integration/package.json
+++ b/packages/board-fabric-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-game-engine/package.json
+++ b/packages/board-game-engine/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-konva-integration/package.json
+++ b/packages/board-konva-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-pixi-integration/package.json
+++ b/packages/board-pixi-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest"
     },

--- a/packages/board-pixi-react-integration/package.json
+++ b/packages/board-pixi-react-integration/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest"
     },

--- a/packages/board-react-adapter/package.json
+++ b/packages/board-react-adapter/package.json
@@ -4,9 +4,9 @@
     "version": "0.17.6",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/board-vue-adapter/package.json
+++ b/packages/board-vue-adapter/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build": "vite build",

--- a/packages/board/package.json
+++ b/packages/board/package.json
@@ -44,14 +44,14 @@
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/ue-too/ue-too.git"
+        "url": "git+https://github.com/kinnet-studio/ue-too.git"
     },
     "author": "niuee",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/ue-too/ue-too/issues"
+        "url": "https://github.com/kinnet-studio/ue-too/issues"
     },
-    "homepage": "https://github.com/ue-too/ue-too#readme",
+    "homepage": "https://github.com/kinnet-studio/ue-too#readme",
     "keywords": [
         "canvas",
         "infinite-canvas",

--- a/packages/border/package.json
+++ b/packages/border/package.json
@@ -4,9 +4,9 @@
     "version": "0.17.6",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "license": "MIT",
     "scripts": {
         "test": "jest",

--- a/packages/curve/package.json
+++ b/packages/curve/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/dynamics/package.json
+++ b/packages/dynamics/package.json
@@ -5,9 +5,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "scripts": {
         "test": "jest",
         "build:legacy": "rm -rf dist && rollup -c rollup.config.js"

--- a/packages/ecs/package.json
+++ b/packages/ecs/package.json
@@ -7,9 +7,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "exports": {
         ".": {
             "types": "./src/index.ts",

--- a/packages/math/package.json
+++ b/packages/math/package.json
@@ -7,9 +7,9 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/ue-too/ue-too.git"
+        "url": "https://github.com/kinnet-studio/ue-too.git"
     },
-    "homepage": "https://github.com/ue-too/ue-too",
+    "homepage": "https://github.com/kinnet-studio/ue-too",
     "exports": {
         ".": {
             "types": "./src/index.ts",


### PR DESCRIPTION
## Why
The **Publish to NPM** workflow on `version/0.17.0` failed with `npm error code E422`:

> Error verifying sigstore provenance bundle: Failed to validate repository information: `package.json: "repository.url"` is `git+https://github.com/ue-too/ue-too.git`, expected to match `https://github.com/kinnet-studio/ue-too` from provenance

The GitHub org was renamed `ue-too` → `kinnet-studio` (#421 on `main`), but that change was never backported to this release branch. npm provenance requires `repository.url` to match the actual GitHub repo, so all 14 packages 422'd and **nothing published** (no partial release to clean up).

## What
Backports the `package.json` URL changes from #421 to `version/0.17.0`:
- `repository.url`, `bugs.url`, and `homepage`: `github.com/ue-too/ue-too` → `github.com/kinnet-studio/ue-too`
- Root + all 15 package `package.json` files (16 total)

Scoped to `package.json` only — README/CHANGELOG references don't affect provenance and would risk conflicts on the release branch.

## After merge
Re-run the **Publish to NPM** workflow on `version/0.17.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)